### PR TITLE
Add support for Xaml file defined event handlers

### DIFF
--- a/doc/articles/supported-features.md
+++ b/doc/articles/supported-features.md
@@ -133,6 +133,7 @@
 - StatusBar Management (Occlusion, Color, events)            
 - Xaml Reader
 - Phased Binding (x:Phase)
+- Xaml code-behind Events registration
 
 ### Non-UI features
 

--- a/src/SourceGenerators/XamlGenerationTests/DataTemplate_Events.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/DataTemplate_Events.xaml
@@ -1,0 +1,54 @@
+﻿<UserControl x:Class="XamlGenerationTests.Shared.DataTemplate_Events"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:XamlGenerationTests.Shared"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<UserControl.Resources>
+		<Color x:Key="Red">#ff0000</Color>
+	</UserControl.Resources>
+	<StackPanel>
+		<ContentControl>
+			<Button Click="OnClick" />
+		</ContentControl>
+
+		<ContentControl>
+			<ContentControl.ContentTemplate>
+				<DataTemplate>
+					<Button Click="OnInnerClick">
+						<Button.ContentTemplate>
+							<DataTemplate>
+								<Grid Tapped="OnTappedInner" />
+							</DataTemplate>
+						</Button.ContentTemplate>
+					</Button>
+				</DataTemplate>
+			</ContentControl.ContentTemplate>
+		</ContentControl>
+
+		<ContentControl>
+			<ContentControl.Template>
+				<ControlTemplate TargetType="ContentControl">
+					<StackPanel>
+						<Grid Tapped="OnTappedInner" />
+						<ContentPresenter />
+					</StackPanel>
+				</ControlTemplate>
+			</ContentControl.Template>
+		</ContentControl>
+
+		<Grid>
+			<Grid.Resources>
+				<DataTemplate x:Key="test2">
+					<Grid Tapped="OnTappedInner" />
+				</DataTemplate>
+			</Grid.Resources>
+		</Grid>
+
+	</StackPanel>
+
+</UserControl>

--- a/src/SourceGenerators/XamlGenerationTests/DataTemplate_Events.xaml.cs
+++ b/src/SourceGenerators/XamlGenerationTests/DataTemplate_Events.xaml.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace XamlGenerationTests.Shared
+{
+	public sealed partial class DataTemplate_Events : UserControl
+	{
+		public DataTemplate_Events()
+		{
+			this.InitializeComponent();
+		}
+
+		public void OnInnerClick(object sender, RoutedEventArgs args)
+		{
+
+		}
+
+		public void OnClick(object sender, RoutedEventArgs args)
+		{
+
+		}
+
+		public void OnTappedInner(object sender, RoutedEventArgs args)
+		{
+
+		}
+	}
+}

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.AttachedPropagation.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.AttachedPropagation.cs
@@ -1,0 +1,134 @@
+﻿using Microsoft.Practices.ServiceLocation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Uno.Logging;
+using Uno.Extensions;
+using Uno.Presentation.Resources;
+using Uno.UI.DataBinding;
+using Windows.UI.Xaml.Data;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using Uno.Disposables;
+using System.ComponentModel;
+using Uno.UI;
+using Windows.UI.Xaml;
+using System.Threading;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Tests.AttachedPropagation
+{
+	[TestClass]
+	public partial class Given_DependencyProperty_AttachedPropagation
+	{
+		[TestMethod]
+		public void When_SimpleInheritance_Late()
+		{
+			var root = new Grid();
+			var child1 = new Grid();
+
+			root.Children.Add(child1);
+
+			MyAttachedPropType.SetMyProperty(root, 42);
+			Assert.AreEqual(0, MyAttachedPropType.GetMyProperty(child1));
+
+			MyAttachedPropType.SetMyProperty(root, 43);
+			Assert.AreEqual(43, MyAttachedPropType.GetMyProperty(child1));
+		}
+
+		[TestMethod]
+		public void When_SimpleInheritance_Early()
+		{
+			var root = new Grid();
+			var child1 = new Grid();
+			Assert.AreEqual(0, MyAttachedPropType.GetMyProperty(child1));
+
+			root.Children.Add(child1);
+
+			MyAttachedPropType.SetMyProperty(root, 42);
+
+			Assert.AreEqual(42, MyAttachedPropType.GetMyProperty(child1));
+		}
+
+		[TestMethod]
+		public void When_SimpleInheritance_Late_Event()
+		{
+			var root = new Grid();
+			var child1 = new Grid();
+
+			root.Children.Add(child1);
+
+			int propagatedValue = -1;
+			child1.RegisterPropertyChangedCallback(
+				MyAttachedPropType.MyPropertyProperty,
+				(s, e) => {
+					propagatedValue = MyAttachedPropType.GetMyProperty(child1);
+				}
+			);
+
+			Assert.AreEqual(-1, propagatedValue);
+			MyAttachedPropType.SetMyProperty(root, 42);
+
+			Assert.AreEqual(42, MyAttachedPropType.GetMyProperty(child1));
+			Assert.AreEqual(42, propagatedValue);
+		}
+
+		[TestMethod]
+		public void When_SimpleInheritance_Early_Event()
+		{
+			var root = new Grid();
+			var child1 = new Grid();
+
+			int propagatedValue = -1;
+			child1.RegisterPropertyChangedCallback(
+				MyAttachedPropType.MyPropertyProperty,
+				(s, e) => {
+					propagatedValue = MyAttachedPropType.GetMyProperty(child1);
+				}
+			);
+
+			Assert.AreEqual(-1, propagatedValue);
+			MyAttachedPropType.SetMyProperty(root, 42);
+
+			root.Children.Add(child1);
+
+			Assert.AreEqual(42, MyAttachedPropType.GetMyProperty(child1));
+			Assert.AreEqual(42, propagatedValue);
+		}
+	}
+
+	public class MyAttachedPropType
+	{
+		public static int GetMyProperty(DependencyObject obj)
+		{
+			return (int)obj.GetValue(MyPropertyProperty);
+		}
+
+		public static void SetMyProperty(DependencyObject obj, int value)
+		{
+			obj.SetValue(MyPropertyProperty, value);
+		}
+
+		// Using a DependencyProperty as the backing store for MyProperty.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty MyPropertyProperty =
+			DependencyProperty.RegisterAttached(
+				name: "MyProperty",
+				propertyType: typeof(int),
+				ownerType: typeof(MyAttachedPropType),
+				typeMetadata: new FrameworkPropertyMetadata(
+					defaultValue: 0,
+					options: FrameworkPropertyMetadataOptions.Inherits,
+					propertyChangedCallback: OnPropertyChanged
+				)
+			);
+
+		private static void OnPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+			
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/XamlInfo.cs
+++ b/src/Uno.UI/UI/Xaml/XamlInfo.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Uno.UI.DataBinding;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.Xaml
+{
+	/// <summary>
+	/// Defines the Xaml owner of a visual tree, used to determine the target of Xaml-defined events.
+	/// </summary>
+	public class XamlInfo
+	{
+		private readonly ManagedWeakReference _owner;
+
+		public XamlInfo(DependencyObject xamlOwner)
+		{
+			if (xamlOwner is IWeakReferenceProvider provider)
+			{
+				_owner = provider.WeakReference;
+			}
+			else
+			{
+				throw new NotSupportedException($"The provided reference must be an " + nameof(IWeakReferenceProvider));
+			}
+		}
+
+		/// <summary>
+		/// Gets the top-level owner of the treem when defined from a xaml file
+		/// </summary>
+		public DependencyObject Owner => _owner.Target as DependencyObject;
+
+		public static XamlInfo GetXamlInfo(DependencyObject obj)
+			=> (XamlInfo)obj.GetValue(XamlInfoProperty);
+
+		public static void SetXamlInfo(DependencyObject obj, XamlInfo owner)
+			=> obj.SetValue(XamlInfoProperty, owner);
+
+		public static readonly DependencyProperty XamlInfoProperty =
+			DependencyProperty.RegisterAttached(
+				name: nameof(XamlInfo),
+				propertyType: typeof(XamlInfo),
+				ownerType: typeof(XamlInfo),
+				typeMetadata: new FrameworkPropertyMetadata(
+					defaultValue: null,
+					options: FrameworkPropertyMetadataOptions.Inherits
+				)
+			);
+	}
+}


### PR DESCRIPTION
This change adds the ability to observe changes of an inherited attached property using RegisterPropertyChangedCallback, and adds the ability to observe changes of an inherited attached property using RegisterPropertyChangedCallback.

This fixes #63.