### PR TITLE
Fix not updated bounds

### DIFF
--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
@@ -150,6 +150,7 @@ namespace Windows.UI.Xaml
 
 				_layouter.Arrange(new Rect(0, 0, newSize.Width, newSize.Height));
 
+				OnLayoutUpdated();
 				OnAfterArrange();
 			}
 


### PR DESCRIPTION
Call OnLayoutUpdated from FrameworkElement.Android to reconsider calculations if there is more than one PaddingMask applied

Related issue on VSTS : https://nventive.visualstudio.com/Umbrella/_workitems/edit/131310