### PR TITLE
[iOS] Improve Image performance with remote urls

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -14,3 +14,4 @@
  * 134104 [iOS] Fixed an issue when back swiping from a page with a collapsed CommandBar
  * 134026 [iOS] Setting a different DP from TextBox.TextChanging can cause an infinite 'ping pong' of changing Text values
  * 134415 [iOS] MenuFlyout was not loaded correctly, causing templates containing a MenuFlyout to fail
+ * 133247 [iOS] Image performance improvements

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.cs
@@ -192,6 +192,15 @@ namespace Windows.UI.Xaml.Controls
 			_imageFetchDisposable.Disposable = cd;
 		}
 
+		private void Execute(Func<CancellationToken, Task> handler)
+		{
+			var cd = new CancellationDisposable();
+
+			var dummy = handler(cd.Token);
+
+			_imageFetchDisposable.Disposable = cd;
+		}
+
 		/// <summary>
 		/// True if horizontally stretched within finite container, or defined by this.Width
 		/// </summary>

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.iOS.cs
@@ -130,7 +130,7 @@ namespace Windows.UI.Xaml.Controls
 						}
 					};
 
-					Dispatch(scheduledFetch);
+					Execute(scheduledFetch);
 				}
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.iOS.cs
@@ -102,6 +102,11 @@ namespace Windows.UI.Xaml.Media
 			   )
 			)
 			{
+				if (ct.IsCancellationRequested)
+				{
+					return null;
+				}
+
 				if (Stream != null)
 				{
 					Stream.Position = 0;

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.iOS.cs
@@ -25,17 +25,15 @@ namespace Windows.UI.Xaml.Media
 
 		static ImageSource()
 		{
-			// The CheckForIllegalCrossThreadCalls field is not thread safe and cannot be changed on the fly.
-			// See https://bugzilla.xamarin.com/show_bug.cgi?id=40520 for more details.
-			SupportsAsyncFromBundle = UIDevice.CurrentDevice.CheckSystemVersion(9, 0) && !UIApplication.CheckForIllegalCrossThreadCalls;
-			SupportsFromBundle = UIDevice.CurrentDevice.CheckSystemVersion(8, 0);			
+			SupportsAsyncFromBundle = UIDevice.CurrentDevice.CheckSystemVersion(9, 0);
+			SupportsFromBundle = UIDevice.CurrentDevice.CheckSystemVersion(8, 0);
 		}
 
 		protected ImageSource()
 		{
 			UseTargetSize = true;
-            InitializeDownloader();
-        }
+			InitializeDownloader();
+		}
 
 		protected ImageSource(UIImage image)
 		{
@@ -157,8 +155,7 @@ namespace Windows.UI.Xaml.Media
 
 					if (SupportsAsyncFromBundle)
 					{
-						// Since iOS9, UIImage.FromBundle is thread safe, so we need to disable 
-						// the Xamarin binding check, which is unconditional.
+						// Since iOS9, UIImage.FromBundle is thread safe.
 						ImageData = UIImage.FromBundle(localFileUri.LocalPath);
 					}
 					else


### PR DESCRIPTION
<!-- Link to relevant issue. All PRs should be asociated with an issue -->
Internal issue https://nventive.visualstudio.com/Umbrella/_workitems/edit/133247

Image performance improvements on iOS:
 - don't dispatch unnecessarily
 - don't download images on UI thread in debug builds