### PR TITLE
Misc binding engine alignments

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
 	<NoWarn>$(NoWarn);1998</NoWarn>
-	<DebugType>full</DebugType>
+	<DebugType>portable</DebugType>
 	<DebugSymbols>True</DebugSymbols>
 	<RepositoryUrl>$(BUILD_REPOSITORY_URI)</RepositoryUrl>
 	<Copyright>nventive</Copyright>

--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
@@ -609,7 +609,8 @@ namespace Uno.UI.Tests.BinderTests
 
 			SUT.SetBinding(
 				Windows.UI.Xaml.Controls.Grid.TagProperty,
-				new Binding() {
+				new Binding()
+				{
 					Path = "MyProperty",
 					CompiledSource = source
 				}
@@ -618,6 +619,25 @@ namespace Uno.UI.Tests.BinderTests
 			SUT.ApplyCompiledBindings();
 
 			Assert.AreEqual(42, SUT.Tag);
+		}
+
+		[TestMethod]
+		public void When_PrivateProperty_And_Binding()
+		{
+			var source = new PrivateProperty(42);
+			var SUT = new Windows.UI.Xaml.Controls.Grid();
+
+			SUT.SetBinding(
+				Windows.UI.Xaml.Controls.Grid.TagProperty,
+				new Binding()
+				{
+					Path = "MyProperty"
+				}
+			);
+
+			SUT.DataContext = source;
+
+			Assert.IsNull(SUT.Tag);
 		}
 
 		public partial class BaseTarget : DependencyObject

--- a/src/Uno.UI/DataBinding/BindingExpression.cs
+++ b/src/Uno.UI/DataBinding/BindingExpression.cs
@@ -271,7 +271,12 @@ namespace Windows.UI.Xaml.Data
 
 			_targetOwnerType = targetPropertyDetails.Property.OwnerType;
 			TargetPropertyDetails = targetPropertyDetails;
-			_bindingPath = new BindingPath(path: ParentBinding.Path, fallbackValue: ParentBinding.FallbackValue);
+			_bindingPath = new BindingPath(
+				path: ParentBinding.Path,
+				fallbackValue: ParentBinding.FallbackValue,
+				precedence: null,
+				allowPrivateMembers: ParentBinding.CompiledSource != null
+			);
 			_boundPropertyType = targetPropertyDetails.Property.Type;
 
 			ExplicitSource = binding.Source;

--- a/src/Uno.UI/UI/Xaml/DependencyProperty.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyProperty.cs
@@ -43,6 +43,7 @@ namespace Windows.UI.Xaml
 		private readonly bool _isTypeNullable;
 		private readonly int _uniqueId;
 		private readonly bool _hasAutoDataContextInherit;
+		private readonly bool _isDependencyObjectCollection;
 		private readonly bool _hasWeakStorage;
 		private object _fallbackDefaultValue;
 
@@ -55,6 +56,7 @@ namespace Windows.UI.Xaml
 			_ownerType = attached || IsTypeDependencyObject(ownerType) ? ownerType : typeof(_View);
 			_isAttached = attached;
 			_hasAutoDataContextInherit = CanAutoInheritDataContext(propertyType);
+			_isDependencyObjectCollection = typeof(DependencyObjectCollection).IsAssignableFrom(propertyType);
 			_isTypeNullable = propertyType.IsNullableCached();
 			_uniqueId = Interlocked.Increment(ref _globalId);
 			_hasWeakStorage = (defaultMetadata as FrameworkPropertyMetadata)?.Options.HasWeakStorage() ?? false;
@@ -87,6 +89,11 @@ namespace Windows.UI.Xaml
 		/// Determines if the property storage should be backed by a <see cref="Uno.UI.DataBinding.ManagedWeakReference"/>
 		/// </summary>
 		internal bool HasWeakStorage => _hasWeakStorage;
+
+		/// <summary>
+		/// Determines if the property type inherits from <see cref="DependencyObjectCollection"/>
+		/// </summary>
+		internal bool IsDependencyObjectCollection => _isDependencyObjectCollection;
 
 		/// <summary>
 		/// Registers a dependency property on the specified <paramref name="ownerType"/>.

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Timeline.cs
@@ -147,7 +147,13 @@ namespace Windows.UI.Xaml.Media.Animation
 				{
 					var target = Target ?? GetTargetFromName();
 
-					_propertyInfo = new BindingPath(path: Storyboard.GetTargetProperty(this), fallbackValue: null, precedence: DependencyPropertyValuePrecedences.Animations);
+					_propertyInfo = new BindingPath(
+						path: Storyboard.GetTargetProperty(this),
+						fallbackValue: null,
+						precedence: DependencyPropertyValuePrecedences.Animations,
+						allowPrivateMembers: false
+					);
+
 					_propertyInfo.DataContext = target;
 				}
 

--- a/src/Uno.UI/UI/Xaml/Setter.cs
+++ b/src/Uno.UI/UI/Xaml/Setter.cs
@@ -136,7 +136,7 @@ namespace Windows.UI.Xaml
 
 		private void BuildBindingPath(DependencyPropertyValuePrecedences precedence)
 		{
-			_bindingPath = new BindingPath(path: Target.Path, fallbackValue: null, precedence: precedence);
+			_bindingPath = new BindingPath(path: Target.Path, fallbackValue: null, precedence: precedence, allowPrivateMembers: false);
 			_bindingPath.DataContext = Target.Target;
 		}
 


### PR DESCRIPTION
- Use Portable symbols for Xamarin debugging stability
- Enable x:Name reference in x:Bind markup. This requires for a failed BindableMetadata lookup to fall through reflection lookup.
- Assume ".Value" binding path on a primitive is equivalent to self, to enable nullable bindings.
- Adjust unit tests logging
- Enables auto "LogicalChild" treatment to allow for DependencyObjectCollection members to be databound
- Enable parent reset for "LogicalChild" assignations