### PR TITLE
Added error messages when unsupported characters are in filenames

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/ResourcesGenerator/ResourcesGenerationTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/ResourcesGenerator/ResourcesGenerationTask.cs
@@ -171,6 +171,12 @@ namespace Uno.UI.Tasks.ResourcesGenerator
 			var logicalTargetPath = Path.Combine(localizedDirectory, "strings.xml"); // this path is required by Xamarin
 			var actualTargetPath = Path.Combine(OutputPath, logicalTargetPath);
 
+			string fileName = Path.GetFileName(actualTargetPath);
+			if (fileName.Contains('-'))
+			{
+				this.Log().Error($"Invalid file name: must contain only [a-z0-9_.] {fileName} is invalid");
+			}
+
 			var targetLastWriteTime = new FileInfo(actualTargetPath).LastWriteTimeUtc;
 
 			if (sourceLastWriteTime > targetLastWriteTime)


### PR DESCRIPTION
Issue: #
<!-- Link to relevant issue. All PRs should be asociated with an issue -->
https://github.com/nventive/Uno/issues/228

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently images with dashes "-" in filenames do not work correctly and no message is given.

## What is the new behavior?
An error message is given to indicate that filenames with invalid characters have been included

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
