### PR TITLE
Do not re-create a new instance of sync ctx for each item scheduled on dispatcher

### DIFF
--- a/src/Uno.UWP/UI/Core/CoreDispatcher.cs
+++ b/src/Uno.UWP/UI/Core/CoreDispatcher.cs
@@ -63,12 +63,22 @@ namespace Windows.UI.Core
 			}
 		}
 
-		private int _globalCount;
+		private readonly CoreDispatcherSynchronizationContext _highSyncCtx;
+		private readonly CoreDispatcherSynchronizationContext _normalSyncCtx;
+		private readonly CoreDispatcherSynchronizationContext _lowSyncCtx;
+		private readonly CoreDispatcherSynchronizationContext _idleSyncCtx;
 		private readonly IdleDispatchedHandlerArgs _idleDispatchedHandlerArgs;
-		private object _gate = new object();
+		private readonly object _gate = new object();
+
+		private int _globalCount;
 
 		public CoreDispatcher()
 		{
+			_highSyncCtx = new CoreDispatcherSynchronizationContext(this, CoreDispatcherPriority.High);
+			_normalSyncCtx = new CoreDispatcherSynchronizationContext(this, CoreDispatcherPriority.Normal);
+			_lowSyncCtx = new CoreDispatcherSynchronizationContext(this, CoreDispatcherPriority.Low);
+			_idleSyncCtx = new CoreDispatcherSynchronizationContext(this, CoreDispatcherPriority.Idle);
+
 			_idleDispatchedHandlerArgs = new IdleDispatchedHandlerArgs(() => IsQueueIdle);
 
 			Initialize();
@@ -247,7 +257,7 @@ namespace Windows.UI.Core
 
 						using (runActivity)
 						{
-                            using (CoreDispatcherSynchronizationContext.Apply(this, operationPriority))
+                            using (GetSyncContext(operationPriority).Apply())
                             {
                                 operation.Action();
                                 operation.Complete();
@@ -275,6 +285,18 @@ namespace Windows.UI.Core
 			else
 			{
 				throw new InvalidOperationException("Dispatch queue is empty");
+			}
+		}
+
+		private CoreDispatcherSynchronizationContext GetSyncContext(CoreDispatcherPriority priority)
+		{
+			switch (priority)
+			{
+				case CoreDispatcherPriority.High: return _highSyncCtx;
+				case CoreDispatcherPriority.Normal: return _normalSyncCtx;
+				case CoreDispatcherPriority.Low: return _lowSyncCtx;
+				case CoreDispatcherPriority.Idle: return _idleSyncCtx;
+				default: throw new ArgumentOutOfRangeException(nameof(priority));
 			}
 		}
 	}

--- a/src/Uno.UWP/UI/Core/CoreDispatcherSynchronizationContext.cs
+++ b/src/Uno.UWP/UI/Core/CoreDispatcherSynchronizationContext.cs
@@ -9,10 +9,10 @@ namespace Windows.UI.Core
     /// <summary>
     /// Provides a CoreDispatched Synchronization context, to allow for async methods to keep the dispatcher priority.
     /// </summary>
-    internal class CoreDispatcherSynchronizationContext : SynchronizationContext
+    internal sealed class CoreDispatcherSynchronizationContext : SynchronizationContext
     {
-        private CoreDispatcher _dispatcher;
-        private CoreDispatcherPriority _priority;
+        private readonly CoreDispatcher _dispatcher;
+        private readonly CoreDispatcherPriority _priority;
 
         public CoreDispatcherSynchronizationContext(CoreDispatcher dispatcher, CoreDispatcherPriority priority)
         {
@@ -43,14 +43,12 @@ namespace Windows.UI.Core
         /// <summary>
         /// Creates a scoped assignment of <see cref="SynchronizationContext.Current"/>.
         /// </summary>
-        /// <param name="dispatcher"></param>
-        /// <param name="priority"></param>
         /// <returns></returns>
-        public static IDisposable Apply(CoreDispatcher dispatcher, CoreDispatcherPriority priority)
+        public IDisposable Apply()
         {
             var current = SynchronizationContext.Current;
 
-            SetSynchronizationContext(new CoreDispatcherSynchronizationContext(dispatcher, priority));
+            SetSynchronizationContext(this);
 
             return Disposable.Create(() => SetSynchronizationContext(current));
         }


### PR DESCRIPTION
Do not re-create a new instance of `CoreDispatcherSynchronizationContext` for each scheduled item.

This reduce pressure on the GC, and also allows the `Task` engine to run continuations synchronously instead of systematically post them to the sync ctx.

## PR Type
- Refactoring (no functional changes, no api changes) 

## What is the current behavior?
A new `CoreDispatcherSynchronizationContext` is created each time a scheduled item is being executed, and we run continuations synchronously if an item is post on this sync ctx from the UI thread.

## What is the new behavior?
We re-use a single instance of `CoreDispatcherSynchronizationContext` per priority. This allows the `Task` engine to validate by its own the needs to post the next continuation, or if it can run it synchronously.

As the `CoreDispatcherSynchronizationContext` already runs posted items synchronously if already on UI thread, this commit should not introduce any behavior change. It's only reducing the indirections in the task engine, and reduces the pressure on the GC.

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
