### PR TITLE
added 'global::' tag preceeding a type cast, this will fix any potent…

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1067,7 +1067,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					if (isDependencyProperty)
 					{
 						writer.AppendLineInvariant(
-							"new global::Windows.UI.Xaml.Setter({0}.{1}Property, ({2}){3})" + lineEnding,
+							"new global::Windows.UI.Xaml.Setter({0}.{1}Property, (global::{2}){3})" + lineEnding,
 							GetGlobalizedTypeName(fullTargetType),
 							property,
 							propertyType,


### PR DESCRIPTION

Issue: #
 114921

## PR Type
What kind of change does this PR introduce?
fixing potential issues arising if projects have a similar namespace as uno.


## What is the current behavior?
 If a project who's namespace ends with uno, then conflicts will emerge. 

## What is the new behavior?
Fixes namespace conflicts 
