### PR TITLE
The <Error> task were not correctly initialized

### DIFF
--- a/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
+++ b/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
@@ -94,7 +94,7 @@
 			<_CompileCommand>"$(_JavaSdkDirectory)bin\javac.exe" -g -source $(_javaVersion) -d .\$(IntermediateOutputPath)\unoclasses -target $(_javaVersion) -J-Dfile.encoding=UTF8 -classpath "@(_AndroidJar)" -bootclasspath "$(_AndroidSdkDirectory)platforms\android-$(_AndroidApiLevel)\android.jar" -encoding UTF-8 .\Uno\UI\*.java</_CompileCommand>
 		</PropertyGroup>
 		
-		<Error Message="The Android SDK for API level $(_AndroidApiLevel) is not installed. Install it through the Android SDK manager." Condition="!Exists('$(_AndroidSdkDirectory)platforms\android-$(_AndroidApiLevel)\android.jar')" />
+		<Error Text="The Android SDK for API level $(_AndroidApiLevel) is not installed. Install it through the Android SDK manager." Condition="!Exists('$(_AndroidSdkDirectory)platforms\android-$(_AndroidApiLevel)\android.jar')" />
 		
 		<Message Text="Compiling java ($(_CurrentSupportV4) for $(TargetFramework)): $(_CompileCommand)" Importance="high" />
 


### PR DESCRIPTION
... resulting with an unrelated error message.