### PR TITLE
Fixed android output paths

### DIFF
--- a/src/SourceGenerators/System.Xaml/Uno.Xaml.csproj
+++ b/src/SourceGenerators/System.Xaml/Uno.Xaml.csproj
@@ -8,6 +8,9 @@
 		<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
 		<ProduceReferenceAssembly>true</ProduceReferenceAssembly>
 		<Deterministic>true</Deterministic>
+		<OutputPath>bin\$(Configuration)\$(TargetFramework)\</OutputPath>
+		<IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
+		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Uno.CrossTargetting.props
+++ b/src/Uno.CrossTargetting.props
@@ -55,6 +55,8 @@
 	<DefineConstants>$(DefineConstants);XAMARIN;XAMARIN_ANDROID</DefineConstants>
 	<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
 	<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
+	<OutputPath>bin\$(Configuration)\$(TargetFramework)\</OutputPath>
+	<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">

--- a/src/Uno.CrossTargetting.props
+++ b/src/Uno.CrossTargetting.props
@@ -56,7 +56,7 @@
 	<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
 	<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
 	<OutputPath>bin\$(Configuration)\$(TargetFramework)\</OutputPath>
-	<IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\</IntermediateOutputPath
+	<IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\</IntermediateOutputPath>
 	<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 

--- a/src/Uno.CrossTargetting.props
+++ b/src/Uno.CrossTargetting.props
@@ -56,6 +56,7 @@
 	<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
 	<AndroidResgenFile>obj\$(TargetFramework)\Resources\Resource.Designer.cs</AndroidResgenFile>
 	<OutputPath>bin\$(Configuration)\$(TargetFramework)\</OutputPath>
+	<IntermediateOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\$(TargetFramework)\</IntermediateOutputPath
 	<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
 


### PR DESCRIPTION
It seems that both Xamarin.Android and .Net targets want to add the TargetFramework at the end of the output path when AppendTargetFrameworkToOutputPath is true, resulting in the NuGet pack not working as intending