### PR TITLE
Setting the ItemsPanel before the Template, DVM workaround

### DIFF
--- a/src/Uno.UI/UI/Xaml/Style/Generic/GenericStyles.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/GenericStyles.Android.cs
@@ -238,14 +238,15 @@ namespace Windows.UI.Xaml
 			{
 				Setters =
 				{
-					new Setter<FlipView>("Template", t =>
-						t.Template = new ControlTemplate(() =>
-							new ItemsPresenter()
-						)
-					),
 					new Setter<FlipView>("ItemsPanel", t=>
 						t.ItemsPanel = new ItemsPanelTemplate(()=>
 							new NativePagedView()
+						)
+					),
+
+					new Setter<FlipView>("Template", t =>
+						t.Template = new ControlTemplate(() =>
+							new ItemsPresenter()
 						)
 					)
 				}


### PR DESCRIPTION
Done in order to prevent DVM from crashing on Android, with Umbrella 3.0

## PR Type
Bugfix
