### PR TITLE
Control - fix ApplyTemplate()

### DIFF
--- a/src/Uno.UI.Tests/ControlTests/Given_Control.cs
+++ b/src/Uno.UI.Tests/ControlTests/Given_Control.cs
@@ -13,46 +13,64 @@ namespace Uno.UI.Tests.ControlTests
 	public partial class Given_Control
 	{
 		[TestMethod]
-		public void When_ManualyApplyTemplate()
+		public void When_ManuallyApplyTemplate()
 		{
-			var templatedRoot = default(UIElement);
-			var sut = new MyControl
+			var current = FeatureConfiguration.Control.UseLegacyLazyApplyTemplate;
+			try
 			{
-				Template = new ControlTemplate(() => templatedRoot = new Grid())
-			};
+				FeatureConfiguration.Control.UseLegacyLazyApplyTemplate = true;
+				var templatedRoot = default(UIElement);
+				var sut = new MyControl
+				{
+					Template = new ControlTemplate(() => templatedRoot = new Grid())
+				};
 
-			Assert.IsNull(sut.TemplatedRoot);
-			Assert.IsNull(templatedRoot);
+				Assert.IsNull(sut.TemplatedRoot);
+				Assert.IsNull(templatedRoot);
 
-			new Grid().Children.Add(sut); // This kind-of simulate that the control is in the visual tree.
+				new Grid().Children.Add(sut); // This kind-of simulate that the control is in the visual tree.
 
-			Assert.IsNull(sut.TemplatedRoot);
-			Assert.IsNull(templatedRoot);
+				Assert.IsNull(sut.TemplatedRoot);
+				Assert.IsNull(templatedRoot);
 
-			var applied = sut.ApplyTemplate();
+				var applied = sut.ApplyTemplate();
 
-			Assert.IsTrue(applied);
-			Assert.IsNotNull(sut.TemplatedRoot);
-			Assert.AreSame(templatedRoot, sut.TemplatedRoot);
+				Assert.IsTrue(applied);
+				Assert.IsNotNull(sut.TemplatedRoot);
+				Assert.AreSame(templatedRoot, sut.TemplatedRoot);
+			}
+			finally
+			{
+				FeatureConfiguration.Control.UseLegacyLazyApplyTemplate = current;
+			}
 		}
 
 		[TestMethod]
-		public void When_ManualyApplyTemplate_OutOfVisualTree()
+		public void When_ManuallyApplyTemplate_OutOfVisualTree()
 		{
-			var templatedRoot = default(UIElement);
-			var sut = new MyControl
+			var current = FeatureConfiguration.Control.UseLegacyLazyApplyTemplate;
+			try
 			{
-				Template = new ControlTemplate(() => templatedRoot = new Grid())
-			};
+				FeatureConfiguration.Control.UseLegacyLazyApplyTemplate = true;
+				var templatedRoot = default(UIElement);
+				var sut = new MyControl
+				{
+					Template = new ControlTemplate(() => templatedRoot = new Grid())
+				};
 
-			Assert.IsNull(sut.TemplatedRoot);
-			Assert.IsNull(templatedRoot);
+				Assert.IsNull(sut.TemplatedRoot);
+				Assert.IsNull(templatedRoot);
 
-			var applied = sut.ApplyTemplate();
+				var applied = sut.ApplyTemplate();
 
-			Assert.IsFalse(applied);
-			Assert.IsNull(sut.TemplatedRoot);
-			Assert.IsNull(templatedRoot);
+				Assert.IsTrue(applied);
+				Assert.IsNotNull(sut.TemplatedRoot);
+				Assert.AreSame(templatedRoot, sut.TemplatedRoot);
+			}
+			finally
+			{
+				FeatureConfiguration.Control.UseLegacyLazyApplyTemplate = current;
+			}
 		}
 
 		public partial class MyControl : Control

--- a/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
+++ b/src/Uno.UI.Tests/DependencyProperty/Given_DependencyProperty.Propagation.cs
@@ -476,8 +476,6 @@ namespace Uno.UI.Tests.BinderTests.Propagation
 			});
 
 			SUT.Template = template;
-
-			new Grid().Children.Add(SUT); // This is enough for now, but the `SUT` should be in the visual tree for its template to get applied
 			SUT.ApplyTemplate();
 
 			Assert.IsNotNull(anim);

--- a/src/Uno.UI.Tests/ItemsControlTests/Given_ItemsControl.cs
+++ b/src/Uno.UI.Tests/ItemsControlTests/Given_ItemsControl.cs
@@ -40,9 +40,6 @@ namespace Uno.UI.Tests.ItemsControlTests
 				}
 			};
 
-			new Grid().Children.Add(SUT); // This is enough for now, but the `SUT` should be in the visual tree for its template to get applied
-			SUT.ApplyTemplate();
-
 			// Search on the panel for now, as the name lookup is not properly
 			// aligned on net46.
 			Assert.IsNotNull(panel.FindName("b1"));

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.cs
@@ -91,10 +91,10 @@ namespace Windows.UI.Xaml.Controls
 		internal void SetUpdateControlTemplate(bool forceUpdate = false)
 		{
 			if (
-				(!FeatureConfiguration.Control.UseLegacyLazyApplyTemplate
-					|| forceUpdate
-					|| CanCreateTemplateWithoutParent)
-				&& this.HasParent() // Instead we should check if we are in a the visual tree
+				!FeatureConfiguration.Control.UseLegacyLazyApplyTemplate
+				|| forceUpdate
+				|| this.HasParent()
+				|| CanCreateTemplateWithoutParent
 			)
 			{
 				UpdateTemplate();


### PR DESCRIPTION
Fix bug where Control.ApplyTemplate() would only work when view was attached to the visual tree. UWP only requires that Template be non-null.

Restore correct behaviour of Control.CanCreateTemplateWithoutParent.

Issue: #133790
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
