### PR TITLE
Pivot, AutoSuggestBox, TextBox, XamlReader updates

### DIFF
--- a/src/SourceGenerators/System.Xaml.Tests.MS/System.Xaml.Tests.MS.csproj
+++ b/src/SourceGenerators/System.Xaml.Tests.MS/System.Xaml.Tests.MS.csproj
@@ -24,6 +24,8 @@
 		
 	<ItemGroup>
 	  <None Remove="XmlFiles\AttachedProperty.xaml" />
+	  <None Remove="XmlFiles\AttachedPropertyWithNamespace.xaml" />
+	  <None Remove="XmlFiles\AttachedPropertyWIthoutNamespace.xaml" />
 	  <None Remove="XmlFiles\RunSpace01.xaml" />
 	  <None Remove="XmlFiles\RunSpace02.xaml" />
 	  <None Remove="XmlFiles\TextLiteral.xaml" />

--- a/src/SourceGenerators/System.Xaml.Tests.MS/XamlReaderTestGenerators.cs
+++ b/src/SourceGenerators/System.Xaml.Tests.MS/XamlReaderTestGenerators.cs
@@ -221,6 +221,28 @@ namespace System.Xaml.Tests.MS
 		}
 
 		[Test]
+		public void Read_AttachedPropertyWithNamespace()
+		{
+			var s = WriteTest("AttachedPropertyWithNamespace.xaml");
+
+			var sequence = new SequenceItem[] {
+			};
+
+			ReadSequence("AttachedPropertyWithNamespace.xaml", sequence);
+		}
+
+		[Test]
+		public void Read_AttachedPropertyWithoutNamespace()
+		{
+			var s = WriteTest("AttachedPropertyWithoutNamespace.xaml");
+
+			var sequence = new SequenceItem[] {
+			};
+
+			ReadSequence("AttachedPropertyWithoutNamespace.xaml", sequence);
+		}
+
+		[Test]
 		public void Read_GenericWithProperty()
 		{
 			var s = WriteTest("GenericWithProperty.xaml");

--- a/src/SourceGenerators/System.Xaml.Tests.MS/XmlFiles/AttachedPropertyWIthoutNamespace.xaml
+++ b/src/SourceGenerators/System.Xaml.Tests.MS/XmlFiles/AttachedPropertyWIthoutNamespace.xaml
@@ -1,0 +1,7 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:other="using:MyOtherNamespace">
+
+  <other:TestObject Attached.Original="test" />
+
+</ResourceDictionary>

--- a/src/SourceGenerators/System.Xaml.Tests.MS/XmlFiles/AttachedPropertyWithNamespace.xaml
+++ b/src/SourceGenerators/System.Xaml.Tests.MS/XmlFiles/AttachedPropertyWithNamespace.xaml
@@ -1,0 +1,8 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:other="using:MyOtherNamespace"
+					xmlns:other2="using:MyOtherNamespace2">
+
+  <other:TestObject other:Attached.Original="test" other2:Attached2.Original="test" />
+
+</ResourceDictionary>

--- a/src/SourceGenerators/System.Xaml.Tests/Test/System.Xaml/XamlXmlReaderTest.cs
+++ b/src/SourceGenerators/System.Xaml.Tests/Test/System.Xaml/XamlXmlReaderTest.cs
@@ -373,7 +373,6 @@ namespace MonoTests.Uno.Xaml
 				new SequenceItem { NodeType = XamlNodeType.NamespaceDeclaration, },
 				new SequenceItem { NodeType = XamlNodeType.NamespaceDeclaration, },
 				new SequenceItem { NodeType = XamlNodeType.NamespaceDeclaration, },
-				new SequenceItem { NodeType = XamlNodeType.NamespaceDeclaration, },
 				new SequenceItem { NodeType = XamlNodeType.StartObject, TypeName = "{http://schemas.microsoft.com/winfx/2006/xaml/presentation}ResourceDictionary"},
 
 				new SequenceItem { NodeType = XamlNodeType.StartMember, MemberType = XamlLanguage.Base.ToString() },
@@ -1516,6 +1515,73 @@ namespace MonoTests.Uno.Xaml
 
 			ReadSequence("RunSpace02.xaml", sequence);
 		}
+
+		[Test]
+		public void Read_AttachedPropertyWithoutNamespace()
+		{
+			var sequence = new SequenceItem[]
+			{
+				new SequenceItem { NodeType = XamlNodeType.NamespaceDeclaration, },
+				new SequenceItem { NodeType = XamlNodeType.NamespaceDeclaration, },
+				new SequenceItem { NodeType = XamlNodeType.NamespaceDeclaration, },
+
+				new SequenceItem { NodeType = XamlNodeType.StartObject, TypeName = "{http://schemas.microsoft.com/winfx/2006/xaml/presentation}ResourceDictionary" },
+
+				new SequenceItem { NodeType = XamlNodeType.StartMember, MemberType = XamlLanguage.Base.ToString() },
+				new SequenceItem { NodeType = XamlNodeType.Value, Value = "", },
+				new SequenceItem { NodeType = XamlNodeType.EndMember, },
+
+				new SequenceItem { NodeType = XamlNodeType.StartMember, MemberType = "{http://schemas.microsoft.com/winfx/2006/xaml}_UnknownContent", },
+				new SequenceItem { NodeType = XamlNodeType.StartObject, TypeName = "{using:MyOtherNamespace}TestObject" },
+
+				new SequenceItem { NodeType = XamlNodeType.StartMember, MemberType = "{http://schemas.microsoft.com/winfx/2006/xaml/presentation}Attached.Original", },
+				new SequenceItem { NodeType = XamlNodeType.Value, Value = "test", },
+				new SequenceItem { NodeType = XamlNodeType.EndMember, },
+
+				new SequenceItem { NodeType = XamlNodeType.EndObject, },
+				new SequenceItem { NodeType = XamlNodeType.EndMember, },
+				new SequenceItem { NodeType = XamlNodeType.EndObject, },
+				new SequenceItem { NodeType = XamlNodeType.None, },
+			};
+
+			ReadSequence("AttachedPropertyWithoutNamespace.xaml", sequence);
+		}
+
+		[Test]
+		public void Read_AttachedPropertyWithNamespace()
+		{
+			var sequence = new SequenceItem[]
+			{
+				new SequenceItem { NodeType = XamlNodeType.NamespaceDeclaration, },
+				new SequenceItem { NodeType = XamlNodeType.NamespaceDeclaration, },
+				new SequenceItem { NodeType = XamlNodeType.NamespaceDeclaration, },
+				new SequenceItem { NodeType = XamlNodeType.NamespaceDeclaration, },
+				new SequenceItem { NodeType = XamlNodeType.StartObject, TypeName = "{http://schemas.microsoft.com/winfx/2006/xaml/presentation}ResourceDictionary"},
+
+				new SequenceItem { NodeType = XamlNodeType.StartMember, MemberType = XamlLanguage.Base.ToString() },
+				new SequenceItem { NodeType = XamlNodeType.Value, Value = "", },
+				new SequenceItem { NodeType = XamlNodeType.EndMember, },
+
+				new SequenceItem { NodeType = XamlNodeType.StartMember, MemberType = "{http://schemas.microsoft.com/winfx/2006/xaml}_UnknownContent", },
+				new SequenceItem { NodeType = XamlNodeType.StartObject, TypeName = "{using:MyOtherNamespace}TestObject"},
+
+				new SequenceItem { NodeType = XamlNodeType.StartMember, MemberType = "{using:MyOtherNamespace}Attached.Original", },
+				new SequenceItem { NodeType = XamlNodeType.Value, Value = "test", },
+				new SequenceItem { NodeType = XamlNodeType.EndMember, },
+
+				new SequenceItem { NodeType = XamlNodeType.StartMember, MemberType = "{using:MyOtherNamespace2}Attached2.Original", },
+				new SequenceItem { NodeType = XamlNodeType.Value, Value = "test", },
+				new SequenceItem { NodeType = XamlNodeType.EndMember, },
+
+				new SequenceItem { NodeType = XamlNodeType.EndObject, },
+				new SequenceItem { NodeType = XamlNodeType.EndMember, },
+				new SequenceItem { NodeType = XamlNodeType.EndObject, },
+				new SequenceItem { NodeType = XamlNodeType.None, },
+			};
+
+			ReadSequence("AttachedPropertyWithNamespace.xaml", sequence);
+		}
+
 		[Test]
 		public void Read_Int32 ()
 		{

--- a/src/SourceGenerators/System.Xaml.Tests/Test/XmlFiles/AttachedPropertyWithNamespace.xaml
+++ b/src/SourceGenerators/System.Xaml.Tests/Test/XmlFiles/AttachedPropertyWithNamespace.xaml
@@ -1,0 +1,8 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:other="using:MyOtherNamespace"
+					xmlns:other2="using:MyOtherNamespace2">
+
+  <other:TestObject other:Attached.Original="test" other2:Attached2.Original="test" />
+
+</ResourceDictionary>

--- a/src/SourceGenerators/System.Xaml.Tests/Test/XmlFiles/AttachedPropertyWithoutNamespace.xaml
+++ b/src/SourceGenerators/System.Xaml.Tests/Test/XmlFiles/AttachedPropertyWithoutNamespace.xaml
@@ -1,0 +1,7 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+					xmlns:other="using:MyOtherNamespace">
+
+  <other:TestObject Attached.Original="test" />
+
+</ResourceDictionary>

--- a/src/SourceGenerators/System.Xaml.Tests/Uno.Xaml.Tests.csproj
+++ b/src/SourceGenerators/System.Xaml.Tests/Uno.Xaml.Tests.csproj
@@ -23,16 +23,9 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-	  <None Remove="Test\XmlFiles\BindingMembers.xaml" />
-	  <None Remove="Test\XmlFiles\Binding_Escape.xaml" />
-	  <None Remove="Test\XmlFiles\CustomAttachedProperty.xaml" />
-	  <None Remove="Test\XmlFiles\RunSpace01.xaml" />
-	  <None Remove="Test\XmlFiles\RunSpace02.xaml" />
-	  <None Remove="Test\XmlFiles\TextLiteral.xaml" />
-	  <None Remove="Test\XmlFiles\WhiteSpacePreservation.xaml" />
-	  <None Remove="Test\XmlFiles\xBind.xaml" />
+	  <None Remove="Test\XmlFiles\AttachedPropertyWithNamespace.xaml" />
 	</ItemGroup>
-	
+		
 	<ItemGroup>
 	  <ProjectReference Include="..\System.Xaml\Uno.Xaml.csproj" />
 	</ItemGroup>
@@ -41,22 +34,7 @@
 		<Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <Content Update="Test\XmlFiles\CustomAttachedProperty.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </Content>
-	  <Content Update="Test\XmlFiles\RunSpace01.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </Content>
-	  <Content Update="Test\XmlFiles\RunSpace02.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </Content>
-	  <Content Update="Test\XmlFiles\xBind.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </Content>
-	</ItemGroup>
-
-	<ItemGroup>
+  <ItemGroup>
 	  <Reference Update="System.Xml">
 	    <Aliases>msxaml,%(Aliases)</Aliases>
 	  </Reference>

--- a/src/SourceGenerators/System.Xaml/System.Xaml/XamlXmlReader.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/XamlXmlReader.cs
@@ -540,7 +540,7 @@ namespace Uno.Xaml
 				string aname = nsidx > 0 ? p.Key.Substring (nsidx + 1) : p.Key;
 				int propidx = aname.IndexOf ('.');
 				if (propidx > 0) {
-					string apns = prefix.Length > 0 ? r.LookupNamespace (prefix) : r.NamespaceURI;
+					string apns = r.LookupNamespace(prefix);
 					var apname = aname.Substring (0, propidx);
 					var axtn = new XamlTypeName (apns, apname, null);
 

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -78,10 +78,13 @@
     <None Remove="XamlReaderTests\When_AttachedProperty_Same_Target.xamltest" />
     <None Remove="XamlReaderTests\When_BasicProperty.xamltest" />
     <None Remove="XamlReaderTests\When_BasicRoot.xamltest" />
+    <None Remove="XamlReaderTests\When_Binding_Converter.xamltest" />
+    <None Remove="XamlReaderTests\When_Binding_ConverterParameter.xamltest" />
     <None Remove="XamlReaderTests\When_Binding_TargetNull.xamltest" />
     <None Remove="XamlReaderTests\When_Binding_TwoWay.xamltest" />
     <None Remove="XamlReaderTests\When_Binding_TwoWay_UpdateSourceTrigger.xamltest" />
     <None Remove="XamlReaderTests\When_ElementName.xamltest" />
+    <None Remove="XamlReaderTests\When_GridRowDefinitions.xamltest" />
     <None Remove="XamlReaderTests\When_MultipleBindings.xamltest" />
     <None Remove="XamlReaderTests\When_StaticResource.xamltest" />
     <None Remove="XamlReaderTests\When_StaticResource_Style_And_Binding.xamltest" />

--- a/src/Uno.UI.Tests/XamlReaderTests/EmptyTestControl.cs
+++ b/src/Uno.UI.Tests/XamlReaderTests/EmptyTestControl.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.Tests.XamlReaderTests
+{
+    public class EmptyTestControl : FrameworkElement
+    {
+    }
+}

--- a/src/Uno.UI.Tests/XamlReaderTests/Given_XamlReader.cs
+++ b/src/Uno.UI.Tests/XamlReaderTests/Given_XamlReader.cs
@@ -568,6 +568,36 @@ namespace Uno.UI.Tests.XamlReaderTests
 		}
 
 		[TestMethod]
+		public void When_Binding_Converter()
+		{
+			var s = GetContent(nameof(When_Binding_Converter));
+			var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
+
+			var c = r.Content as ContentControl;
+
+			Assert.AreEqual(Visibility.Visible, c.Visibility);
+
+			c.DataContext = false;
+
+			Assert.AreEqual(Visibility.Collapsed, c.Visibility);
+
+			c.DataContext = true;
+
+			Assert.AreEqual(Visibility.Visible, c.Visibility);
+		}
+
+		[TestMethod]
+		public void When_Binding_ConverterParameter()
+		{
+			var s = GetContent(nameof(When_Binding_ConverterParameter));
+			var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
+
+			var c = r.Content as ContentControl;
+
+			Assert.AreEqual("42", c.GetBindingExpression(UIElement.VisibilityProperty).ParentBinding.ConverterParameter);
+		}
+
+		[TestMethod]
 		public void When_StaticResource_Style_And_Binding()
 		{
 			var s = GetContent(nameof(When_StaticResource_Style_And_Binding));
@@ -590,6 +620,28 @@ namespace Uno.UI.Tests.XamlReaderTests
 
 			Assert.IsTrue((bool)tb1.IsChecked);
 			Assert.IsTrue((bool)tb2.IsChecked);
+		}
+		
+		[TestMethod]
+		public void When_GridRowDefinitions()
+		{
+			var s = GetContent(nameof(When_GridRowDefinitions));
+			var r = Windows.UI.Xaml.Markup.XamlReader.Load(s) as UserControl;
+
+			var root = r.FindName("root") as Grid;
+
+			Assert.AreEqual(3, root.RowDefinitions.Count);
+			Assert.AreEqual(GridUnitType.Star, root.RowDefinitions[0].Height.GridUnitType);
+			Assert.AreEqual(1.0, root.RowDefinitions[0].Height.Value);
+			Assert.AreEqual(GridUnitType.Star, root.RowDefinitions[1].Height.GridUnitType);
+			Assert.AreEqual(1.0, root.RowDefinitions[1].Height.Value);
+
+			var panel = r.FindName("innerPanel") as EmptyTestControl;
+			Assert.AreEqual(1, Grid.GetRow(panel));
+
+			var panel2 = r.FindName("innerPanel2") as StackPanel;
+			Assert.AreEqual(2, Grid.GetRow(panel2));
+
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.Tests/XamlReaderTests/When_Binding_Converter.xamltest
+++ b/src/Uno.UI.Tests/XamlReaderTests/When_Binding_Converter.xamltest
@@ -1,0 +1,10 @@
+﻿<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:converters="using:Uno.UI.Converters"
+      x:Name="testPage">
+  <UserControl.Resources>
+	<converters:FromNullableBoolToVisibilityConverter x:Key="myConverter"/>
+  </UserControl.Resources>
+
+  <ContentControl Visibility="{Binding Converter={StaticResource myConverter}}" />
+</UserControl>

--- a/src/Uno.UI.Tests/XamlReaderTests/When_Binding_ConverterParameter.xamltest
+++ b/src/Uno.UI.Tests/XamlReaderTests/When_Binding_ConverterParameter.xamltest
@@ -1,0 +1,10 @@
+﻿<UserControl xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:converters="using:Uno.UI.Converters"
+      x:Name="testPage">
+  <UserControl.Resources>
+	<converters:NullConverter x:Key="myConverter"/>
+  </UserControl.Resources>
+
+  <ContentControl Visibility="{Binding Converter={StaticResource myConverter}, ConverterParameter=42}" />
+</UserControl>

--- a/src/Uno.UI.Tests/XamlReaderTests/When_GridRowDefinitions.xamltest
+++ b/src/Uno.UI.Tests/XamlReaderTests/When_GridRowDefinitions.xamltest
@@ -1,0 +1,18 @@
+﻿<Page xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:testControls="using:Uno.UI.Tests.XamlReaderTests"
+			Name="rootPage"
+      mc:Ignorable="d">
+
+	<Grid x:Name="root">
+	  <Grid.RowDefinitions>
+		<RowDefinition/>
+		<RowDefinition/>
+		<RowDefinition/>
+	  </Grid.RowDefinitions>
+	  <testControls:EmptyTestControl x:Name="innerPanel" Grid.Row="1" />
+	  <StackPanel x:Name="innerPanel2" Grid.Row="2" />
+	</Grid>
+</Page>

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBox.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBox.cs
@@ -7,7 +7,7 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class AutoSuggestBox : global::Windows.UI.Xaml.Controls.ItemsControl
 	{
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#if false
 		[global::Uno.NotImplemented]
 		public  string PlaceholderText
 		{
@@ -20,8 +20,8 @@ namespace Windows.UI.Xaml.Controls
 				this.SetValue(PlaceholderTextProperty, value);
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public  double MaxSuggestionListHeight
 		{
@@ -34,8 +34,8 @@ namespace Windows.UI.Xaml.Controls
 				this.SetValue(MaxSuggestionListHeightProperty, value);
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public  bool IsSuggestionListOpen
 		{
@@ -48,8 +48,8 @@ namespace Windows.UI.Xaml.Controls
 				this.SetValue(IsSuggestionListOpenProperty, value);
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public  object Header
 		{
@@ -62,8 +62,8 @@ namespace Windows.UI.Xaml.Controls
 				this.SetValue(HeaderProperty, value);
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public  bool AutoMaximizeSuggestionArea
 		{
@@ -76,8 +76,8 @@ namespace Windows.UI.Xaml.Controls
 				this.SetValue(AutoMaximizeSuggestionAreaProperty, value);
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public  bool UpdateTextOnSelect
 		{
@@ -90,8 +90,8 @@ namespace Windows.UI.Xaml.Controls
 				this.SetValue(UpdateTextOnSelectProperty, value);
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public  string TextMemberPath
 		{
@@ -104,8 +104,8 @@ namespace Windows.UI.Xaml.Controls
 				this.SetValue(TextMemberPathProperty, value);
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Xaml.Style TextBoxStyle
 		{
@@ -118,8 +118,8 @@ namespace Windows.UI.Xaml.Controls
 				this.SetValue(TextBoxStyleProperty, value);
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public  string Text
 		{
@@ -132,8 +132,8 @@ namespace Windows.UI.Xaml.Controls
 				this.SetValue(TextProperty, value);
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Xaml.Controls.IconElement QueryIcon
 		{
@@ -146,8 +146,8 @@ namespace Windows.UI.Xaml.Controls
 				this.SetValue(QueryIconProperty, value);
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if __ANDROID__ || __IOS__ || NET46 || __WASM__
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Xaml.Controls.LightDismissOverlayMode LightDismissOverlayMode
 		{
@@ -160,101 +160,95 @@ namespace Windows.UI.Xaml.Controls
 				this.SetValue(LightDismissOverlayModeProperty, value);
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+
+#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty MaxSuggestionListHeightProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
 			"MaxSuggestionListHeight", typeof(double), 
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox), 
 			new FrameworkPropertyMetadata(default(double)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty PlaceholderTextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
 			"PlaceholderText", typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox), 
 			new FrameworkPropertyMetadata(default(string)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextBoxStyleProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
 			"TextBoxStyle", typeof(global::Windows.UI.Xaml.Style), 
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Style)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextMemberPathProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
 			"TextMemberPath", typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox), 
 			new FrameworkPropertyMetadata(default(string)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty TextProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
 			"Text", typeof(string), 
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox), 
 			new FrameworkPropertyMetadata(default(string)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty UpdateTextOnSelectProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
 			"UpdateTextOnSelect", typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox), 
 			new FrameworkPropertyMetadata(default(bool)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty AutoMaximizeSuggestionAreaProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
 			"AutoMaximizeSuggestionArea", typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox), 
 			new FrameworkPropertyMetadata(default(bool)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty HeaderProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
 			"Header", typeof(object), 
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox), 
 			new FrameworkPropertyMetadata(default(object)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty IsSuggestionListOpenProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
 			"IsSuggestionListOpen", typeof(bool), 
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox), 
 			new FrameworkPropertyMetadata(default(bool)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty QueryIconProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
 			"QueryIcon", typeof(global::Windows.UI.Xaml.Controls.IconElement), 
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.IconElement)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+	#if __ANDROID__ || __IOS__ || NET46 || __WASM__
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
 			"LightDismissOverlayMode", typeof(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode), 
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.LightDismissOverlayMode)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
-		[global::Uno.NotImplemented]
-		public AutoSuggestBox() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.AutoSuggestBox", "AutoSuggestBox.AutoSuggestBox()");
-		}
 		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.AutoSuggestBox.AutoSuggestBox()
 		// Forced skipping of method Windows.UI.Xaml.Controls.AutoSuggestBox.MaxSuggestionListHeight.get
@@ -296,53 +290,5 @@ namespace Windows.UI.Xaml.Controls
 		// Forced skipping of method Windows.UI.Xaml.Controls.AutoSuggestBox.HeaderProperty.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.AutoSuggestBox.AutoMaximizeSuggestionAreaProperty.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.AutoSuggestBox.TextBoxStyleProperty.get
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
-		[global::Uno.NotImplemented]
-		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Xaml.Controls.AutoSuggestBox, global::Windows.UI.Xaml.Controls.AutoSuggestBoxSuggestionChosenEventArgs> SuggestionChosen
-		{
-			[global::Uno.NotImplemented]
-			add
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.AutoSuggestBox", "event TypedEventHandler<AutoSuggestBox, AutoSuggestBoxSuggestionChosenEventArgs> AutoSuggestBox.SuggestionChosen");
-			}
-			[global::Uno.NotImplemented]
-			remove
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.AutoSuggestBox", "event TypedEventHandler<AutoSuggestBox, AutoSuggestBoxSuggestionChosenEventArgs> AutoSuggestBox.SuggestionChosen");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
-		[global::Uno.NotImplemented]
-		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Xaml.Controls.AutoSuggestBox, global::Windows.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs> TextChanged
-		{
-			[global::Uno.NotImplemented]
-			add
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.AutoSuggestBox", "event TypedEventHandler<AutoSuggestBox, AutoSuggestBoxTextChangedEventArgs> AutoSuggestBox.TextChanged");
-			}
-			[global::Uno.NotImplemented]
-			remove
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.AutoSuggestBox", "event TypedEventHandler<AutoSuggestBox, AutoSuggestBoxTextChangedEventArgs> AutoSuggestBox.TextChanged");
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
-		[global::Uno.NotImplemented]
-		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Xaml.Controls.AutoSuggestBox, global::Windows.UI.Xaml.Controls.AutoSuggestBoxQuerySubmittedEventArgs> QuerySubmitted
-		{
-			[global::Uno.NotImplemented]
-			add
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.AutoSuggestBox", "event TypedEventHandler<AutoSuggestBox, AutoSuggestBoxQuerySubmittedEventArgs> AutoSuggestBox.QuerySubmitted");
-			}
-			[global::Uno.NotImplemented]
-			remove
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.AutoSuggestBox", "event TypedEventHandler<AutoSuggestBox, AutoSuggestBoxQuerySubmittedEventArgs> AutoSuggestBox.QuerySubmitted");
-			}
-		}
-		#endif
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBoxQuerySubmittedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBoxQuerySubmittedEventArgs.cs
@@ -7,7 +7,7 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class AutoSuggestBoxQuerySubmittedEventArgs : global::Windows.UI.Xaml.DependencyObject
 	{
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+		#if false
 		[global::Uno.NotImplemented]
 		public  object ChosenSuggestion
 		{
@@ -17,7 +17,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+		#if false
 		[global::Uno.NotImplemented]
 		public  string QueryText
 		{
@@ -27,7 +27,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if false || false || false || false
+		#if false
 		[global::Uno.NotImplemented]
 		public AutoSuggestBoxQuerySubmittedEventArgs() : base()
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBoxSuggestionChosenEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBoxSuggestionChosenEventArgs.cs
@@ -7,7 +7,7 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class AutoSuggestBoxSuggestionChosenEventArgs : global::Windows.UI.Xaml.DependencyObject
 	{
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+		#if false
 		[global::Uno.NotImplemented]
 		public  object SelectedItem
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBoxTextChangedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestBoxTextChangedEventArgs.cs
@@ -7,7 +7,7 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class AutoSuggestBoxTextChangedEventArgs : global::Windows.UI.Xaml.DependencyObject
 	{
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+		#if false
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Xaml.Controls.AutoSuggestionBoxTextChangeReason Reason
 		{
@@ -21,7 +21,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+		#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty ReasonProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(
@@ -29,12 +29,12 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.AutoSuggestionBoxTextChangeReason)));
 		#endif
-		#if false || false || false || false
+		#if false
 		[global::Uno.NotImplemented]
 		public AutoSuggestBoxTextChangedEventArgs() : base()
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs", "AutoSuggestBoxTextChangedEventArgs.AutoSuggestBoxTextChangedEventArgs()");
-		}
+		} 
 		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs.AutoSuggestBoxTextChangedEventArgs()
 		// Forced skipping of method Windows.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs.Reason.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestionBoxTextChangeReason.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/AutoSuggestionBoxTextChangeReason.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+	#if false
 	#if __ANDROID__ || __IOS__ || NET46 || __WASM__
 	[global::Uno.NotImplemented]
 	#endif

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.Properties.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.Properties.cs
@@ -1,0 +1,142 @@
+
+using System;
+using Windows.Foundation;
+
+namespace Windows.UI.Xaml.Controls
+{
+	public partial class AutoSuggestBox : ItemsControl
+	{
+		public string PlaceholderText
+		{
+			get => (string)this.GetValue(PlaceholderTextProperty);
+			set => this.SetValue(PlaceholderTextProperty, value);
+		}
+
+		public double MaxSuggestionListHeight
+		{
+			get => (double)this.GetValue(MaxSuggestionListHeightProperty);
+			set => this.SetValue(MaxSuggestionListHeightProperty, value);
+		}
+
+		public bool IsSuggestionListOpen
+		{
+			get => (bool)this.GetValue(IsSuggestionListOpenProperty);
+			set => this.SetValue(IsSuggestionListOpenProperty, value);
+		}
+
+		public object Header
+		{
+			get => (object)this.GetValue(HeaderProperty);
+			set => this.SetValue(HeaderProperty, value);
+		}
+
+		public bool AutoMaximizeSuggestionArea
+		{
+			get => (bool)this.GetValue(AutoMaximizeSuggestionAreaProperty);
+			set => this.SetValue(AutoMaximizeSuggestionAreaProperty, value);
+		}
+
+		public bool UpdateTextOnSelect
+		{
+			get => (bool)this.GetValue(UpdateTextOnSelectProperty);
+			set => this.SetValue(UpdateTextOnSelectProperty, value);
+		}
+
+		public string TextMemberPath
+		{
+			get => (string)this.GetValue(TextMemberPathProperty);
+			set => this.SetValue(TextMemberPathProperty, value);
+		}
+
+		public global::Windows.UI.Xaml.Style TextBoxStyle
+		{
+			get => (global::Windows.UI.Xaml.Style)this.GetValue(TextBoxStyleProperty);
+			set => this.SetValue(TextBoxStyleProperty, value);
+		}
+
+		public string Text
+		{
+			get => (string)this.GetValue(TextProperty);
+			set => this.SetValue(TextProperty, value);
+		}
+
+		public global::Windows.UI.Xaml.Controls.IconElement QueryIcon
+		{
+			get => (global::Windows.UI.Xaml.Controls.IconElement)this.GetValue(QueryIconProperty);
+			set => this.SetValue(QueryIconProperty, value);
+		}
+
+		public static global::Windows.UI.Xaml.DependencyProperty MaxSuggestionListHeightProperty { get; } =
+		Windows.UI.Xaml.DependencyProperty.Register(
+			"MaxSuggestionListHeight", typeof(double),
+			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox),
+			new FrameworkPropertyMetadata(defaultValue: double.PositiveInfinity)
+		);
+
+		public static global::Windows.UI.Xaml.DependencyProperty PlaceholderTextProperty { get; } =
+		Windows.UI.Xaml.DependencyProperty.Register(
+			"PlaceholderText", typeof(string),
+			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox),
+			new FrameworkPropertyMetadata(defaultValue: "")
+		);
+
+		public static global::Windows.UI.Xaml.DependencyProperty TextBoxStyleProperty { get; } =
+		Windows.UI.Xaml.DependencyProperty.Register(
+			"TextBoxStyle", typeof(global::Windows.UI.Xaml.Style),
+			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox),
+			new FrameworkPropertyMetadata(defaultValue: null)
+		);
+
+		public static global::Windows.UI.Xaml.DependencyProperty TextMemberPathProperty { get; } =
+		Windows.UI.Xaml.DependencyProperty.Register(
+			"TextMemberPath", typeof(string),
+			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox),
+			new FrameworkPropertyMetadata(defaultValue: null)
+		);
+
+		public static DependencyProperty TextProperty { get; } =
+		Windows.UI.Xaml.DependencyProperty.Register(
+			"Text", typeof(string),
+			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox),
+			new FrameworkPropertyMetadata(defaultValue: "", OnTextChanged)
+		);
+
+		public static global::Windows.UI.Xaml.DependencyProperty UpdateTextOnSelectProperty { get; } =
+		Windows.UI.Xaml.DependencyProperty.Register(
+			"UpdateTextOnSelect", typeof(bool),
+			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox),
+			new FrameworkPropertyMetadata(defaultValue: true)
+		);
+
+		public static global::Windows.UI.Xaml.DependencyProperty AutoMaximizeSuggestionAreaProperty { get; } =
+		Windows.UI.Xaml.DependencyProperty.Register(
+			"AutoMaximizeSuggestionArea", typeof(bool),
+			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox),
+			new FrameworkPropertyMetadata(defaultValue: false)
+		);
+
+		public static global::Windows.UI.Xaml.DependencyProperty HeaderProperty { get; } =
+		Windows.UI.Xaml.DependencyProperty.Register(
+			"Header", typeof(object),
+			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox),
+			new FrameworkPropertyMetadata(defaultValue: null)
+		);
+
+		public static global::Windows.UI.Xaml.DependencyProperty IsSuggestionListOpenProperty { get; } =
+		Windows.UI.Xaml.DependencyProperty.Register(
+			"IsSuggestionListOpen", typeof(bool),
+			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox),
+			new FrameworkPropertyMetadata(defaultValue: false, propertyChangedCallback: (s, e) => (s as AutoSuggestBox)?.OnIsSuggestionListOpenChanged(e))
+		);
+
+		public static global::Windows.UI.Xaml.DependencyProperty QueryIconProperty { get; } =
+		Windows.UI.Xaml.DependencyProperty.Register(
+			"QueryIcon", typeof(global::Windows.UI.Xaml.Controls.IconElement),
+			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBox),
+			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.IconElement)));
+
+		public event TypedEventHandler<AutoSuggestBox, AutoSuggestBoxSuggestionChosenEventArgs> SuggestionChosen;
+		public event TypedEventHandler<AutoSuggestBox, AutoSuggestBoxTextChangedEventArgs> TextChanged;
+		public event TypedEventHandler<AutoSuggestBox, AutoSuggestBoxQuerySubmittedEventArgs> QuerySubmitted;
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBox.cs
@@ -22,7 +22,6 @@ namespace Windows.UI.Xaml.Controls
 		private TextBox _textBox;
 		private Popup _popup;
 		private Grid _layoutRoot;
-		private Border _suggestionContainer;
 		private ListView _suggestionsList;
 		private Button _queryButton;
 
@@ -38,11 +37,10 @@ namespace Windows.UI.Xaml.Controls
 			_textBox = GetTemplateChild("TextBox") as TextBox;
 			_popup = GetTemplateChild("SuggestionsPopup") as Popup;
 			_layoutRoot = GetTemplateChild("LayoutRoot") as Grid;
-			_suggestionContainer = GetTemplateChild("SuggestionsContainer") as Border;
 			_suggestionsList = GetTemplateChild("SuggestionsList") as ListView;
 			_queryButton = GetTemplateChild("QueryButton") as Button;
 
-			_textBox.SetBinding(
+			_textBox?.SetBinding(
 				TextBox.TextProperty,
 				new Binding()
 				{
@@ -64,29 +62,36 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnItemsChanged(IObservableVector<object> sender, IVectorChangedEventArgs @event)
 		{
-			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+			if (_suggestionsList != null)
 			{
-				this.Log().Debug("ItemsChanged, refreshing suggestion list");
-			}
+				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				{
+					this.Log().Debug("ItemsChanged, refreshing suggestion list");
+				}
 
-			_suggestionsList.ItemsSource = GetItems();
-
-			if(GetItems().Count() == 0)
-			{
-				IsSuggestionListOpen = false;
-			}
-			else
-			{
-				IsSuggestionListOpen = true;
 				_suggestionsList.ItemsSource = GetItems();
 
-				LayoutPopup();
+				if (GetItems().Count() == 0)
+				{
+					IsSuggestionListOpen = false;
+				}
+				else
+				{
+					IsSuggestionListOpen = true;
+					_suggestionsList.ItemsSource = GetItems();
+
+					LayoutPopup();
+				}
 			}
 		}
 
 		private void LayoutPopup()
 		{
-			if (_popup.IsOpen && _popup.Child is FrameworkElement popupChild)
+			if (
+				_popup != null
+				&& _popup.IsOpen
+				&& _popup.Child is FrameworkElement popupChild
+			)
 			{
 				if (_popup is Popup popup)
 				{
@@ -155,14 +160,25 @@ namespace Windows.UI.Xaml.Controls
 
 		void RegisterEvents()
 		{
-			_textBox.KeyDown += OnTextBoxKeyDown;
-			_queryButton.Click += OnQueryButtonClick;
-			_suggestionsList.ItemClick += OnSuggestionListItemClick;
+			if (_textBox != null)
+			{
+				_textBox.KeyDown += OnTextBoxKeyDown;
+			}
+
+			if (_queryButton != null)
+			{
+				_queryButton.Click += OnQueryButtonClick;
+			}
+
+			if (_suggestionsList != null)
+			{
+				_suggestionsList.ItemClick += OnSuggestionListItemClick;
+			}
 		}
 
 		private void OnIsSuggestionListOpenChanged(DependencyPropertyChangedEventArgs e)
 		{
-			if (e.NewValue is bool isOpened)
+			if (e.NewValue is bool isOpened && _popup != null)
 			{
 				_popup.IsOpen = isOpened;
 			}
@@ -218,9 +234,20 @@ namespace Windows.UI.Xaml.Controls
 
 		void UnregisterEvents()
 		{
-			_textBox.KeyDown -= OnTextBoxKeyDown;
-			_queryButton.Click -= OnQueryButtonClick;
-			_suggestionsList.ItemClick -= OnSuggestionListItemClick;
+			if (_textBox != null)
+			{
+				_textBox.KeyDown -= OnTextBoxKeyDown;
+			}
+
+			if (_queryButton != null)
+			{
+				_queryButton.Click -= OnQueryButtonClick;
+			}
+
+			if (_suggestionsList != null)
+			{
+				_suggestionsList.ItemClick -= OnSuggestionListItemClick;
+			}
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxQuerySubmittedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxQuerySubmittedEventArgs.cs
@@ -1,0 +1,21 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.UI.Xaml.Controls
+{
+	public  partial class AutoSuggestBoxQuerySubmittedEventArgs
+	{
+		public  object ChosenSuggestion { get; }
+
+		public  string QueryText { get; }
+
+		public AutoSuggestBoxQuerySubmittedEventArgs() : base()
+		{
+		}
+
+		internal AutoSuggestBoxQuerySubmittedEventArgs(object chosenSuggestion, string queryText)
+		{
+			ChosenSuggestion = chosenSuggestion;
+			QueryText = queryText;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxSuggestionChosenEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxSuggestionChosenEventArgs.cs
@@ -1,0 +1,16 @@
+namespace Windows.UI.Xaml.Controls
+{
+	public partial class AutoSuggestBoxSuggestionChosenEventArgs
+	{
+		public object SelectedItem { get; }
+
+		public AutoSuggestBoxSuggestionChosenEventArgs() : base()
+		{
+		}
+
+		internal AutoSuggestBoxSuggestionChosenEventArgs(object selectedItem)
+		{
+			SelectedItem = selectedItem;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxTextChangedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestBoxTextChangedEventArgs.cs
@@ -1,0 +1,23 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.UI.Xaml.Controls
+{
+	public  partial class AutoSuggestBoxTextChangedEventArgs : global::Windows.UI.Xaml.DependencyObject
+	{
+		public AutoSuggestionBoxTextChangeReason Reason
+		{
+			get => (AutoSuggestionBoxTextChangeReason)this.GetValue(ReasonProperty);
+			set => this.SetValue(ReasonProperty, value);
+		}
+
+		public static global::Windows.UI.Xaml.DependencyProperty ReasonProperty { get; } = 
+		Windows.UI.Xaml.DependencyProperty.Register(
+			"Reason", typeof(AutoSuggestionBoxTextChangeReason), 
+			typeof(global::Windows.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs), 
+			new FrameworkPropertyMetadata(default(AutoSuggestionBoxTextChangeReason)));
+
+		public AutoSuggestBoxTextChangedEventArgs() : base()
+		{
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestionBoxTextChangeReason.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/AutoSuggestBox/AutoSuggestionBoxTextChangeReason.cs
@@ -1,0 +1,9 @@
+namespace Windows.UI.Xaml.Controls
+{
+	public enum AutoSuggestionBoxTextChangeReason 
+	{
+		UserInput,
+		ProgrammaticChange,
+		SuggestionChosen,
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Pivot/Pivot.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Pivot/Pivot.cs
@@ -188,15 +188,11 @@ namespace Windows.UI.Xaml.Controls
 				{
 					if (item is PivotItem pivotItem && item != selectedPivotitem)
 					{
-						pivotItem.Opacity = 0;
-						pivotItem.IsHitTestVisible = false;
 						pivotItem.Visibility = Visibility.Collapsed;
 					}
 				}
 
-				selectedPivotitem.Opacity = 1;
 				selectedPivotitem.Visibility = Visibility.Visible;
-				selectedPivotitem.IsHitTestVisible = true;
 
 				foreach (var child in _staticHeader.Children)
 				{

--- a/src/Uno.UI/UI/Xaml/Controls/Pivot/Pivot.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Pivot/Pivot.cs
@@ -190,10 +190,12 @@ namespace Windows.UI.Xaml.Controls
 					{
 						pivotItem.Opacity = 0;
 						pivotItem.IsHitTestVisible = false;
+						pivotItem.Visibility = Visibility.Collapsed;
 					}
 				}
 
 				selectedPivotitem.Opacity = 1;
+				selectedPivotitem.Visibility = Visibility.Visible;
 				selectedPivotitem.IsHitTestVisible = true;
 
 				foreach (var child in _staticHeader.Children)

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.iOS.cs
@@ -13,17 +13,29 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class Popup
 	{
-		public UIView MainWindow { get; private set; }
+		private UIView _mainWindow;
 
 		public Popup()
 		{
-			MainWindow = UIApplication.SharedApplication.KeyWindow ?? UIApplication.SharedApplication.Windows[0];
+		}
 
-			PopupPanel = new PopupPanel(this);
+		public UIView MainWindow
+		{
+			get
+			{
+				if (_mainWindow == null)
+				{
+					_mainWindow = UIApplication.SharedApplication.KeyWindow ?? UIApplication.SharedApplication.Windows[0];
 
-			MainWindow.AddSubview(PopupPanel);
+					PopupPanel = new PopupPanel(this);
 
-			UpdateDismissTriggers();
+					MainWindow.AddSubview(PopupPanel);
+
+					UpdateDismissTriggers();
+				}
+
+				return _mainWindow;
+			}
 		}
 
 		partial void OnPopupPanelChanged(DependencyPropertyChangedEventArgs e)

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.netstd.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Drawing;
 using Uno.Disposables;
 using Windows.UI.Xaml.Media;
+using Uno.Logging;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -26,6 +27,11 @@ namespace Windows.UI.Xaml.Controls
 		protected override void OnIsOpenChanged(bool oldIsOpen, bool newIsOpen)
 		{
 			base.OnIsOpenChanged(oldIsOpen, newIsOpen);
+
+			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+			{
+				this.Log().Debug($"Popup.IsOpenChanged({oldIsOpen}, {newIsOpen})");
+			}
 
 			if (newIsOpen)
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBoxView.netstd.cs
@@ -17,7 +17,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			IsMultiline = isMultiline;
 			_textBox = textBox;
-			OnTextChanged(textBox, new TextChangedEventArgs()); // TODO
+			SynchronizeTextBoxText();
 
 			SetStyle(
 				("overflow-x", "visible"),
@@ -40,6 +40,8 @@ namespace Windows.UI.Xaml.Controls
 
 			_textBox.TextChanged += OnTextChanged;
 			HtmlInput += OnInput;
+
+			SynchronizeTextBoxText();
 		}
 
 		protected override void OnUnloaded()
@@ -49,6 +51,9 @@ namespace Windows.UI.Xaml.Controls
 			_textBox.TextChanged -= OnTextChanged;
 			HtmlInput -= OnInput;
 		}
+
+		private void SynchronizeTextBoxText()
+			=> OnTextChanged(_textBox, new TextChangedEventArgs());
 
 		private void OnInput(object sender, EventArgs eventArgs)
 		{

--- a/src/Uno.UI/UI/Xaml/Media/TransformGroup.cs
+++ b/src/Uno.UI/UI/Xaml/Media/TransformGroup.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Windows.UI.Xaml.Markup;
 
 #if XAMARIN_ANDROID
 using Android.Views;
@@ -17,6 +18,7 @@ namespace Windows.UI.Xaml.Media
 	/// TransformGroup :  Based on the WinRT TransformGroup
 	/// https://msdn.microsoft.com/en-us/library/system.windows.media.transformgroup(v=vs.110).aspx
 	/// </summary>
+	[ContentProperty(Name = "Children")]
 	public partial class TransformGroup : Transform
 	{
 

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -7866,4 +7866,371 @@
 		</Setter>
 	</Style>
 
+    <Style TargetType="TextBox" x:Key="AutoSuggestBoxTextBoxStyle">
+        <Setter Property="MinWidth" Value="{ThemeResource TextControlThemeMinWidth}" />
+        <Setter Property="MinHeight" Value="{ThemeResource TextControlThemeMinHeight}" />
+        <Setter Property="Foreground" Value="{ThemeResource TextControlForeground}" />
+        <Setter Property="Background" Value="{ThemeResource TextControlBackground}" />
+        <Setter Property="BorderBrush" Value="{ThemeResource TextControlBorderBrush}" />
+        <Setter Property="SelectionHighlightColor" Value="{ThemeResource TextControlSelectionHighlightColor}" />
+        <Setter Property="BorderThickness" Value="{ThemeResource TextControlBorderThemeThickness}" />
+        <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+        <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
+        <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Auto" />
+        <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto" />
+        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
+        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
+        <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
+        <Setter Property="Padding" Value="{ThemeResource TextControlThemePadding}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TextBox">
+                    <Grid>
+                        <Grid.Resources>
+                            <Style x:Name="DeleteButtonStyle" TargetType="Button">
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="Button">
+                                            <Grid x:Name="ButtonLayoutGrid"
+                                                BorderBrush="{ThemeResource TextControlButtonBorderBrush}"
+                                                BorderThickness="{TemplateBinding BorderThickness}"
+                                                Background="{ThemeResource TextControlButtonBackground}">
+                                                <VisualStateManager.VisualStateGroups>
+                                                    <VisualStateGroup x:Name="CommonStates">
+                                                        <VisualState x:Name="Normal" />
+                                                        <VisualState x:Name="PointerOver">
+                                                            <Storyboard>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="Background">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBackgroundPointerOver}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="BorderBrush">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBorderBrushPointerOver}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="GlyphElement" Storyboard.TargetProperty="Foreground">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonForegroundPointerOver}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                            </Storyboard>
+                                                        </VisualState>
+                                                        <VisualState x:Name="Pressed">
+                                                            <Storyboard>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="Background">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBackgroundPressed}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="BorderBrush">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBorderBrushPressed}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="GlyphElement" Storyboard.TargetProperty="Foreground">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonForegroundPressed}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                            </Storyboard>
+                                                        </VisualState>
+                                                        <VisualState x:Name="Disabled">
+                                                            <Storyboard>
+                                                                <DoubleAnimation Storyboard.TargetName="ButtonLayoutGrid"
+                                                                    Storyboard.TargetProperty="Opacity"
+                                                                    To="0"
+                                                                    Duration="0" />
+                                                            </Storyboard>
+                                                        </VisualState>
+                                                    </VisualStateGroup>
+                                                </VisualStateManager.VisualStateGroups>
+                                                <TextBlock x:Name="GlyphElement"
+                                                    Foreground="{ThemeResource TextControlButtonForeground}"
+                                                    VerticalAlignment="Center"
+                                                    HorizontalAlignment="Center"
+                                                    FontStyle="Normal"
+                                                    FontSize="{ThemeResource AutoSuggestBoxIconFontSize}"
+                                                    Text="&#xE10A;"
+                                                    FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                    AutomationProperties.AccessibilityView="Raw" />
+                                            </Grid>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                            <Style x:Name="QueryButtonStyle" TargetType="Button">
+                                <Setter Property="Template">
+                                    <Setter.Value>
+                                        <ControlTemplate TargetType="Button">
+                                            <Grid x:Name="ButtonLayoutGrid"
+                                                BorderBrush="{ThemeResource TextControlButtonBorderBrush}"
+                                                BorderThickness="{TemplateBinding BorderThickness}"
+                                                Background="{ThemeResource TextControlButtonBackground}">
+                                                <VisualStateManager.VisualStateGroups>
+                                                    <VisualStateGroup x:Name="CommonStates">
+                                                        <VisualState x:Name="Normal" />
+                                                        <VisualState x:Name="PointerOver">
+                                                            <Storyboard>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="Background">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBackgroundPointerOver}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="BorderBrush">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBorderBrushPointerOver}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonForegroundPointerOver}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                            </Storyboard>
+                                                        </VisualState>
+                                                        <VisualState x:Name="Pressed">
+                                                            <Storyboard>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="Background">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBackgroundPressed}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="BorderBrush">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBorderBrushPressed}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonForegroundPressed}" />
+                                                                </ObjectAnimationUsingKeyFrames>
+                                                            </Storyboard>
+                                                        </VisualState>
+                                                        <VisualState x:Name="Disabled">
+                                                            <Storyboard>
+                                                                <DoubleAnimation Storyboard.TargetName="ButtonLayoutGrid"
+                                                                    Storyboard.TargetProperty="Opacity"
+                                                                    To="0"
+                                                                    Duration="0" />
+                                                            </Storyboard>
+                                                        </VisualState>
+                                                    </VisualStateGroup>
+                                                </VisualStateManager.VisualStateGroups>
+                                                <ContentPresenter x:Name="ContentPresenter"
+                                                    Content="{TemplateBinding Content}"
+                                                    ContentTransitions="{TemplateBinding ContentTransitions}"
+                                                    ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                    Margin="{TemplateBinding Padding}"
+                                                    FontSize="{ThemeResource AutoSuggestBoxIconFontSize}"
+                                                    HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                    VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                    AutomationProperties.AccessibilityView="Raw" />
+                                            </Grid>
+                                        </ControlTemplate>
+                                    </Setter.Value>
+                                </Setter>
+                            </Style>
+                        </Grid.Resources>
+
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+
+                                <VisualState x:Name="Disabled">
+
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlHeaderForegroundDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBackgroundDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderBrushDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlPlaceholderForegroundDisabled}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Normal" />
+
+                                <VisualState x:Name="PointerOver">
+
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderBrushPointerOver}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBackgroundPointerOver}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlPlaceholderForegroundPointerOver}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundPointerOver}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Focused">
+
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlPlaceholderForegroundFocused}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBackgroundFocused}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderBrush">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderBrushFocused}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundFocused}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="RequestedTheme">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Light" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="QueryButton" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonForeground}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="ButtonStates">
+                                <VisualState x:Name="ButtonVisible">
+
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DeleteButton" Storyboard.TargetProperty="Visibility">
+                                            <DiscreteObjectKeyFrame KeyTime="0">
+                                                <DiscreteObjectKeyFrame.Value>
+                                                    <Visibility>Visible</Visibility>
+                                                </DiscreteObjectKeyFrame.Value>
+                                            </DiscreteObjectKeyFrame>
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="ButtonCollapsed" />
+                            </VisualStateGroup>
+
+                        </VisualStateManager.VisualStateGroups>
+
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Border x:Name="BorderElement"
+                            Grid.Row="1"
+                            Background="{TemplateBinding Background}"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            Grid.ColumnSpan="3"
+                            Grid.RowSpan="1" />
+                        <ContentPresenter x:Name="HeaderContentPresenter"
+                            x:DeferLoadStrategy="Lazy"
+                            Visibility="Collapsed"
+                            Grid.Row="0"
+                            Foreground="{ThemeResource TextControlHeaderForeground}"
+                            Margin="0,0,0,8"
+                            Grid.ColumnSpan="3"
+                            Content="{TemplateBinding Header}"
+                            ContentTemplate="{TemplateBinding HeaderTemplate}"
+                            FontWeight="Normal"
+                            TextWrapping="Wrap" />
+                        <ScrollViewer x:Name="ContentElement"
+                            Grid.Row="1"
+                            HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+                            HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+                            VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+                            VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+                            IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+                            IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+                            IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+                            Margin="{TemplateBinding BorderThickness}"
+                            Padding="{TemplateBinding Padding}"
+                            IsTabStop="False"
+                            AutomationProperties.AccessibilityView="Raw"
+                            ZoomMode="Disabled" />
+                        <ContentControl x:Name="PlaceholderTextContentPresenter"
+                            Grid.Row="1"
+                            Foreground="{ThemeResource TextControlPlaceholderForeground}"
+                            Margin="{TemplateBinding BorderThickness}"
+                            Padding="{TemplateBinding Padding}"
+                            IsTabStop="False"
+                            Grid.ColumnSpan="3"
+                            Content="{TemplateBinding PlaceholderText}"
+                            IsHitTestVisible="False" />
+                        <Button x:Name="DeleteButton"
+                            Grid.Row="1"
+                            Style="{StaticResource DeleteButtonStyle}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            IsTabStop="False"
+                            Grid.Column="1"
+                            Visibility="Collapsed"
+                            FontSize="{TemplateBinding FontSize}"
+                            MinWidth="34"
+                            AutomationProperties.AccessibilityView="Raw"
+                            VerticalAlignment="Stretch" />
+                        <Button x:Name="QueryButton"
+                            Grid.Row="1"
+                            Style="{StaticResource QueryButtonStyle}"
+                            BorderThickness="{TemplateBinding BorderThickness}"
+                            IsTabStop="False"
+                            Grid.Column="2"
+                            FontSize="{TemplateBinding FontSize}"
+                            MinWidth="34"
+                            Width="{TemplateBinding Height}"
+                            VerticalAlignment="Stretch"
+                            AutomationProperties.AccessibilityView="Raw"/>
+                    
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+    
+    <!-- Default Style for AutoSuggestBox -->
+    <Style TargetType="AutoSuggestBox">
+        <Setter Property="VerticalAlignment" Value="Top" />
+        <Setter Property="IsTabStop" Value="False" />
+        <Setter Property="TextBoxStyle" Value="{StaticResource AutoSuggestBoxTextBoxStyle}" />
+        <Setter Property="UseSystemFocusVisuals" Value="{ThemeResource IsApplicationFocusVisualKindReveal}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="AutoSuggestBox">
+                    <Grid x:Name="LayoutRoot">
+
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="Orientation">
+                                <VisualState x:Name="Landscape" />
+                                <VisualState x:Name="Portrait" />
+                            </VisualStateGroup>
+
+                        </VisualStateManager.VisualStateGroups>
+                        <TextBox x:Name="TextBox"
+                            Style="{TemplateBinding TextBoxStyle}"
+                            PlaceholderText="{TemplateBinding PlaceholderText}"
+                            Header="{TemplateBinding Header}"
+                            Width="{TemplateBinding Width}"
+                            ScrollViewer.BringIntoViewOnFocusChange="False"
+                            Canvas.ZIndex="0"
+                            Margin="0"
+                            DesiredCandidateWindowAlignment="BottomEdge"
+                            UseSystemFocusVisuals="{TemplateBinding UseSystemFocusVisuals}"/>
+                        <Popup x:Name="SuggestionsPopup">
+                            <Border x:Name="SuggestionsContainer">
+                                <Border.RenderTransform>
+                                    <TranslateTransform x:Name="UpwardTransform" />
+                                </Border.RenderTransform>
+                                <ListView x:Name="SuggestionsList"
+                                    Background="{ThemeResource AutoSuggestBoxSuggestionsListBackground}"
+                                    BorderThickness="{ThemeResource AutoSuggestListBorderThemeThickness}"
+                                    BorderBrush="{ThemeResource AutoSuggestBoxSuggestionsListBorderBrush}"
+                                    DisplayMemberPath="{TemplateBinding DisplayMemberPath}"
+                                    IsItemClickEnabled="True"
+                                    ItemTemplate="{TemplateBinding ItemTemplate}"
+                                    ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+                                    ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
+                                    MaxHeight="{ThemeResource AutoSuggestListMaxHeight}"
+                                    Margin="{ThemeResource AutoSuggestListMargin}"
+                                    Padding="{ThemeResource AutoSuggestListPadding}">
+                                    <ListView.ItemContainerTransitions>
+                                        <TransitionCollection />
+                                    </ListView.ItemContainerTransitions>
+                                </ListView>
+                            </Border>
+                        </Popup>
+                    
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+	
 </ResourceDictionary>

--- a/src/Uno.UI/UI/Xaml/Style/Generic/SystemResources.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/SystemResources.xaml
@@ -242,6 +242,7 @@
 	<FontWeight x:Key="HubHeaderThemeFontWeight">Light</FontWeight>
 	<FontWeight x:Key="HubSectionHeaderThemeFontWeight">Normal</FontWeight>
 	<GridLength x:Key="AppBarExpandButtonThemeWidthGridLength">48</GridLength>
+	<x:Boolean x:Key="IsApplicationFocusVisualKindReveal">False</x:Boolean>
 
 
 	<!--
@@ -559,6 +560,10 @@
     <SolidColorBrush x:Key="MenuFlyoutItemPressedForegroundThemeBrush" Color="#FFFFFFFF" />
     <SolidColorBrush x:Key="MenuFlyoutSeparatorThemeBrush" Color="#FF7A7A7A" />
 	
+	<!-- Resources for AutoSuggestBox -->
+    <SolidColorBrush x:Key="AutoSuggestBoxSuggestionsListBackground" Color="{StaticResource SystemChromeMediumLowColor}" />
+    <SolidColorBrush x:Key="AutoSuggestBoxSuggestionsListBorderBrush" Color="{StaticResource SystemChromeHighColor}" />
+
     <!-- Resources for Windows.UI.Xaml.Controls.Pivot -->
     <SolidColorBrush x:Key="PivotBackground" Color="Transparent" />
     <SolidColorBrush x:Key="PivotHeaderBackground" Color="Transparent" />

--- a/src/Uno.UI/UI/Xaml/Style/Generic/SystemResources.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/SystemResources.xaml
@@ -359,6 +359,7 @@
     <SolidColorBrush x:Key="SystemControlPageTextBaseHighBrush" Color="{StaticResource SystemBaseHighColor}"/>
     <SolidColorBrush x:Key="SystemControlPageTextBaseMediumBrush" Color="{StaticResource SystemBaseMediumColor}"/>
     <SolidColorBrush x:Key="SystemControlPageTextChromeBlackMediumLowBrush" Color="{StaticResource SystemChromeBlackMediumLowColor}"/>
+	<SolidColorBrush x:Key="SystemControlBackgroundAltMediumBrush" Color="{StaticResource SystemAltMediumColor}" />
 
     <!-- Legacy brushes -->
     <SolidColorBrush x:Key="AppBarBackgroundThemeBrush" Color="#FFF0F0F0" />
@@ -776,5 +777,46 @@
     <SolidColorBrush x:Key="ToolTipBackgroundThemeBrush" Color="#FFFFFFFF" />
     <SolidColorBrush x:Key="ToolTipBorderThemeBrush" Color="#FF808080" />
     <SolidColorBrush x:Key="ToolTipForegroundThemeBrush" Color="#FF666666" />
+
+
+	    <!--
+        Resources for:
+                
+        Windows.UI.Xaml.Controls.TextBox
+        Windows.UI.Xaml.Controls.PasswordBox
+        Windows.UI.Xaml.Controls.RichEditBox
+        AutoSuggestTextBoxStyle
+    -->
+    <SolidColorBrush x:Key="TextControlForeground"  Color="{StaticResource SystemBaseHighColor}" />
+    <SolidColorBrush x:Key="TextControlForegroundPointerOver"  Color="{StaticResource SystemBaseHighColor}" />
+    <SolidColorBrush x:Key="TextControlForegroundFocused" Color="{StaticResource SystemChromeBlackHighColor}" />
+    <SolidColorBrush x:Key="TextControlForegroundDisabled" Color="{StaticResource SystemChromeDisabledLowColor}" />
+    <SolidColorBrush x:Key="TextControlBackground" Color="{StaticResource SystemAltMediumLowColor}" />
+    <SolidColorBrush x:Key="TextControlBackgroundPointerOver" Color="{StaticResource SystemAltMediumColor}" />
+    <SolidColorBrush x:Key="TextControlBackgroundFocused" Color="{StaticResource SystemChromeWhiteColor}" />
+    <SolidColorBrush x:Key="TextControlBackgroundDisabled" Color="{StaticResource SystemBaseLowColor}" />
+    <SolidColorBrush x:Key="TextControlBorderBrush" Color="{StaticResource SystemBaseMediumLowColor}" />
+    <SolidColorBrush x:Key="TextControlBorderBrushPointerOver" Color="{StaticResource SystemBaseMediumColor}"/>
+    <SolidColorBrush x:Key="TextControlBorderBrushFocused" Color="{ThemeResource SystemAccentColor}" />
+    <SolidColorBrush x:Key="TextControlBorderBrushDisabled" Color="{StaticResource SystemBaseLowColor}" />
+    <SolidColorBrush x:Key="TextControlPlaceholderForeground" Color="{StaticResource SystemBaseMediumColor}" />
+    <SolidColorBrush x:Key="TextControlPlaceholderForegroundPointerOver" Color="{StaticResource SystemBaseMediumColor}" />
+    <SolidColorBrush x:Key="TextControlPlaceholderForegroundFocused" Color="{StaticResource SystemChromeBlackMediumLowColor}" />
+    <SolidColorBrush x:Key="TextControlPlaceholderForegroundDisabled" Color="{StaticResource SystemChromeDisabledLowColor}" />
+    <SolidColorBrush x:Key="TextControlHeaderForeground"  Color="{StaticResource SystemBaseHighColor}" />
+    <SolidColorBrush x:Key="TextControlHeaderForegroundDisabled" Color="{StaticResource SystemBaseMediumLowColor}" />
+    <SolidColorBrush x:Key="TextControlSelectionHighlightColor" Color="{ThemeResource SystemAccentColor}" />
+    <SolidColorBrush x:Key="TextControlButtonBackground" Color="Transparent"  />
+    <SolidColorBrush x:Key="TextControlButtonBackgroundPointerOver" Color="Transparent" />
+    <SolidColorBrush x:Key="TextControlButtonBackgroundPressed" Color="{ThemeResource SystemAccentColor}" />
+    <SolidColorBrush x:Key="TextControlButtonBorderBrush" Color="Transparent" />
+    <SolidColorBrush x:Key="TextControlButtonBorderBrushPointerOver" Color="Transparent" />
+    <SolidColorBrush x:Key="TextControlButtonBorderBrushPressed" Color="Transparent" />
+    <SolidColorBrush x:Key="TextControlButtonForeground" Color="{StaticResource SystemChromeBlackMediumColor}" />
+    <SolidColorBrush x:Key="TextControlButtonForegroundPointerOver" Color="{ThemeResource SystemAccentColor}" />
+    <SolidColorBrush x:Key="TextControlButtonForegroundPressed" Color="{StaticResource SystemChromeWhiteColor}" />
+    <SolidColorBrush x:Key="ContentLinkForegroundColor" Color="{ThemeResource SystemAccentColor}" />
+    <SolidColorBrush x:Key="ContentLinkBackgroundColor" Color="{StaticResource SystemChromeAltLowColor}" />
+
 
 </ResourceDictionary>

--- a/src/Uno.UI/UI/Xaml/Window.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Window.wasm.cs
@@ -177,11 +177,24 @@ namespace Windows.UI.Xaml
 
 		internal IDisposable OpenPopup(Popup popup)
 		{
+			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+			{
+				this.Log().Debug($"Creating popup");
+			}
+			
 			var popupChild = popup.Child;
 			_popupRoot.Children.Add(popupChild);
 
 			return new CompositeDisposable(
-				Disposable.Create(() => _popupRoot.Children.Remove(popupChild)),
+				Disposable.Create(() => {
+
+					if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+					{
+						this.Log().Debug($"Closing popup");
+					}
+
+					_popupRoot.Children.Remove(popupChild);
+				}),
 				VisualTreeHelper.RegisterOpenPopup(popup)
 			);
 		}

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Threading/ThreadPoolTimer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Threading/ThreadPoolTimer.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.System.Threading
 {
-	#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#if false
 	[global::Uno.NotImplemented]
-	#endif
-	public  partial class ThreadPoolTimer 
+#endif
+	public partial class ThreadPoolTimer 
 	{
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#if false
 		[global::Uno.NotImplemented]
 		public  global::System.TimeSpan Delay
 		{
@@ -16,8 +16,8 @@ namespace Windows.System.Threading
 				throw new global::System.NotImplementedException("The member TimeSpan ThreadPoolTimer.Delay is not implemented in Uno.");
 			}
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public  global::System.TimeSpan Period
 		{
@@ -26,43 +26,43 @@ namespace Windows.System.Threading
 				throw new global::System.NotImplementedException("The member TimeSpan ThreadPoolTimer.Period is not implemented in Uno.");
 			}
 		}
-		#endif
+#endif
 		// Forced skipping of method Windows.System.Threading.ThreadPoolTimer.Period.get
 		// Forced skipping of method Windows.System.Threading.ThreadPoolTimer.Delay.get
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#if false
 		[global::Uno.NotImplemented]
 		public  void Cancel()
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.System.Threading.ThreadPoolTimer", "void ThreadPoolTimer.Cancel()");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.System.Threading.ThreadPoolTimer CreatePeriodicTimer( global::Windows.System.Threading.TimerElapsedHandler handler,  global::System.TimeSpan period)
 		{
 			throw new global::System.NotImplementedException("The member ThreadPoolTimer ThreadPoolTimer.CreatePeriodicTimer(TimerElapsedHandler handler, TimeSpan period) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.System.Threading.ThreadPoolTimer CreateTimer( global::Windows.System.Threading.TimerElapsedHandler handler,  global::System.TimeSpan delay)
 		{
 			throw new global::System.NotImplementedException("The member ThreadPoolTimer ThreadPoolTimer.CreateTimer(TimerElapsedHandler handler, TimeSpan delay) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.System.Threading.ThreadPoolTimer CreatePeriodicTimer( global::Windows.System.Threading.TimerElapsedHandler handler,  global::System.TimeSpan period,  global::Windows.System.Threading.TimerDestroyedHandler destroyed)
 		{
 			throw new global::System.NotImplementedException("The member ThreadPoolTimer ThreadPoolTimer.CreatePeriodicTimer(TimerElapsedHandler handler, TimeSpan period, TimerDestroyedHandler destroyed) is not implemented in Uno.");
 		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+#endif
+#if false
 		[global::Uno.NotImplemented]
 		public static global::Windows.System.Threading.ThreadPoolTimer CreateTimer( global::Windows.System.Threading.TimerElapsedHandler handler,  global::System.TimeSpan delay,  global::Windows.System.Threading.TimerDestroyedHandler destroyed)
 		{
 			throw new global::System.NotImplementedException("The member ThreadPoolTimer ThreadPoolTimer.CreateTimer(TimerElapsedHandler handler, TimeSpan delay, TimerDestroyedHandler destroyed) is not implemented in Uno.");
 		}
-		#endif
+#endif
 	}
 }

--- a/src/Uno.UWP/System.Threading/ThreadPoolTimer.cs
+++ b/src/Uno.UWP/System.Threading/ThreadPoolTimer.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Threading;
+
+namespace Windows.System.Threading
+{
+	public partial class ThreadPoolTimer
+	{
+		private readonly Timer _timer;
+		private readonly TimerDestroyedHandler _destroyed;
+		private CancellationTokenSource _cts = new CancellationTokenSource();
+
+		public TimeSpan Delay { get; }
+
+		public TimeSpan Period { get; }
+
+		public void Cancel()
+		{
+			_cts.Cancel();
+			_timer.Dispose();
+			_destroyed?.Invoke(this);
+		}
+
+		internal ThreadPoolTimer(TimerElapsedHandler handler, TimeSpan? period = null, TimeSpan? delay = null, TimerDestroyedHandler destroyed = null)
+		{
+			_timer = new Timer(_ =>
+			{
+				if (!_cts.IsCancellationRequested)
+				{
+					handler.Invoke(this);
+				}
+			});
+
+			_destroyed = destroyed;
+
+			_timer.Change(
+				period: period ?? global::System.Threading.Timeout.InfiniteTimeSpan,
+				dueTime: delay ?? global::System.Threading.Timeout.InfiniteTimeSpan
+			);
+		}
+
+		public static ThreadPoolTimer CreatePeriodicTimer(TimerElapsedHandler handler, TimeSpan period)
+			=> new ThreadPoolTimer(handler, period: period);
+
+		public static ThreadPoolTimer CreateTimer(TimerElapsedHandler handler, TimeSpan delay)
+			=> new ThreadPoolTimer(handler, delay: delay);
+
+		public static ThreadPoolTimer CreatePeriodicTimer(TimerElapsedHandler handler, TimeSpan period, TimerDestroyedHandler destroyed)
+			=> new ThreadPoolTimer(handler, period: period, destroyed: destroyed);
+
+		public static ThreadPoolTimer CreateTimer(TimerElapsedHandler handler, TimeSpan delay, TimerDestroyedHandler destroyed)
+			=> new ThreadPoolTimer(handler, delay: delay, destroyed: destroyed);
+	}
+}


### PR DESCRIPTION
- Added missing `TransformGroup` `ContentProperty`
- Fixed invalid namespace attribution of attached properties in `XamlReader`
- Fixed `BitmapImage.UriSource` udpates not being applied on Wasm
- Add basic implementation of `AutoSuggestBox`
- Fixed focus stealing issues with inactive `PivotItem` content
- Add `ThreadPoolTimer` support
- Fix for iOS popup not appearing
- Fix for Wasm textbox not properly updating while not loaded