### PR TITLE
Added logic to add a global:: tag preceeding casted properties

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/NamedTypeSymbolExtensions.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/NamedTypeSymbolExtensions.cs
@@ -1,0 +1,293 @@
+﻿// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using Microsoft.CodeAnalysis;
+
+namespace Uno.SourceGenerators.Helpers
+{
+	public static class NamedTypeSymbolExtensions
+	{
+		public static SymbolNames GetSymbolNames(this INamedTypeSymbol typeSymbol, INamedTypeSymbol typeToUseForSubstitutions = null)
+		{
+			var substitutions = typeToUseForSubstitutions.GetSubstitutionTypes();
+
+			var symbolName = typeSymbol.Name;
+
+			// Generate a filename suffix from the namespace to prevent filename clashing when processing classes with the same name.
+			var filenameSuffix = $"{typeSymbol.GetNamespaceHash():X}";
+
+			if (typeSymbol.TypeArguments.Length == 0) // not a generic type
+			{
+				return new SymbolNames(typeSymbol, symbolName, "", symbolName, symbolName, symbolName, $"{symbolName}_{filenameSuffix}", "");
+			}
+
+			var argumentNames = typeSymbol.GetTypeArgumentNames(substitutions);
+			var genericArguments = string.Join(", ", argumentNames);
+
+			// symbolNameWithGenerics: MyType<T1, T2>
+			var symbolNameWithGenerics = $"{symbolName}<{genericArguments}>";
+
+			// symbolNameWithGenerics: MyType&lt;T1, T2&gt;
+			var symbolForXml = $"{symbolName}&lt;{genericArguments}&gt;";
+
+			// symbolNameDefinition: MyType<,>
+			var symbolNameDefinition = $"{symbolName}<{string.Join(",", typeSymbol.TypeArguments.Select(ta => ""))}>";
+
+			// symbolNameWithGenerics: MyType_T1_T2
+			var symbolFilename = $"{symbolName}_{string.Join("_", argumentNames)}_{filenameSuffix}";
+
+			var genericConstraints = " " + string.Join(" ", typeSymbol
+				.TypeArguments
+				.OfType<ITypeParameterSymbol>()
+				.SelectMany((tps, i) => tps.ConstraintTypes.Select(c => (tps: tps, c: c, i: i)))
+				.Select(x => $"where {argumentNames[x.i]} : {x.c}"));
+
+			return new SymbolNames(typeSymbol, symbolName, $"<{genericArguments}>", symbolNameWithGenerics, symbolForXml, symbolNameDefinition, symbolFilename, genericConstraints);
+		}
+
+		public static string[] GetTypeArgumentNames(
+			this ITypeSymbol typeSymbol,
+			(string argumentName, string type)[] substitutions)
+		{
+			if (typeSymbol is INamedTypeSymbol namedSymbol)
+			{
+				var dict = substitutions.ToDictionary(x => x.argumentName, x => x.type);
+
+				return namedSymbol.TypeArguments
+					.Select(ta => ta.ToString())
+					.Select(t => dict.ContainsKey(t) ? dict[t] : t)
+					.ToArray();
+			}
+			return new string[0];
+		}
+
+		public static (string argumentName, string type)[] GetSubstitutionTypes(this INamedTypeSymbol type)
+		{
+			if (type == null || type.TypeArguments.Length == 0)
+			{
+				return new(string, string)[] { };
+			}
+
+			var argumentParameters = type.TypeParameters;
+			var argumentTypes = type.TypeArguments;
+
+			var result = new(string, string)[type.TypeArguments.Length];
+
+			for (var i = 0; i < argumentParameters.Length; i++)
+			{
+				var parameterType = argumentTypes[i] as INamedTypeSymbol;
+				var parameterNames = parameterType.GetSymbolNames();
+
+				result[i] = (argumentParameters[i].Name, parameterNames.GetSymbolFullNameWithGenerics());
+			}
+
+			return result;
+		}
+
+		public static int GetNamespaceHash(this INamedTypeSymbol typeSymbol)
+		{
+			var hashCode = 0;
+			INamespaceSymbol namespaceSymbol = typeSymbol.ContainingNamespace;
+			while (!namespaceSymbol?.IsGlobalNamespace ?? false)
+			{
+				hashCode ^= namespaceSymbol.Name.GetStableHashCode();
+				namespaceSymbol = namespaceSymbol.ContainingNamespace;
+			}
+
+			return hashCode;
+		}
+
+		private static int GetStableHashCode(this string str)
+		{
+			// A fully managed version of the 64bit GetHashCode() that does not use any randomization and will always return
+			// the same value for equal strings.
+			// https://stackoverflow.com/questions/36845430/persistent-hashcode-for-strings
+			unchecked
+			{
+				int hash1 = 5381;
+				int hash2 = hash1;
+
+				for (int i = 0; i < str.Length && str[i] != '\0'; i += 2)
+				{
+					hash1 = ((hash1 << 5) + hash1) ^ str[i];
+					if (i == str.Length - 1 || str[i + 1] == '\0')
+						break;
+					hash2 = ((hash2 << 5) + hash2) ^ str[i + 1];
+				}
+
+				return hash1 + (hash2 * 1566083941);
+			}
+		}
+	}
+
+	public class SymbolNames
+	{
+		public SymbolNames(
+			INamedTypeSymbol symbol,
+			string symbolName,
+			string genericArguments,
+			string symbolNameWithGenerics,
+			string symbolFoxXml,
+			string symbolNameDefinition,
+			string symbolFilename,
+			string genericConstraints)
+		{
+			Symbol = symbol;
+			SymbolName = symbolName;
+			GenericArguments = genericArguments;
+			SymbolNameWithGenerics = symbolNameWithGenerics;
+			SymbolFoxXml = symbolFoxXml;
+			SymbolNameDefinition = symbolNameDefinition;
+			SymbolFilename = symbolFilename;
+			GenericConstraints = genericConstraints;
+		}
+
+		public INamedTypeSymbol Symbol { get; }
+
+		/// <summary>
+		/// The name of the symbol, without any namespace, container type or generic decorations.
+		/// </summary>
+		public string SymbolName { get; }
+
+		/// <summary>
+		/// Generic arguments, if any.  Ex: `&lt;T1, T2&gt;`
+		/// </summary>
+		/// <remarks>
+		/// Empty if no generics
+		/// </remarks>
+		public string GenericArguments { get; }
+
+		/// <summary>
+		/// SymbolName + GenericArguments, Ex: `MyType&lt;T1, T2&gt;`
+		/// </summary>
+		public string SymbolNameWithGenerics { get; }
+
+		/// <summary>
+		/// Same as SymbolNameWithGenerics but escaped for XML
+		/// </summary>
+		public string SymbolFoxXml { get; }
+
+		/// <summary>
+		/// Definition for symbol name, ex: `MyType&lt;,&gt;`
+		/// </summary>
+		public string SymbolNameDefinition { get; }
+
+		/// <summary>
+		/// Appropriate result filename for the type
+		/// </summary>
+		public string SymbolFilename { get; }
+
+		/// <summary>
+		/// Generic constraints on the type, Ex: `where T1 : string`
+		/// </summary>
+		/// <remarks>
+		/// Empty if no generics or no constraints
+		/// </remarks>
+		public string GenericConstraints { get; }
+
+		private string GetContainingTypeFullName(INamedTypeSymbol typeForSubstitutions = null)
+		{
+			if (Symbol.ContainingType != null)
+			{
+				return Symbol
+					.ContainingType
+					.GetSymbolNames(typeForSubstitutions)
+					.GetSymbolFullNameWithGenerics();
+			}
+
+			return "global::" + Symbol.ContainingNamespace;
+		}
+
+		private static readonly IReadOnlyList<SpecialType> LanguageSupportedSpecialTypes = new[]
+		{
+			SpecialType.System_Boolean,
+			SpecialType.System_Byte,
+			SpecialType.System_Char,
+			SpecialType.System_Decimal,
+			SpecialType.System_Double,
+			SpecialType.System_Int16,
+			SpecialType.System_Int32,
+			SpecialType.System_Int64,
+			SpecialType.System_Object,
+			SpecialType.System_SByte,
+			SpecialType.System_String,
+			SpecialType.System_UInt16,
+			SpecialType.System_UInt32,
+			SpecialType.System_UInt64,
+		};
+
+		public string GetSymbolFullNameWithGenerics(INamedTypeSymbol typeForSubstitutions = null)
+		{
+			if ((!Symbol.IsGenericType || typeForSubstitutions == null)
+				&& LanguageSupportedSpecialTypes.Contains(Symbol.SpecialType))
+			{
+				return Symbol.ToString();
+			}
+
+			if (Symbol.IsTupleType)
+			{
+				var tupleElements = Symbol.TupleElements
+					.Select(t =>
+					{
+						var type = t.Type.GetSymbolNames(typeForSubstitutions)?.GetSymbolFullNameWithGenerics(typeForSubstitutions) ?? t.Type.ToString();
+						var name = t.Name;
+
+						if (string.IsNullOrEmpty(name))
+						{
+							return type;
+						}
+
+						return type + " " + name;
+					});
+
+				return "(" + string.Join(", ", tupleElements) + ")";
+			}
+
+			if (string.IsNullOrEmpty(SymbolNameWithGenerics))
+			{
+				return Symbol.ToString();
+			}
+
+			return GetContainingTypeFullName(typeForSubstitutions) + "." + SymbolNameWithGenerics;
+		}
+
+
+		public void Deconstruct(
+			out string symbolName,
+			out string genericArguments,
+			out string symbolNameWithGenerics,
+			out string symbolFoxXml,
+			out string symbolNameDefinition,
+			out string symbolFilename,
+			out string genericConstraints)
+		{
+			symbolName = SymbolName;
+			genericArguments = GenericArguments;
+			symbolNameWithGenerics = SymbolNameWithGenerics;
+			symbolFoxXml = SymbolFoxXml;
+			symbolNameDefinition = SymbolNameDefinition;
+			symbolFilename = SymbolFilename;
+			genericConstraints = GenericConstraints;
+		}
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/TypeSymbolExtensions.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Helpers/TypeSymbolExtensions.cs
@@ -1,0 +1,418 @@
+﻿// ******************************************************************
+// Copyright � 2015-2018 nventive inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// ******************************************************************
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+
+namespace Uno.SourceGenerators.Helpers
+{
+	public static class TypeSymbolExtensions
+	{
+		public static bool IsPrimitive(this ITypeSymbol type)
+		{
+			switch (type.SpecialType)
+			{
+				case SpecialType.System_Boolean:
+				case SpecialType.System_Byte:
+				case SpecialType.System_Char:
+				case SpecialType.System_DateTime:
+				case SpecialType.System_Decimal:
+				case SpecialType.System_Double:
+				case SpecialType.System_Enum:
+				case SpecialType.System_Int16:
+				case SpecialType.System_Int32:
+				case SpecialType.System_Int64:
+				case SpecialType.System_IntPtr:
+				case SpecialType.System_SByte:
+				case SpecialType.System_String:
+				case SpecialType.System_Single:
+				case SpecialType.System_UInt16:
+				case SpecialType.System_UInt32:
+				case SpecialType.System_UInt64:
+				case SpecialType.System_UIntPtr:
+					return true;
+			}
+
+			return false;
+		}
+
+		private static ImmutableDictionary<(ITypeSymbol, bool), bool> _isImmutable =
+			ImmutableDictionary<(ITypeSymbol, bool), bool>.Empty;
+
+		public static SymbolNames GetSymbolNames(this ITypeSymbol symbol, INamedTypeSymbol typeToUseForSubstitutions = null)
+		{
+			return symbol is INamedTypeSymbol namedSymbol
+				? namedSymbol.GetSymbolNames(typeToUseForSubstitutions)
+				: null;
+		}
+
+		public static bool IsImmutable(this ITypeSymbol type, bool treatArrayAsImmutable, IReadOnlyList<ITypeSymbol> knownAsImmutable)
+		{
+			bool GetIsImmutable((ITypeSymbol type, bool treatArrayAsImmutable) x)
+			{
+				var (t, asImmutable) = x;
+				foreach (var attribute in t.GetAttributes())
+				{
+					switch (attribute.AttributeClass.ToString())
+					{
+						case "Uno.ImmutableAttribute":
+						case "Uno.GeneratedImmutableAttribute":
+							return true;
+					}
+				}
+
+				if (t.IsPrimitive())
+				{
+					return true;
+				}
+
+				switch (t.SpecialType)
+				{
+					case SpecialType.None:
+					case SpecialType.System_Collections_Generic_IReadOnlyCollection_T:
+					case SpecialType.System_Collections_Generic_IReadOnlyList_T:
+						break; // need further validation
+					default:
+						return false;
+				}
+
+				if (t is IArrayTypeSymbol arrayType)
+				{
+					return arrayType.ElementType?.IsImmutable(asImmutable, knownAsImmutable) ?? false;
+				}
+
+				var definitionType = t.GetDefinitionType();
+
+				switch (definitionType.ToString())
+				{
+					case "System.Attribute": // strange, but valid
+					case "System.DateTime":
+					case "System.DateTimeOffset":
+					case "System.Guid":
+					case "System.TimeSpan":
+					case "System.Type":
+					case "System.Uri":
+					case "System.Version":
+						return true;
+
+					// .NET framework
+					case "System.Collections.Generic.IReadOnlyList<T>":
+					case "System.Collections.Generic.IReadOnlyCollection<T>":
+					case "System.Nullable<T>":
+					case "System.Tuple<T>":
+					// System.Collections.Immutable (nuget package)
+					case "System.Collections.Immutable.IImmutableList<T>":
+					case "System.Collections.Immutable.IImmutableQueue<T>":
+					case "System.Collections.Immutable.IImmutableSet<T>":
+					case "System.Collections.Immutable.IImmutableStack<T>":
+					case "System.Collections.Immutable.ImmutableArray<T>":
+					case "System.Collections.Immutable.ImmutableHashSet<T>":
+					case "System.Collections.Immutable.ImmutableList<T>":
+					case "System.Collections.Immutable.ImmutableQueue<T>":
+					case "System.Collections.Immutable.ImmutableSortedSet<T>":
+					case "System.Collections.Immutable.ImmutableStack<T>":
+						{
+							var argumentParameter = (t as INamedTypeSymbol)?.TypeArguments.FirstOrDefault();
+							return argumentParameter == null || argumentParameter.IsImmutable(asImmutable, knownAsImmutable);
+						}
+					case "System.Collections.Immutable.IImmutableDictionary<TKey, TValue>":
+					case "System.Collections.Immutable.ImmutableDictionary<TKey, TValue>":
+					case "System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>":
+						{
+							var keyTypeParameter = (t as INamedTypeSymbol)?.TypeArguments.FirstOrDefault();
+							var valueTypeParameter = (t as INamedTypeSymbol)?.TypeArguments.Skip(1).FirstOrDefault();
+							return (keyTypeParameter == null || keyTypeParameter.IsImmutable(asImmutable, knownAsImmutable))
+								&& (valueTypeParameter == null || valueTypeParameter.IsImmutable(asImmutable, knownAsImmutable));
+						}
+				}
+
+				if (knownAsImmutable.Contains(definitionType))
+				{
+					return true;
+				}
+
+				switch (definitionType.GetType().Name)
+				{
+					case "TupleTypeSymbol":
+						return true; // tuples are immutables
+				}
+
+				switch (definitionType.BaseType?.ToString())
+				{
+					case "System.Enum":
+						return true;
+					case "System.Array":
+						return asImmutable;
+				}
+
+				return IsImmutableByRequirements(t, treatArrayAsImmutable, knownAsImmutable);
+			}
+
+			return ImmutableInterlocked.GetOrAdd(ref _isImmutable, (type, treatArrayAsImmutable), GetIsImmutable);
+		}
+
+		private static bool IsImmutableByRequirements(ITypeSymbol type, bool treatArrayAsImmutable, IReadOnlyList<ITypeSymbol> knownAsImmutable)
+		{
+			// Check if type is complying to immutable requirements
+			// 1) all instance fields are readonly
+			// 2) all properties are getter-only
+			// 3) base class is immutable
+
+			foreach (var member in type.GetMembers())
+			{
+				if (member is IFieldSymbol f && !(f.IsStatic || f.IsReadOnly || f.IsImplicitlyDeclared) && f.Type.IsImmutable(treatArrayAsImmutable, knownAsImmutable))
+				{
+					return false; // there's a non-readonly non-static field
+				}
+				if (member is IPropertySymbol p && !(p.IsStatic || p.IsReadOnly || p.IsImplicitlyDeclared) && p.Type.IsImmutable(treatArrayAsImmutable, knownAsImmutable))
+				{
+					return false; // there's a non-readonly non-static property
+				}
+			}
+
+			// It's immutable if the base type is (or no base type)
+			return type.BaseType == null
+				|| type.BaseType.SpecialType == SpecialType.System_Object
+				|| type.BaseType.SpecialType == SpecialType.System_ValueType
+				|| type.BaseType.IsImmutable(treatArrayAsImmutable, knownAsImmutable);
+		}
+
+		public static ITypeSymbol GetDefinitionType(this ITypeSymbol type)
+		{
+			var definitionType = type;
+
+			while ((definitionType as INamedTypeSymbol)?.ConstructedFrom.Equals(definitionType) == false)
+			{
+				definitionType = ((INamedTypeSymbol)definitionType).ConstructedFrom;
+			}
+
+			return definitionType;
+		}
+
+		private static ImmutableDictionary<ITypeSymbol, (ITypeSymbol, bool, bool)> _isCollection =
+			ImmutableDictionary<ITypeSymbol, (ITypeSymbol, bool, bool)>.Empty;
+
+		public static bool IsCollection(this ITypeSymbol type, out ITypeSymbol elementType, out bool isReadonlyCollection, out bool isOrdered)
+		{
+			(ITypeSymbol elementType, bool isReadonlyCollection, bool isOrdered) GetTypeArgumentIfItIsACollection(INamedTypeSymbol t)
+			{
+				if (t != null)
+				{
+					var interfaceDefinition = t.GetDefinitionType();
+
+					switch (interfaceDefinition.ToString())
+					{
+						case "System.Collections.Immutable.ImmutableHashSet<T>":
+						case "System.Collections.Immutable.IImmutableSet<T>":
+							{
+								return (t.TypeArguments[0], true, false);
+							}
+						case "System.Collections.Immutable.IImmutableList<T>":
+						case "System.Collections.Immutable.IImmutableQueue<T>":
+						case "System.Collections.Immutable.IImmutableStack<T>":
+						case "System.Collections.Immutable.ImmutableArray<T>":
+						case "System.Collections.Immutable.ImmutableList<T>":
+						case "System.Collections.Immutable.ImmutableQueue<T>":
+						case "System.Collections.Immutable.ImmutableSortedSet<T>":
+						case "System.Collections.Immutable.ImmutableStack<T>":
+							{
+								return (t.TypeArguments[0], true, true);
+							}
+						case "System.Collections.Generic.IReadOnlyCollection<T>":
+							{
+								return (t.TypeArguments[0], true, true);
+							}
+						case "System.Collections.Generic.HashSet<T>":
+							{
+								return (t.TypeArguments[0], false, false);
+							}
+						case "System.Collections.Generic.ICollection<T>":
+						case "System.Collections.Generic.List<T>":
+						case "System.Collections.Generic.LinkedList<T>":
+						case "System.Collections.Generic.Queue<T>":
+						case "System.Collections.Generic.SortedSet<T>":
+						case "System.Collections.Generic.Stack<T>":
+							{
+								return (t.TypeArguments[0], false, true);
+							}
+					}
+				}
+
+				return (default(ITypeSymbol), default(bool), default(bool));
+			}
+
+			(ITypeSymbol elementType, bool isReadonlyCollection, bool isOrdered) GetIsCollection(ITypeSymbol t)
+			{
+				var r = GetTypeArgumentIfItIsACollection(t as INamedTypeSymbol);
+
+				if (r.elementType != null)
+				{
+					return r;
+				}
+
+				foreach (var @interface in t.AllInterfaces)
+				{
+					r = GetTypeArgumentIfItIsACollection(@interface);
+					if (r.elementType != null)
+					{
+						return r;
+					}
+				}
+
+				return (default(ITypeSymbol), default(bool), default(bool));
+			}
+
+			(elementType, isReadonlyCollection, isOrdered) = ImmutableInterlocked.GetOrAdd(ref _isCollection, type, GetIsCollection);
+			return elementType != null;
+		}
+
+		private static ImmutableDictionary<ITypeSymbol, (ITypeSymbol, ITypeSymbol, bool)> _isDictionary =
+			ImmutableDictionary<ITypeSymbol, (ITypeSymbol, ITypeSymbol, bool)>.Empty;
+
+		public static bool IsDictionary(this ITypeSymbol type, out ITypeSymbol keyType, out ITypeSymbol valueType, out bool isReadonlyDictionary)
+		{
+			(ITypeSymbol keyType, ITypeSymbol valueType, bool isReadonlyDictionary) GetTypeArgumentIfItIsACollection(INamedTypeSymbol t)
+			{
+				if (t != null)
+				{
+					var interfaceDefinition = t.GetDefinitionType();
+
+					switch (interfaceDefinition.ToString())
+					{
+						case "System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>":
+							{
+								return (t.TypeArguments[0], t.TypeArguments[1], true);
+							}
+						case "System.Collections.Generic.IDictionary<TKey, TValue>":
+							{
+								return (t.TypeArguments[0], t.TypeArguments[1], false);
+							}
+					}
+				}
+
+				return (null, null, false);
+			}
+
+			(ITypeSymbol keyType, ITypeSymbol valueType, bool isReadonlyDictionary) GetIsACollection(ITypeSymbol t)
+			{
+				var r = GetTypeArgumentIfItIsACollection(t as INamedTypeSymbol);
+
+				if (r.keyType != null)
+				{
+					return r;
+				}
+
+				foreach (var @interface in t.AllInterfaces)
+				{
+					r = GetTypeArgumentIfItIsACollection(@interface);
+					if (r.keyType != null)
+					{
+						return r;
+					}
+				}
+
+				return (null, null, false);
+			}
+
+			(keyType, valueType, isReadonlyDictionary) = ImmutableInterlocked.GetOrAdd(ref _isDictionary, type, GetIsACollection);
+			return keyType != null;
+		}
+
+		private static MethodInfo _isAutoPropertyGetter;
+
+		public static bool IsAutoProperty(this IPropertySymbol symbol)
+		{
+			if (symbol.IsWithEvents || symbol.IsIndexer || !symbol.IsReadOnly)
+			{
+				return false;
+			}
+
+			while (!Equals(symbol.OriginalDefinition, symbol))
+			{
+				// In some cases we're dealing with a derived type of `WrappedPropertySymbol`.
+				// This code needs to deal with the SourcePropertySymbol from Roslyn,
+				// the type containing the `IsAutoProperty` internal member.
+				symbol = symbol.OriginalDefinition;
+			}
+
+			var type = symbol.GetType();
+			switch (type.FullName)
+			{
+				case "Microsoft.CodeAnalysis.CSharp.Symbols.Metadata.PE.PEPropertySymbol":
+					return symbol.IsReadOnly; // It's from compiled code. We assume it's an auto-property when "read only"
+				case "Microsoft.CodeAnalysis.CSharp.Symbols.SourcePropertySymbol":
+					break; // ok
+				default:
+					throw new InvalidOperationException(
+						"Unable to find the internal property `IsAutoProperty` on implementation of `IPropertySymbol`. " +
+						"Should be on internal class `PropertySymbol`. Maybe you are using an incompatible version of Roslyn.");
+			}
+
+			if (_isAutoPropertyGetter == null)
+			{
+				_isAutoPropertyGetter = type
+					.GetProperty("IsAutoProperty", BindingFlags.Instance | BindingFlags.NonPublic)
+					.GetMethod;
+			}
+
+			var isAuto = _isAutoPropertyGetter.Invoke(symbol, new object[] { });
+			return (bool)isAuto;
+		}
+
+		public static bool IsFromPartialDeclaration(this ISymbol symbol)
+		{
+			return symbol
+				.DeclaringSyntaxReferences
+				.Select(reference => reference.GetSyntax(CancellationToken.None))
+				.OfType<ClassDeclarationSyntax>()
+				.Any(node => node.Modifiers.Any(SyntaxKind.PartialKeyword));
+		}
+
+		private static ImmutableDictionary<ITypeSymbol, ITypeSymbol> _isFunc =
+			ImmutableDictionary<ITypeSymbol, ITypeSymbol>.Empty;
+
+		public static bool IsFunc(this ITypeSymbol type, out ITypeSymbol resultType)
+		{
+			ITypeSymbol GetIsFunc(ITypeSymbol t)
+			{
+				if (t != null && t is INamedTypeSymbol namedTypeSymbol)
+				{
+					var interfaceDefinition = t.GetDefinitionType();
+
+					switch (interfaceDefinition.ToString())
+					{
+						case "System.Func<TResult>":
+							return namedTypeSymbol.TypeArguments[0];
+					}
+				}
+
+				return null;
+			}
+
+			resultType = ImmutableInterlocked.GetOrAdd(ref _isFunc, type, GetIsFunc);
+			return resultType != null;
+		}
+	}
+}

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
@@ -92,9 +92,11 @@
     <Compile Include="DependencyObject\DependencyObjectGenerator.cs" />
     <Compile Include="DependencyObject\MethodCallFinder.cs" />
     <Compile Include="Helpers\AnalyzerSuppressions.cs" />
+    <Compile Include="Helpers\NamedTypeSymbolExtensions.cs" />
     <Compile Include="Helpers\PathHelper.cs" />
     <Compile Include="Helpers\RoslynMetadataHelper.cs" />
     <Compile Include="Helpers\SymbolExtensions.cs" />
+    <Compile Include="Helpers\TypeSymbolExtensions.cs" />
     <Compile Include="NativeCtor\NativeCtorsGenerator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="XamlGenerator\BackingFieldDefinition.cs" />

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -19,6 +19,7 @@ using Microsoft.CodeAnalysis.Formatting;
 using System.Threading;
 using Uno;
 using Uno.Logging;
+using Uno.SourceGenerators.Helpers;
 using Uno.UI.SourceGenerators.XamlGenerator.XamlRedirection;
 
 namespace Uno.UI.SourceGenerators.XamlGenerator
@@ -1070,7 +1071,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 							"new global::Windows.UI.Xaml.Setter({0}.{1}Property, ({2}){3})" + lineEnding,
 							GetGlobalizedTypeName(fullTargetType),
 							property,
-							propertyType,
+							propertyType.GetSymbolNames().GetSymbolFullNameWithGenerics(),
 							BuildLiteralValue(valueNode, propertyType)
 						);
 					}


### PR DESCRIPTION
Issue: #
 114921

## PR Type
What kind of change does this PR introduce?
fixing potential issues arising if projects have a similar namespace as uno.


## What is the current behavior?
 If a project who's namespace ends with uno, then conflicts will emerge. 

## What is the new behavior?
Fixes namespace conflicts 
