### PR TITLE
Fix invalid ResourceGenerationTask use in libraries

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -15,7 +15,7 @@
 	<Target Name="ResourcesGeneration"
 					BeforeTargets="PrepareForBuild;_CheckForContent"
 					DependsOnTargets="AssignLinkMetadata"
-					Condition="'$(BuildingInsideUnoSourceGenerator)' == ''">
+					Condition="'$(BuildingInsideUnoSourceGenerator)' == '' and '$(XamarinProjectType)'!=''">
 		<!-- String resources -->
 		<PropertyGroup>
 			<!-- LEGACY: Old projects define DefaultApplicationLanguage instead of DefaultLanguage -->


### PR DESCRIPTION
Fixes ""ResourcesGenerationTask" task was not given a value for the required parameter TargetPlatform" when building cross-targeted libraries.