### PR TITLE
Workaround for VS15.6 Hosted Agents source generation

### DIFF
--- a/src/Uno.UI/UI/Xaml/Style/Generic/GenericStyles.cs
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/GenericStyles.cs
@@ -24,8 +24,7 @@ namespace Windows.UI.Xaml
 		{
 			if (Uno.UI.FeatureConfiguration.Style.UseUWPDefaultStyles)
 			{
-				// netstd is disabled until the codegen is fixed on 15.6
-#if !NET46 && !NETSTANDARD2_0
+#if !NET46
 				Style.RegisterDefaultStyleForType(typeof(Controls.Button), Uno.UI.GlobalStaticResources.XamlDefaultButton);
 				Style.RegisterDefaultStyleForType(typeof(Controls.TextBox), Uno.UI.GlobalStaticResources.XamlDefaultTextBox);
 				Style.RegisterDefaultStyleForType(typeof(Controls.CheckBox), Uno.UI.GlobalStaticResources.XamlDefaultCheckBox);
@@ -36,7 +35,10 @@ namespace Windows.UI.Xaml
 				Style.RegisterDefaultStyleForType(typeof(Controls.Frame), Uno.UI.GlobalStaticResources.XamlDefaultFrame);
 				Style.RegisterDefaultStyleForType(typeof(Controls.ProgressBar), Uno.UI.GlobalStaticResources.XamlDefaultProgressBar);
 				Style.RegisterDefaultStyleForType(typeof(Controls.Slider), Uno.UI.GlobalStaticResources.XamlDefaultSlider);
+
+#if !NETSTANDARD2_0
 				Style.RegisterDefaultStyleForType(typeof(Controls.AppBar), Uno.UI.GlobalStaticResources.XamlCommandBar);
+#endif
 #endif
 			}
 		}

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -81,6 +81,24 @@
 	<Page Remove="@(Page)" />
   </ItemGroup>
 
+  <Target Name="AdjustPage" BeforeTargets="Compile" Condition="'$(BuildingInsideUnoSourceGenerator)'=='true'">
+
+	<!-- Workaround for VS15.6 build agent issue -->
+	
+	<ItemGroup Condition="'$(TargetFramework)'!='net46'">
+	  <None Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
+
+	  <!-- remove files included by msbuild extras -->
+	  <Page Remove="@(Page)" />
+	  <Page Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
+	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)'=='net46'">
+	  <None Include="**\*.xaml" Exclude="bin\**\*.xaml;obj\**\*.xaml" />
+	  <Page Remove="@(Page)" />
+	</ItemGroup>
+	
+  </Target>
+
   <ItemGroup>
 	<None Include="Resources\AboutResources.txt" />
 	<None Include="Resources\Values\Attrs.xml" />


### PR DESCRIPTION
This works around a strange issue where the source generator, in the context of a VSTS VS15.6 hosted agent, would not pick up the Page item group.
