### PR TITLE
Improve ListView.ScrollIntoView behaviour

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.iOS.cs
@@ -554,7 +554,15 @@ namespace Windows.UI.Xaml.Controls
 				{
 					//Scroll to individual item, We set the UICollectionViewScrollPosition to None to have the same behavior as windows.
 					//We can potentially customize this By using ConvertScrollAlignment and use different alignments.
-					ScrollToItem(index, ConvertSnapPointsAlignmentToScrollPosition(), AnimateScrollIntoView);
+					var needsMaterialize = Source.UpdateLastMaterializedItem(index);
+					if (needsMaterialize)
+					{
+						NativeLayout.InvalidateLayout();
+					}
+
+					var offset = NativeLayout.GetTargetScrollOffset(index, alignment);
+					SetContentOffset(offset, AnimateScrollIntoView);
+					NativeLayout.UpdateStickyHeaderPositions();
 				}
 			}
 		}
@@ -680,6 +688,7 @@ namespace Windows.UI.Xaml.Controls
 				_needsLayoutAfterReloadData = true;
 				ReloadData();
 
+				Source?.ReloadData();
 				NativeLayout?.ReloadData();
 
 				_listEmptyLastRefresh = XamlParent?.NumberOfItems == 0;

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
@@ -226,7 +226,7 @@ namespace Windows.UI.Xaml.Controls
 		private void ApplyScrollToPosition(int targetPosition, ScrollIntoViewAlignment alignment, RecyclerView.Recycler recycler, RecyclerView.State state)
 		{
 			int offsetToApply = 0;
-			bool shouldSnapToStart = false;
+			bool shouldSnapToStart = false; //Initial values: if the item is fully visible, it shouldn't snap (alignment = default)
 			bool shouldSnapToEnd = false;
 
 			// 1. Incrementally scroll until target position lies within range of visible positions
@@ -234,14 +234,14 @@ namespace Windows.UI.Xaml.Controls
 			int appliedOffset = 0;
 			while (targetPosition > GetLastVisibleDisplayPosition() && GetNextUnmaterializedItem(FillDirection.Forward) != null)
 			{
-				shouldSnapToEnd = true;
+				shouldSnapToEnd = true; //If the item is below the viewport, it should be snapped to the bottom of the viewport (alignment = default)
 				appliedOffset += GetScrollConsumptionIncrement(FillDirection.Forward);
 				offsetToApply += ScrollByInner(appliedOffset, recycler, state);
 			}
 			//While target position is before first visible position, scroll backward
 			while (targetPosition < GetFirstVisibleDisplayPosition() && GetNextUnmaterializedItem(FillDirection.Back) != null)
 			{
-				shouldSnapToStart = true;
+				shouldSnapToStart = true; //If the item is above the viewport, it should be snapped to the bottom of the viewport (alignment = default)
 				appliedOffset -= GetScrollConsumptionIncrement(FillDirection.Back);
 				offsetToApply += ScrollByInner(appliedOffset, recycler, state);
 			}
@@ -251,6 +251,7 @@ namespace Windows.UI.Xaml.Controls
 
 			if (alignment == ScrollIntoViewAlignment.Leading)
 			{
+				// 'Leading' means that the item always snaps to the top of the viewport no matter what
 				shouldSnapToStart = true;
 				shouldSnapToEnd = false;
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
@@ -259,7 +259,9 @@ namespace Windows.UI.Xaml.Controls
 			//2. If view for position lies partially outside visible bounds, bring it into view
 			var target = FindViewByAdapterPosition(targetPosition);
 
-			var gapToStart = 0 - GetChildStartWithMargin(target);
+			var gapToStart = 0 - GetChildStartWithMargin(target)
+				// Ensure sticky group header doesn't cover item
+				+ GetStickyGroupHeaderExtent();
 			if (!shouldSnapToStart)
 			{
 				gapToStart = Math.Max(0, gapToStart);
@@ -287,6 +289,11 @@ namespace Windows.UI.Xaml.Controls
 			FillLayout(FillDirection.Forward, 0, Extent, ContentBreadth, recycler, state);
 			FillLayout(FillDirection.Back, 0, Extent, ContentBreadth, recycler, state);
 		}
+
+		/// <summary>
+		/// Get extent of currently sticking group header (if any)
+		/// </summary>
+		private int GetStickyGroupHeaderExtent() => GetFirstGroup().ItemsExtentOffset;
 
 		private class ScrollToPositionRequest
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -1239,7 +1239,8 @@ namespace Windows.UI.Xaml.Controls
 			nfloat GetBaseOffset()
 			{
 				var frame = LayoutAttributesForItem(item).Frame;
-				var frameExtentStart = GetExtentStart(frame);
+				var headerCorrection = GetStickyHeaderExtent(item.Section);
+				var frameExtentStart = GetExtentStart(frame) - headerCorrection;
 				if (alignment == ScrollIntoViewAlignment.Leading)
 				{
 					// Alignment=Leading snaps item to same position no matter where it currently is
@@ -1268,6 +1269,13 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 		}
+
+		/// <summary>
+		/// Get extent added by sticky group header for given section, if any.
+		/// </summary>
+		private nfloat GetStickyHeaderExtent(int section) => AreStickyGroupHeadersEnabled && RelativeGroupHeaderPlacement == RelativeHeaderPlacement.Inline ?
+			GetExtent(_inlineHeaderFrames[section].Size) :
+			0;
 
 		/// <summary>
 		/// Get all LayoutAttributes for every display element.

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -862,6 +862,18 @@ namespace Windows.UI.Xaml.Controls
 			return false;
 		}
 
+		/// <summary>
+		/// Triggers an update of the sticky group header positions.
+		/// </summary>
+		public void UpdateStickyHeaderPositions()
+		{
+			if (AreStickyGroupHeadersEnabled)
+			{
+				_invalidatingHeadersOnBoundsChange = true;
+				InvalidateLayout(); 
+			}
+		}
+
 		public override void InvalidateLayout()
 		{
 			//Called in response to INotifyCollectionChanged operation, update layout reusing already-calculated databound element sizes
@@ -1205,6 +1217,55 @@ namespace Windows.UI.Xaml.Controls
 					return (float)(contentOffset + GetExtent(CollectionView.Bounds.Size));
 				default:
 					throw new InvalidOperationException($"{SnapPointsAlignment} out of range.");
+			}
+		}
+
+		/// <summary>
+		/// Get offset to apply to scroll item into view
+		/// </summary>
+		internal CGPoint GetTargetScrollOffset(NSIndexPath item, ScrollIntoViewAlignment alignment)
+		{
+			var baseOffsetExtent = GetBaseOffset();
+			var snapTo = GetSnapTo(scrollVelocity: 0, (float)baseOffsetExtent);
+			if (snapTo.HasValue)
+			{
+				return GetSnapToAsOffset(snapTo.Value);
+			}
+			else
+			{
+				return SetExtentOffset(CGPoint.Empty, baseOffsetExtent);
+			}
+
+			nfloat GetBaseOffset()
+			{
+				var frame = LayoutAttributesForItem(item).Frame;
+				var frameExtentStart = GetExtentStart(frame);
+				if (alignment == ScrollIntoViewAlignment.Leading)
+				{
+					// Alignment=Leading snaps item to same position no matter where it currently is
+					return frameExtentStart;
+				}
+				else // Alignment=Default
+				{
+					var currentOffset = GetExtent(Owner.ContentOffset);
+					var targetOffset = currentOffset;
+					var frameExtentEnd = GetExtentEnd(frame);
+					var viewportHeight = GetExtent(CollectionView.Bounds.Size);
+
+					if (frameExtentStart < currentOffset)
+					{
+						// Start of item is above viewport, it should snap to start of viewport
+						targetOffset = frameExtentStart;
+					}
+					if (frameExtentEnd > currentOffset + viewportHeight)
+					{
+						//End of item is below viewport, it should snap to end of viewport
+						targetOffset = frameExtentEnd - viewportHeight;
+					}
+					// (If neither of the conditions apply, item is already fully in view, return current offset unaltered)
+
+					return targetOffset;
+				}
 			}
 		}
 


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix

 - ScrollIntoView works correctly on iOS when using fixed-height item templates defined inside an ItemTemplateSelector. It still has trouble with variable-sized items.
 - ScrollIntoView leaves space to show sticky group headers (iOS and Android)

Feature

Support ScrollIntoViewAlignment.Leading on iOS

<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
Issue 131768