### PR TITLE
Fix support for VisualTransition.Storyboard children lazy bindings

### DIFF
--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
@@ -20,6 +20,7 @@ using Windows.UI.Xaml;
 using Uno.UI.Converters;
 using Microsoft.Extensions.Logging;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media.Animation;
 
 namespace Uno.UI.Tests.BinderTests.Propagation
 {
@@ -449,6 +450,35 @@ namespace Uno.UI.Tests.BinderTests.Propagation
 			SUT.DataContext = 42;
 
 			Assert.IsNull(template.DataContext);
+		}
+
+		[TestMethod]
+		public void When_ControlTemplate_And_Animation()
+		{
+			var SUT = new ContentControl() { Tag = 42 };
+			DoubleAnimation anim = null;
+
+			var template = new ControlTemplate(() => {
+				var g = new Grid();
+
+				var vg = new VisualStateGroup();
+				var t1 = new VisualTransition();
+				var sb = new Storyboard();
+				anim = new DoubleAnimation();
+				anim.SetBinding(DoubleAnimation.ToProperty, new Binding() { Path = "Tag", RelativeSource = RelativeSource.TemplatedParent });
+				sb.Children.Add(anim);
+				t1.Storyboard = sb;
+				vg.Transitions.Add(t1);
+
+				VisualStateManager.SetVisualStateGroups(g, new List<VisualStateGroup> { vg });
+
+				return g;
+			});
+
+			SUT.Template = template;
+			SUT.ApplyTemplate();
+
+			Assert.IsNotNull(anim);
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
@@ -214,10 +214,10 @@ namespace Windows.UI.Xaml.Media.Animation
 			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 			{
 				this.Log().DebugFormat(
-					"Setting [{0}] to [{1} / {2}] current {3}/{4}={5}",
+					"Setting [{0}] to [{1} / {2}] current {3:X8}/{4}={5}",
 					value,
 					Storyboard.GetTargetName(this), Storyboard.GetTargetProperty(this),
-					PropertyInfo?.GetHashCode(),
+					PropertyInfo?.DataContext?.GetHashCode(),
 					PropertyInfo?.DataContext?.GetType(),
 					PropertyInfo?.Value
 				);

--- a/src/Uno.UI/UI/Xaml/VisualTransition.cs
+++ b/src/Uno.UI/UI/Xaml/VisualTransition.cs
@@ -37,7 +37,7 @@ namespace Windows.UI.Xaml
 				typeof(VisualTransition),
 				new FrameworkPropertyMetadata(
 					defaultValue: null,
-					options: FrameworkPropertyMetadataOptions.ValueInheritsDataContext
+					options: FrameworkPropertyMetadataOptions.LogicalChild
 				)
 			);
 


### PR DESCRIPTION
This fixes some transition issues in FlipView, where the drawer would not collapse in overlay mode.