### PR TITLE
Fix inline collection declaration

### DIFF
--- a/src/SourceGenerators/XamlGenerationTests/CollectionsTests.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/CollectionsTests.xaml
@@ -1,0 +1,26 @@
+﻿<UserControl
+    x:Class="XamlGeneration.CollectionsTests"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uConv="using:Uno.UI.Converters"
+    xmlns:xamlExpanded="using:Windows.Xaml.UI"
+  	xmlns:ios="http://uno.ui/ios"
+    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	xmlns:uloc="http://uno.ui/localization/1.0"
+    xmlns:local="using:XamlGenerationTests"
+	mc:Ignorable="d uloc android ios xamarin"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<!-- Assign a collection in the ConetntProperty of the control + set a property on the collection and add an item -->
+	<local:CollectionsTest_Control>
+		<local:CollectionsTest_Collection
+			MyProperty="421">
+			<local:CollectionsTest_Item />
+		</local:CollectionsTest_Collection>
+	</local:CollectionsTest_Control>
+</UserControl>

--- a/src/SourceGenerators/XamlGenerationTests/CollectionsTestsSubjects.cs
+++ b/src/SourceGenerators/XamlGenerationTests/CollectionsTestsSubjects.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Markup;
+
+namespace XamlGenerationTests
+{
+	[ContentProperty(Name = nameof(MyCollection))]
+	public partial class CollectionsTest_Control : Control
+	{
+		public CollectionsTest_Collection MyCollection { get; set; }
+	}
+
+	public partial class CollectionsTest_Collection : List<CollectionsTest_Item>
+	{
+		public int MyProperty { get; set; }
+	}
+
+	public partial class CollectionsTest_Item
+	{
+
+	}
+}


### PR DESCRIPTION
- Add ability to declare some properties *and*  items on an object which is a collection
- Add ability to declare the collection object of a `ContentProperty` instead of being forced declare only the items to add to the collection

Issue: #176 #177 

## PR Type
Bugfix

## What is the current behavior?
Generated code does not compile

## What is the new behavior?
It compiles ;)

## PR Checklist
- [X] Tested code with current [supported SDKs](../readme.md#supported)
- [X] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/docs/.feature-template.md). (for bug fixes / features)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes

## Other information
