### PR TITLE
[iOS] Fix infinite sequence of changing TextBox.Text values

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -12,3 +12,4 @@
  * 134189 [iOS] The Time Picker flyout placement is not always respected
  * 134132 [Android] Fix loading of ItemsPresenter
  * 134104 [iOS] Fixed an issue when back swiping from a page with a collapsed CommandBar
+ * 134026 [iOS] Setting a different DP from TextBox.TextChanging can cause an infinite 'ping pong' of changing Text values

--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
@@ -20,6 +20,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
 using Uno.Conversion;
 using Microsoft.Extensions.Logging;
+using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Tests.BinderTests
 {
@@ -638,6 +639,39 @@ namespace Uno.UI.Tests.BinderTests
 			SUT.DataContext = source;
 
 			Assert.IsNull(SUT.Tag);
+		}
+
+		[TestMethod]
+		//TODO: Amend this test when Uno correctly supports reentrantly modifying DPs.
+		public void When_Reentrant_Set()
+		{
+			var sut = new TextBox();
+
+			sut.TextChanged += (o, e) =>
+			{
+				sut.Text = "Bob";
+			};
+
+			sut.Text = "Alice";
+
+			Assert.AreEqual("Alice", sut.Text);
+		}
+
+		[TestMethod]
+		//TODO: Amend this test when Uno correctly supports reentrantly modifying DPs.
+		public void When_Reentrant_Set_With_Additional_Set()
+		{
+			var sut = new TextBox();
+
+			sut.TextChanged += (o, e) =>
+			{
+				sut.SetValue(Grid.RowProperty, 0);
+				sut.Text = "Bob";
+			};
+
+			sut.Text = "Alice";
+
+			Assert.AreEqual("Alice", sut.Text);
 		}
 
 		public partial class BaseTarget : DependencyObject

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/MultilineTextBoxView.iOS.cs
@@ -44,6 +44,8 @@ namespace Windows.UI.Xaml.Controls
 			}
 			set
 			{
+				// The native control will ignore a value of null and retain an empty string. We coalesce the null to prevent a spurious empty string getting bounced back via two-way binding.
+				value = value ?? string.Empty;
 				if (base.Text != value)
 				{
 					base.Text = value;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/SinglelineTextBoxView.iOS.cs
@@ -38,6 +38,8 @@ namespace Windows.UI.Xaml.Controls
 
 			set
 			{
+				// The native control will ignore a value of null and retain an empty string. We coalesce the null to prevent a spurious empty string getting bounced back via two-way binding.
+				value = value ?? string.Empty;
 				if (base.Text != value)
 				{
 					base.Text = value;

--- a/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectStore.cs
@@ -579,16 +579,20 @@ namespace Windows.UI.Xaml
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		private void PopCurrentlySettingProperty(DependencyProperty property)
 		{
-			var popped = _currentlySettingPropertyStack.Count > 0
+			var hasStack = _currentlySettingPropertyStack.Count > 0;
+			var popped = hasStack
 				? _currentlySettingPropertyStack.Pop()
 				: _currentlySettingProperty;
 
-			_currentlySettingProperty = null;
+			if (!hasStack)
+			{
+				_currentlySettingProperty = null;
+			}
 
 			if (popped != property && property.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 			{
 				property.Log().DebugFormat(
-					"Invalid stack state for DependecyObject.SetValue()."
+					"Invalid stack state for DependencyObject.SetValue()."
 					, property.Name
 					, _originalObjectType
 				);


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
Fixes infinite 'pingpong' of changing Text values from TextBox in a very specific scenario. Brings us closer to permitting DPs to be changed while they are already changing (allowing features like TextBox.TextChanging to be correctly supported.)

Internal issue: https://nventive.visualstudio.com/Umbrella/_workitems/edit/134026
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
