### PR TITLE
Improve support for resources

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlCodeGeneration.cs
@@ -76,7 +76,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				.ToArray();
 
 			_resourceFiles = msbProject
-				.GetItems("XamlCodeGenerationResourceFiles")
+				.GetItems("PRIResource")
 				.Select(i => i.EvaluatedInclude)
 				.ToArray();
 
@@ -295,6 +295,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							.Select(node => node.GetAttribute("name"))
 							.ToArray()
 						)
+						.Distinct()
 						.ToArray();
 				}
 			}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -2435,7 +2435,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
                 var fullKey = objectUid + "." + memberName;
                 if (_resourceKeys.Any(k => k == fullKey))
                 {
-                    return @"ResourceHelper.FindResourceString(""" + fullKey + @""")";
+                    return @"global::Windows.ApplicationModel.Resources.ResourceLoader.GetForCurrentView().GetString(""" + fullKey + @""")";
                 }
             }
 

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -15,7 +15,7 @@
 	<Target Name="ResourcesGeneration"
 					BeforeTargets="PrepareForBuild;_CheckForContent"
 					DependsOnTargets="AssignLinkMetadata"
-					Condition="'$(ResourcesDirectory)'!='' and '$(BuildingInsideUnoSourceGenerator)' == ''">
+					Condition="'$(BuildingInsideUnoSourceGenerator)' == ''">
 		<!-- String resources -->
 		<PropertyGroup>
 			<!-- LEGACY: Old projects define DefaultApplicationLanguage instead of DefaultLanguage -->
@@ -23,7 +23,7 @@
 			<!-- Default to English if DefaultLanguage isn't set -->
 			<DefaultLanguage Condition="'$(DefaultLanguage)'==''">en</DefaultLanguage>			
 		</PropertyGroup>
-		<ResourcesGenerationTask ResourcesDirectory="$(ResourcesDirectory)"
+		<ResourcesGenerationTask Resources="@(PRIResource)"
 														 TargetProjectDirectory="$(ProjectDir)"
 														 TargetPlatform="$(XamarinProjectType)"
 														 IntermediateOutputPath="$(IntermediateOutputPath)"

--- a/src/Uno.UI/UI/Xaml/Application.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Application.iOS.cs
@@ -9,6 +9,7 @@ using Windows.UI.Xaml.Controls.Primitives;
 using Windows.ApplicationModel;
 using ObjCRuntime;
 using Windows.Graphics.Display;
+using Uno.UI.Services;
 
 namespace Windows.UI.Xaml
 {
@@ -22,6 +23,7 @@ namespace Windows.UI.Xaml
 		{
 			Current = this;
 			Windows.UI.Xaml.GenericStyles.Initialize();
+			ResourceHelper.ResourcesService = new ResourcesService(new[] { NSBundle.MainBundle });
 		}
 
 		public Application(IntPtr handle) : base(handle)

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/UnoWKWebView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/UnoWKWebView.iOS.cs
@@ -16,6 +16,7 @@ using System.Linq;
 using UIKit;
 using Uno.UI.Services;
 using Microsoft.Extensions.Logging;
+using Windows.ApplicationModel.Resources;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -31,9 +32,9 @@ namespace Windows.UI.Xaml.Controls
 
 		public UnoWKWebView() : base(CGRect.Empty, new WebKit.WKWebViewConfiguration())
 		{
-			ResourceHelper.ResourcesService = new ResourcesService(new[] { NSBundle.MainBundle });
-			var ok = ResourceHelper.FindResourceString(OkResourceKey);
-			var cancel = ResourceHelper.FindResourceString(CancelResourceKey);
+			var resourceLoader = ResourceLoader.GetForCurrentView();
+			var ok = resourceLoader.GetString("OkResourceKey");
+			var cancel = resourceLoader.GetString("CancelResourceKey");
 
 			if (NSLocale.CurrentLocale.LanguageCode == "en")
 			{

--- a/src/Uno.UI/UI/Xaml/NativeApplication.cs
+++ b/src/Uno.UI/UI/Xaml/NativeApplication.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using Android.App;
 using Java.Interop;
+using Uno.UI.Services;
 using Windows.ApplicationModel.Activation;
 
 namespace Windows.UI.Xaml
@@ -16,6 +17,7 @@ namespace Windows.UI.Xaml
 			: base(javaReference, transfer)
 		{
 			_app = app;
+			ResourceHelper.ResourcesService = new ResourcesService(this);
 		}
 
 		public override void OnCreate()

--- a/src/Uno.UI/UI/Xaml/ResourceHelper.cs
+++ b/src/Uno.UI/UI/Xaml/ResourceHelper.cs
@@ -6,11 +6,17 @@ using Uno.Logging;
 using Uno.UI.Converters;
 using Windows.UI.Xaml.Data;
 using Uno.UI;
+using Windows.ApplicationModel.Resources;
 
 namespace Windows.UI.Xaml
 {
     public static class ResourceHelper
     {
+		static ResourceHelper()
+		{
+			ResourceLoader.GetStringInternal = key => ResourcesService.Get(key);
+		}
+
 		/// <summary>
 		/// Provides a global registry, similar to the Application.Current.Resources in WinRT.
 		/// </summary>

--- a/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/ResourceLoader.cs
@@ -16,7 +16,12 @@ namespace Windows.ApplicationModel.Resources
 
 		public string GetString(string resource)
 		{
-			throw new NotImplementedException(); // ResourceHelper.FindResourceString(resource);
+			if (GetStringInternal == null)
+			{
+				throw new InvalidOperationException($"ResourceLoader.GetStringInternal hasn't been set. Make sure ResourceHelper is initialized properly.");
+			}
+
+			return GetStringInternal.Invoke(resource);
 		}
 
 		public string GetStringForUri(Uri uri) { throw new NotSupportedException(); }
@@ -30,5 +35,8 @@ namespace Windows.ApplicationModel.Resources
 		public static ResourceLoader GetForViewIndependentUse(string name) => _loader;
 
 		public static string GetStringForReference(Uri uri) { throw new NotSupportedException(); }
+
+		// TODO: Remove this property when getting rid of ResourceHelper
+		public static Func<string, string> GetStringInternal { get; set; }
 	}
 }


### PR DESCRIPTION
- Projects no longer need to define `XamlCodeGenerationFiles` (fixes #144)
- Projects no longer need to define `ResourcesDirectory` (fixes #106)
- Projects no longer need to initialize `ResourceHelper.ResourcesService` (fixes #142)
- `ResourceLoader.GetString` is now supported (fixes #142)