### PR TITLE
Wait for a control to have a parent before loading its template

### DIFF
--- a/src/Uno.UI.Tests/ControlTests/Given_Control.cs
+++ b/src/Uno.UI.Tests/ControlTests/Given_Control.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Uno.UI.Tests.ControlTests
+{
+	[TestClass]
+	public partial class Given_Control
+	{
+		[TestMethod]
+		public void When_ManualyApplyTemplate()
+		{
+			var templatedRoot = default(UIElement);
+			var sut = new MyControl
+			{
+				Template = new ControlTemplate(() => templatedRoot = new Grid())
+			};
+
+			Assert.IsNull(sut.TemplatedRoot);
+			Assert.IsNull(templatedRoot);
+
+			new Grid().Children.Add(sut); // This kind-of simulate that the control is in the visual tree.
+
+			Assert.IsNull(sut.TemplatedRoot);
+			Assert.IsNull(templatedRoot);
+
+			var applied = sut.ApplyTemplate();
+
+			Assert.IsTrue(applied);
+			Assert.IsNotNull(sut.TemplatedRoot);
+			Assert.AreSame(templatedRoot, sut.TemplatedRoot);
+		}
+
+		[TestMethod]
+		public void When_ManualyApplyTemplate_OutOfVisualTree()
+		{
+			var templatedRoot = default(UIElement);
+			var sut = new MyControl
+			{
+				Template = new ControlTemplate(() => templatedRoot = new Grid())
+			};
+
+			Assert.IsNull(sut.TemplatedRoot);
+			Assert.IsNull(templatedRoot);
+
+			var applied = sut.ApplyTemplate();
+
+			Assert.IsFalse(applied);
+			Assert.IsNull(sut.TemplatedRoot);
+			Assert.IsNull(templatedRoot);
+		}
+
+		public partial class MyControl : Control
+		{
+		}
+	}
+}

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
@@ -476,6 +476,8 @@ namespace Uno.UI.Tests.BinderTests.Propagation
 			});
 
 			SUT.Template = template;
+
+			new Grid().Children.Add(SUT); // This is enough for now, but the `SUT` should be in the visual tree for its template to get applied
 			SUT.ApplyTemplate();
 
 			Assert.IsNotNull(anim);

--- a/src/Uno.UI.Tests/ItemsControlTests/Given_ItemsControl.cs
+++ b/src/Uno.UI.Tests/ItemsControlTests/Given_ItemsControl.cs
@@ -40,6 +40,9 @@ namespace Uno.UI.Tests.ItemsControlTests
 				}
 			};
 
+			new Grid().Children.Add(SUT); // This is enough for now, but the `SUT` should be in the visual tree for its template to get applied
+			SUT.ApplyTemplate();
+
 			// Search on the panel for now, as the name lookup is not properly
 			// aligned on net46.
 			Assert.IsNotNull(panel.FindName("b1"));

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -91,10 +91,10 @@ namespace Windows.UI.Xaml.Controls
 		internal void SetUpdateControlTemplate(bool forceUpdate = false)
 		{
 			if (
-				!FeatureConfiguration.Control.UseLegacyLazyApplyTemplate
-				|| forceUpdate
-				|| this.HasParent()
-				|| CanCreateTemplateWithoutParent
+				(!FeatureConfiguration.Control.UseLegacyLazyApplyTemplate
+					|| forceUpdate
+					|| CanCreateTemplateWithoutParent)
+				&& this.HasParent() // Instead we should check if we are in a the visual tree
 			)
 			{
 				UpdateTemplate();


### PR DESCRIPTION
Issue: #190 

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Templates of controls are loaded as soon as the `Template` property is set

## What is the new behavior?
We check if the control has a parent before loading its template.

_Note: for now we only check if the control has a parent, but we should also check if the control is in the visual tree. See the #190 for full behavior description._

## PR Checklist
- [x] Tested code with current [supported SDKs](../readme.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/docs/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes

