### PR TITLE
Fixed and prevented crash caused by a null ItemsPanel in ItemsControl.cs

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -15,3 +15,4 @@
  * 134026 [iOS] Setting a different DP from TextBox.TextChanging can cause an infinite 'ping pong' of changing Text values
  * 134415 [iOS] MenuFlyout was not loaded correctly, causing templates containing a MenuFlyout to fail
  * 133247 [iOS] Image performance improvements
+ * 135112 [Android] Fix crash in UpdateItemsPanelRoot() in the ItemsControl class.

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
@@ -17,6 +17,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 using Android.Views;
 using Uno.UI.Extensions;
+using Uno.Logging;
 using global::Windows.UI.Xaml.Input;
 using Point = Windows.Foundation.Point;
 using Uno.UI;
@@ -40,18 +41,34 @@ namespace <#= mixin.NamespaceName #>
 #if <#= mixin.OverridesAttachedToWindow #>
 		protected override void OnNativeLoaded()
 		{
-			((IDependencyObjectStoreProvider)this).Store.Parent = base.Parent;
-			OnLoading();
-			OnLoaded();
+			try
+			{
+				((IDependencyObjectStoreProvider)this).Store.Parent = base.Parent;
+				OnLoading();
+				OnLoaded();
 
-			base.OnNativeLoaded();
+				base.OnNativeLoaded();
+			}
+			catch (Exception ex)
+			{
+				this.Log().Error("OnNativeLoaded failed in FrameworkElementMixins", ex);
+				Application.Current.RaiseRecoverableUnhandledException(ex);
+			}
 		}
 
 		protected override void OnNativeUnloaded()
 		{
-			OnUnloaded();
+			try
+			{
+				OnUnloaded();
 
-			base.OnNativeUnloaded();
+				base.OnNativeUnloaded();
+			}
+			catch(Exception ex)
+			{
+				this.Log().Error("OnNativeUnloaded failed in FrameworkElementMixins", ex);
+				Application.Current.RaiseRecoverableUnhandledException(ex);
+			}
 		}
 			
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Style/Generic/GenericStyles.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/GenericStyles.Android.cs
@@ -238,16 +238,16 @@ namespace Windows.UI.Xaml
 			{
 				Setters =
 				{
-					new Setter<FlipView>("Template", t =>
-						t.Template = new ControlTemplate(() =>
-							new ItemsPresenter()
-						)
-					),
 					new Setter<FlipView>("ItemsPanel", t=>
 						t.ItemsPanel = new ItemsPanelTemplate(()=>
 							new NativePagedView()
 						)
-					)
+					),
+					new Setter<FlipView>("Template", t =>
+						t.Template = new ControlTemplate(() =>
+							new ItemsPresenter()
+						)
+					)					
 				}
 			};
 


### PR DESCRIPTION
Issue: # 135112
https://nventive.visualstudio.com/Umbrella/_workitems/edit/135112

## PR Type
What kind of change does this PR introduce?
Bugfix 

## What is the current behavior?
In InitFlipView(), ItemsPanel was set after Template, sometimes making ItemsPanel null in the UpdateItemsPanelRoot() method, causing some crashes on runtime, on Android.

## What is the new behavior?
Setting the ItemsPanel before the Template in GenericStyles on Android in order to prevent crashes. Added try-catch statements in IFrameworkElementImplementation for OnNativeLoaded() and OnNativeUnloaded().

## PR Checklist

- [x ] Tested code with current [supported SDKs](../README.md#supported)
- [x ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x ] Contains **NO** breaking changes