### PR TITLE
Add a CommandBarHelper that allows apps to use CommanBar without using a Frame

### DIFF
--- a/doc/articles/working-with-commandbar.md
+++ b/doc/articles/working-with-commandbar.md
@@ -295,6 +295,12 @@ To ensure everything works properly, you must follow a few rules:
 * The `CommandBar` must be accessible as soon as the page is being navigated to (i.e., don't put it inside a `DataTemplate` or an `AsyncValuePresenter`).
 * There can only be one `CommandBar` per page.
 
+## Extensibility
+
+The `CommandBar` it automatically managed by the `Frame` control, however you can still use the "native" mode of the `CommandBar` with your own navigation mechanisim.
+
+On **iOS** a `CommandBarHelper` is available for this purpose, you only have to invoke each of the provided method in your own `UIViewController` implementation.
+
 # AppBarButton
 
 The `AppBarButton` in **Uno** is designed to be used the same way you would use the `AppBarButton` on **UWP**. In most cases, you should refer to the [official `CommandBar` documentation](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.appbarbutton).

--- a/src/Uno.UI/Controls/CommandBarHelper.iOS.cs
+++ b/src/Uno.UI/Controls/CommandBarHelper.iOS.cs
@@ -1,0 +1,107 @@
+﻿#if __IOS__
+using System;
+using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using UIKit;
+
+namespace Uno.UI.Controls
+{
+	public static class CommandBarHelper
+	{
+		internal static void SetNavigationBar(CommandBar commandBar, UIKit.UINavigationBar navigationBar)
+		{
+			commandBar.GetRenderer(() => new CommandBarRenderer(commandBar)).Native = navigationBar;
+		}
+
+		internal static void SetNavigationItem(CommandBar commandBar, UIKit.UINavigationItem navigationItem)
+		{
+			commandBar.GetRenderer(() => new CommandBarNavigationItemRenderer(commandBar)).Native = navigationItem;
+		}
+
+		/// <summary>
+		/// Finds and configures the <see cref="CommandBar" /> for a given page <see cref="UIViewController" />.
+		/// </summary>
+		/// <param name="pageController">The controller of the page</param>
+		public static void PageCreated(UIViewController pageController)
+		{
+			var topCommandBar = pageController.FindTopCommandBar();
+			if (topCommandBar == null)
+			{
+				// The default CommandBar style contains information that might be relevant to all pages, including those without a CommandBar.
+				// For example the Uno.UI.Toolkit.CommandBarExtensions.BackButtonTitle attached property is often set globally to "" through 
+				// a default CommandBar style in order to remove the back button text throughout an entire application.
+				// In order to leverage this information, we create a new CommandBar instance that only exists to "render" the NavigationItem.
+				topCommandBar = new CommandBar();
+			}
+
+			// Hook CommandBar to NavigationItem
+			SetNavigationItem(topCommandBar, pageController.NavigationItem);
+		}
+
+		/// <summary>
+		/// Cleanups the <see cref="CommandBar" /> of a page <see cref="UIViewController" />.
+		/// </summary>
+		/// <param name="pageController">The controller of the page</param>
+		public static void PageDestroyed(UIViewController pageController)
+		{
+			var topCommandBar = pageController.FindTopCommandBar();
+			if (topCommandBar != null)
+			{
+				SetNavigationItem(topCommandBar, null);
+			}
+		}
+
+		/// <summary>
+		/// When a page <see cref="UIViewController" /> will appear, connects the <see cref="CommandBar" /> to the navigation controller.
+		/// </summary>
+		/// <param name="pageController">The controller of the page</param>
+		public static void PageWillAppear(UIViewController pageController)
+		{
+			var topCommandBar = pageController.FindTopCommandBar();
+			if (topCommandBar != null)
+			{
+				// Hook CommandBar to NavigationBar
+				// We do it here because we know the NavigationController is set (and NavigationBar is available)
+				SetNavigationBar(topCommandBar, pageController.NavigationController.NavigationBar);
+
+				// We call this method after rendering the CommandBar to work around buggy behaviour on iOS 11, but we have to make 
+				// sure not to overwrite the visibility set by the renderer.
+				var isHidden = topCommandBar.Visibility == Visibility.Collapsed;
+				pageController.NavigationController.SetNavigationBarHidden(hidden: isHidden, animated: true);
+
+				if (isHidden && pageController.NavigationController.InteractivePopGestureRecognizer != null)
+				{
+					//set a gesture recognizer in the case that the UINavigationBar is hidden
+					var callback = new Uno.UI.Helpers.NativeFramePresenterUIGestureRecognizerDelegate(() => pageController.NavigationController);
+					pageController.NavigationController.InteractivePopGestureRecognizer.Delegate = callback;
+				}
+			}
+			else // No CommandBar
+			{
+				pageController.NavigationController.SetNavigationBarHidden(true, true);
+			}
+		}
+
+		/// <summary>
+		/// When a page <see cref="UIViewController" /> did disappear, disconnects the <see cref="CommandBar" /> from the navigation controller.
+		/// </summary>
+		/// <param name="pageController">The controller of the page</param>
+		public static void PageDidDisappear(UIViewController pageController)
+		{
+			var topCommandBar = pageController.FindTopCommandBar();
+			if (topCommandBar != null)
+			{
+				// Set the native navigation bar to null so it does not render when the page is not visible
+				SetNavigationBar(topCommandBar, null);
+			}
+		}
+
+		private static CommandBar FindTopCommandBar(this UIViewController controller)
+		{
+			return (controller.View as Page)?.TopAppBar as CommandBar
+				?? controller.View.FindFirstChild<CommandBar>();
+		}
+	}
+}
+#endif

--- a/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs
+++ b/src/Uno.UI/Controls/NativeFramePresenter.iOS.cs
@@ -193,20 +193,7 @@ namespace Uno.UI.Controls
 				Page = page;
 				View = Page;
 
-				var topCommandBar = GetCommandBar();
-
-				if (topCommandBar == null)
-				{
-					// The default CommandBar style contains information that might be relevant to all pages, including those without a CommandBar.
-					// For example the Uno.UI.Toolkit.CommandBarExtensions.BackButtonTitle attached property is often set globally to "" through 
-					// a default CommandBar style in order to remove the back button text throughout an entire application.
-					// In order to leverage this information, we create a new CommandBar instance that only exists to "render" the NavigationItem.
-					topCommandBar = new CommandBar();
-				}
-
-				// Hook CommandBar to NavigationItem
-				var navigationCommandBarRenderer = topCommandBar.GetRenderer(() => new CommandBarNavigationItemRenderer(topCommandBar));
-				navigationCommandBarRenderer.Native = NavigationItem;
+				CommandBarHelper.PageCreated(this);
 			}
 
 			public override void ViewWillAppear(bool animated)
@@ -215,29 +202,7 @@ namespace Uno.UI.Controls
 				{
 					base.ViewWillAppear(animated);
 
-					var topCommandBar = GetCommandBar();
-
-					if (topCommandBar != null)
-					{
-						// Hook CommandBar to NavigationBar
-						// We do it here because we know the NavigationController is set (and NavigationBar is available)
-						topCommandBar.GetRenderer(() => new CommandBarRenderer(topCommandBar)).Native = NavigationController.NavigationBar;
-
-						// We call this method after rendering the CommandBar to work around buggy behaviour on iOS 11, but we have to make 
-						// sure not to overwrite the visibility set by the renderer.
-						var isHidden = topCommandBar.Visibility == Visibility.Collapsed;
-						NavigationController.SetNavigationBarHidden(hidden: isHidden, animated: true);
-
-						if (isHidden && NavigationController.InteractivePopGestureRecognizer != null)
-						{
-							//set a gesture recognizer in the case that the UINavigationBar is hidden
-			 				NavigationController.InteractivePopGestureRecognizer.Delegate = new NativeFramePresenterUIGestureRecognizerDelegate(() => NavigationController);
-						}
-					}
-					else // No CommandBar
-					{
-						NavigationController.SetNavigationBarHidden(true, true);
-					}
+					CommandBarHelper.PageWillAppear(this);
 				}
 				catch (Exception e)
 				{
@@ -251,13 +216,7 @@ namespace Uno.UI.Controls
 				{
 					base.ViewDidDisappear(animated);
 
-					var topCommandBar = GetCommandBar();
-
-					// Set the native navigation bar to null so it does not render when the page is not visible
-					if (topCommandBar != null)
-					{
-						topCommandBar.GetRenderer(() => new CommandBarRenderer(topCommandBar)).Native = null;
-					}
+					CommandBarHelper.PageDidDisappear(this);
 				}
 				catch (Exception e)
 				{

--- a/src/Uno.UI/Extensions/UIViewExtensions.iOS.cs
+++ b/src/Uno.UI/Extensions/UIViewExtensions.iOS.cs
@@ -309,20 +309,13 @@ namespace UIKit
 
 			do
 			{
-				var uiView = responder as UIView;
-
-				if (uiView != null)
+				if (responder is UIView uiView)
 				{
 					responder = uiView.NextResponder;
 				}
-				else
+				else if (responder is UIViewController uiViewController)
 				{
-					var uiViewController = responder as UIViewController;
-
-					if (uiViewController != null)
-					{
-						return uiViewController;
-					}
+					return uiViewController;
 				}
 
 			} while (responder != null);


### PR DESCRIPTION

## PR Type
What kind of change does this PR introduce?
 - Feature

## What is the current behavior?
`CommandBar` are tightly coupled to the `Frame` and cannot be used without one.

## What is the new behavior?
We are now able to render a `CommandBar` using a `UINavigationController` not managed by a `Frame`.

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
