### PR TITLE
Fix MenuFlyoutItemExtensions being linked out in iOS

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -13,3 +13,4 @@
  * 134132 [Android] Fix loading of ItemsPresenter
  * 134104 [iOS] Fixed an issue when back swiping from a page with a collapsed CommandBar
  * 134026 [iOS] Setting a different DP from TextBox.TextChanging can cause an infinite 'ping pong' of changing Text values
+ * 134415 [iOS] MenuFlyout was not loaded correctly, causing templates containing a MenuFlyout to fail

--- a/src/Uno.UI.Toolkit/MenuFlyoutItemExtensions.cs
+++ b/src/Uno.UI.Toolkit/MenuFlyoutItemExtensions.cs
@@ -8,7 +8,12 @@ using Windows.UI.Xaml.Controls;
 
 namespace Uno.UI.Toolkit
 {
-    public static class MenuFlyoutItemExtensions
+#if __IOS__
+	[Foundation.PreserveAttribute(AllMembers = true)]
+#elif __ANDROID__
+	[Android.Runtime.PreserveAttribute(AllMembers = true)]
+#endif
+	public static class MenuFlyoutItemExtensions
 	{
 		#region IsDestructive
 


### PR DESCRIPTION
## PR Type
Bugfix

## What is the current behavior?
MenuFlyout does not load correctly on iOS. If a template contains a MenuFlyout at any level, the template is not loaded (what is displayed is the default TextBlock with DataContext.ToString()).

## What is the new behavior?
MenuFlyout is correctly loaded.

## Other information
Internal work item: 134415