### PR TITLE
Ensure default Style isn't cleared

### DIFF
--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -268,7 +268,10 @@ namespace Windows.UI.Xaml
 			{
 				ApplyDefaultStyle();
 
-				if (FeatureConfiguration.FrameworkElement.ClearPreviousOnStyleChange)
+				if (FeatureConfiguration.FrameworkElement.ClearPreviousOnStyleChange && 
+					// Don't clear the default Style, which should always be present.
+					!(bool)(oldStyle == Style.DefaultStyleForType(GetType()))
+				)
 				{
 					oldStyle?.ClearStyle(this);
 				}


### PR DESCRIPTION
If Style changes from default to a new style, ensure the default isn't cleared. This fixes issues with default Style being absent such as no ControlTemplate, observed in iOS ListView.