### PR TITLE
API Compatibility updates

### DIFF
--- a/src/Uno.UI.Tests/BitmapImageTests/Given_BitmapImage.cs
+++ b/src/Uno.UI.Tests/BitmapImageTests/Given_BitmapImage.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions;
+using Windows.Foundation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Media.Imaging;
+
+namespace Uno.UI.Tests.BitmapImageTests
+{
+	[TestClass]
+	public class Given_BitmapImage
+    {
+		[TestMethod]
+		[DataRow("http://example.com/image.png", "http://example.com/image.png")]
+		[DataRow("ms-appx:///image.png", "ms-appx:///image.png")]
+		[DataRow("ms-appx:///image.png", "image.png")]
+		[DataRow("ms-appx:///folder/image.png", "folder/image.png")]
+		[DataRow("ms-appx:///folder/image.png", "folder\\image.png")]
+		[DataRow("ms-appx:///folder/folder2/image.png", "folder/folder2/image.png")]
+		[DataRow("ms-appx:///folder/folder2/image.png", "folder\\folder2\\image.png")]
+		[DataRow("ms-appx:///image.png", "/image.png")]
+		[DataRow("ms-appx:///folder/image.png", "/folder/image.png")]
+		public void When_Uri(string expected, string uri)
+		{
+			var SUT = new BitmapImage(new Uri(uri, UriKind.RelativeOrAbsolute));
+
+			Assert.AreEqual(new Uri(expected), SUT.WebUri);
+		}
+	}
+}

--- a/src/Uno.UI.Tests/ItemsControlTests/Given_ItemsControl.cs
+++ b/src/Uno.UI.Tests/ItemsControlTests/Given_ItemsControl.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions;
+using Windows.Foundation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+
+namespace Uno.UI.Tests.ItemsControlTests
+{
+	[TestClass]
+	public class Given_ItemsControl
+    {
+		[TestMethod]
+		public void When_EarlyItems()
+		{
+			var style = new Style(typeof(Windows.UI.Xaml.Controls.ItemsControl))
+			{
+				Setters =  {
+					new Setter<ItemsControl>("Template", t =>
+						t.Template = Funcs.Create(() =>
+							new ItemsPresenter()
+						)
+					)
+				}
+			};
+
+			var panel = new StackPanel();
+
+			var SUT = new ItemsControl()
+			{
+				Style = style,
+				ItemsPanel = new ItemsPanelTemplate(() => panel),
+				Items = {
+					new Border { Name = "b1" }
+				}
+			};
+
+			// Search on the panel for now, as the name lookup is not properly
+			// aligned on net46.
+			Assert.IsNotNull(panel.FindName("b1"));
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -84,6 +84,7 @@
     <None Remove="XamlReaderTests\When_ElementName.xamltest" />
     <None Remove="XamlReaderTests\When_MultipleBindings.xamltest" />
     <None Remove="XamlReaderTests\When_StaticResource.xamltest" />
+    <None Remove="XamlReaderTests\When_StaticResource_Style_And_Binding.xamltest" />
     <None Remove="XamlReaderTests\When_Style_FontWeight.xamltest" />
     <None Remove="XamlReaderTests\When_TextBlock_Basic.xamltest" />
     <None Remove="XamlReaderTests\When_TextBlock_FontFamily.xamltest" />

--- a/src/Uno.UI.Tests/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/XamlReaderTests/Given_XamlReader.cs
@@ -15,6 +15,8 @@ using Windows.UI;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Documents;
 using FluentAssertions;
+using Windows.UI.Xaml.Controls.Primitives;
+using Microsoft.Extensions.Logging;
 
 namespace Uno.UI.Tests.XamlReaderTests
 {
@@ -31,6 +33,11 @@ namespace Uno.UI.Tests.XamlReaderTests
 		public void Initialize()
 		{
 			ResourceDictionary.DefaultResolver = null;
+
+			Uno.Extensions.LogExtensionPoint
+				.AmbientLoggerFactory
+				.AddConsole(LogLevel.Debug)
+				.AddDebug(LogLevel.Debug);
 		}
 
 		[TestMethod]
@@ -558,6 +565,31 @@ namespace Uno.UI.Tests.XamlReaderTests
 
 			Assert.IsTrue(r.Resources.ContainsKey(typeof(Grid)));
 			Assert.IsTrue(r.Resources.ContainsKey(typeof(TextBlock)));
+		}
+
+		[TestMethod]
+		public void When_StaticResource_Style_And_Binding()
+		{
+			var s = GetContent(nameof(When_StaticResource_Style_And_Binding));
+			var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
+
+			Assert.IsTrue(r.Resources.ContainsKey("test"));
+
+			var tb1 = r.FindName("tb1") as ToggleButton;
+			var tb2 = r.FindName("tb2") as ToggleButton;
+
+			Assert.IsTrue((bool)tb1.IsChecked);
+			Assert.IsTrue((bool)tb2.IsChecked);
+
+			tb1.IsChecked = false;
+
+			Assert.IsFalse((bool)tb1.IsChecked);
+			Assert.IsFalse((bool)tb2.IsChecked);
+
+			tb2.IsChecked = true;
+
+			Assert.IsTrue((bool)tb1.IsChecked);
+			Assert.IsTrue((bool)tb2.IsChecked);
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.Tests/XamlReaderTests/When_StaticResource_Style_And_Binding.xamltest
+++ b/src/Uno.UI.Tests/XamlReaderTests/When_StaticResource_Style_And_Binding.xamltest
@@ -1,0 +1,15 @@
+﻿<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      x:Name="testPage">
+  <UserControl.Resources>
+	<Style x:Key="test" TargetType="ToggleButton">
+	  <Setter Property="IsChecked" Value="true"/>
+	</Style>
+  </UserControl.Resources>
+
+  <StackPanel>
+	<ToggleButton x:Name="tb1" IsChecked="{Binding IsChecked, Mode=TwoWay, ElementName=tb2}" />
+	<ToggleButton x:Name="tb2" Style="{StaticResource test}" />
+  </StackPanel>
+
+</UserControl>

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
@@ -61,6 +61,25 @@ namespace Uno.UI.DataBinding
 				}
 			}
 
+			if (input is bool boolInput)
+			{
+				if (FastBooleanConvert(outputType, boolInput, ref output))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		}
+
+		private static bool FastBooleanConvert(Type outputType, bool boolInput, ref object output)
+		{
+			if (outputType == typeof(Visibility))
+			{
+				output = boolInput ? Visibility.Visible : Visibility.Collapsed;
+				return true;
+			}
+
 			return false;
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -43,6 +43,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private bool _isReady; // Template applied
 		private bool _needsUpdateItems;
+		private ItemCollection _items = new ItemCollection();
 
 		// This gets prepended to MaterializedContainers to ensure it's being considered 
 		// even if it might not yet have be added to the ItemsPanel (e.eg., NativeListViewBase).
@@ -82,6 +83,10 @@ namespace Windows.UI.Xaml.Controls
 			InitializePartial();
 
 			OnDisplayMemberPathChangedPartial(string.Empty, this.DisplayMemberPath);
+
+			_items.VectorChanged += (s, e) => {
+				SetNeedsUpdateItems();
+			};
 		}
 
 		partial void InitializePartial();
@@ -223,19 +228,7 @@ namespace Windows.UI.Xaml.Controls
 		);
 		#endregion
 
-		private ItemCollection _items;
-		//TODO: this should reflect the content of ItemsSource, if that property is set. For now, it only exists for setting ItemsControl's contents in xaml.
-		public ItemCollection Items
-		{
-			get { return _items; }
-			set
-			{
-				_items = value;
-
-				SetNeedsUpdateItems();
-				OnItemsChanged();
-			}
-		}
+		public ItemCollection Items => _items;
 
 		internal virtual void OnItemsChanged() { }
 
@@ -838,6 +831,7 @@ namespace Windows.UI.Xaml.Controls
 		public void SetNeedsUpdateItems()
 		{
 			_needsUpdateItems = true;
+			UpdateItemsIfNeeded();
 			RequestLayoutPartial();
 		}
 

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -304,9 +304,22 @@ namespace Windows.UI.Xaml
 			}
 			else
 			{
+				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				{
+					this.Log().Debug($"OverrideLocalPrecedence({precedence})");
+				}
+
 				_precedenceOverride = precedence;
 
-				return Disposable.Create(() => _precedenceOverride = null);
+				return Disposable.Create(() => {
+
+					_precedenceOverride = null;
+
+					if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+					{
+						this.Log().Debug("OverrideLocalPrecedence(None)");
+					}
+				});
 			}
 		}
 
@@ -445,6 +458,16 @@ namespace Windows.UI.Xaml
 						}
 
 						TryUpdateInheritedAttachedProperty(property, propertyDetails);
+
+						if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+						{
+							var name = (_originalObjectRef.Target as IFrameworkElement)?.Name ?? _originalObjectRef.Target?.GetType().Name;
+							var hashCode = _originalObjectRef.Target?.GetHashCode();
+
+							this.Log().Debug(
+								$"SetValue on [{name}/{hashCode:X8}] for [{property.Name}] to [{newValue}] (req:{value} reqp:{precedence} p:{previousValue} pp:{previousPrecedence} np:{newPrecedence})"
+							);
+						}
 
 						RaiseCallbacks(actualInstanceAlias, propertyDetails, previousValue, previousPrecedence, newValue, newPrecedence);
 					}

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.cs
@@ -66,13 +66,6 @@ namespace Windows.UI.Xaml.Media
 
 			if (url.HasValueTrimmed() && Uri.TryCreate(url.Trim(), UriKind.RelativeOrAbsolute, out uri))
 			{
-				if (!uri.IsAbsoluteUri || uri.Scheme == "")
-				{
-					uri = new Uri(MsAppXScheme + "://" + url.TrimStart("/"));
-					InitFromResource(uri);
-					return;
-				}
-
 				InitFromUri(uri);
 			}
 			else
@@ -96,10 +89,14 @@ namespace Windows.UI.Xaml.Media
 
 		internal void InitFromUri(Uri uri)
 		{
+			if (!uri.IsAbsoluteUri || uri.Scheme == "")
+			{
+				uri = new Uri(MsAppXScheme + ":///" + uri.OriginalString.TrimStart("/"));
+			}
 
 			var isResource = uri.Scheme.Equals(MsAppXScheme, StringComparison.OrdinalIgnoreCase)
-							|| uri.Scheme.Equals(MsAppDataScheme, StringComparison.OrdinalIgnoreCase)
-							;
+							|| uri.Scheme.Equals(MsAppDataScheme, StringComparison.OrdinalIgnoreCase);
+
 			if (isResource)
 			{
 				InitFromResource(uri);
@@ -113,10 +110,12 @@ namespace Windows.UI.Xaml.Media
 
 			WebUri = uri;
 		}
+
 		private void InitFromFile(Uri uri)
 		{
 			FilePath = uri.PathAndQuery;
 		}
+
 		partial void InitFromResource(Uri uri);
 
 		static public implicit operator ImageSource(string url)

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.net.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.net.cs
@@ -1,0 +1,30 @@
+﻿using Uno.Extensions;
+using Uno.Logging;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Net.Http;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Uno;
+using Uno.Diagnostics.Eventing;
+using Windows.UI.Xaml.Media.Imaging;
+
+#if !IS_UNO
+using Uno.Web.Query;
+using Uno.Web.Query.Cache;
+#endif
+
+namespace Windows.UI.Xaml.Media
+{
+	partial class ImageSource 
+	{
+		partial void InitFromResource(Uri uri)
+		{
+			WebUri = uri;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Style/Style.cs
+++ b/src/Uno.UI/UI/Xaml/Style/Style.cs
@@ -29,6 +29,7 @@ namespace Windows.UI.Xaml
 
 		public Style()
 		{
+			Precedence = DependencyPropertyValuePrecedences.ExplicitStyle;
 		}
 
 		public Style(Type targetType)
@@ -41,7 +42,7 @@ namespace Windows.UI.Xaml
 			TargetType = targetType;
 
 			Precedence = DependencyPropertyValuePrecedences.ExplicitStyle;
-        }
+		}
 
 		public Style(Type targetType, Style basedOn)
 			: this(targetType, basedOn, false)

--- a/src/Uno.UI/UI/Xaml/UIElementCollection.Net.cs
+++ b/src/Uno.UI/UI/Xaml/UIElementCollection.Net.cs
@@ -20,7 +20,10 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override IEnumerable<View> ClearCore()
 		{
-			throw new NotImplementedException();
+			var old = _elements.ToArray();
+			_elements.Clear();
+
+			return old;
 		}
 
 		protected override bool ContainsCore(View item)


### PR DESCRIPTION
- Add support for implicit bool to `Visibility` conversion  
- Fix default `Style` constructor does not set the proper property precedence
- Add more `DependencyObjectStore` logging 
- Align `ItemsControl.Items` behavior with UWP (#34)
- Fix invalid uri parsing when set through `BitmapImage.UriSource`
