### PR TITLE
[iOS] ListView - improve ScrollIntoView when ItemTemplateSelector is set

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -18,4 +18,5 @@
  * 135112 [Android] Fix crash in UpdateItemsPanelRoot() in the ItemsControl class.
  * 132014, 134103 [Android] Set the leading edge considering header can push groups out off the screen
  * 131998 [Android] Window bounds set too late
+ * 131768 [iOS] Improve ListView.ScrollIntoView() when ItemTemplateSelector is set
  

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -262,7 +262,7 @@ namespace Windows.UI.Xaml.Controls
 		/// <summary>
 		/// Is item in the range of already-materialized items?
 		/// </summary>
-		private bool IsMaterialized(NSIndexPath itemPath) => itemPath.Compare(_lastMaterializedItem) >= 0;
+		private bool IsMaterialized(NSIndexPath itemPath) => itemPath.Compare(_lastMaterializedItem) <= 0;
 
 		// Consider group header to be materialized if first item in group is materialized
 		private bool IsMaterialized(int section) => section <= _lastMaterializedItem.Section;

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBase.iOS.cs
@@ -558,6 +558,7 @@ namespace Windows.UI.Xaml.Controls
 					if (needsMaterialize)
 					{
 						NativeLayout.InvalidateLayout();
+						NativeLayout.PrepareLayout();
 					}
 
 					var offset = NativeLayout.GetTargetScrollOffset(index, alignment);


### PR DESCRIPTION
Fix sign error in IsMaterialized, call PrepareLayout() so that correct item sizes are set before target scroll offset is calculated.

Issue: #
https://nventive.visualstudio.com/Umbrella/_workitems/edit/131768