### PR TITLE
[iOS] Fixed ImageBrush flash/flickering upon navigation

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -15,6 +15,7 @@
  * 134026 [iOS] Setting a different DP from TextBox.TextChanging can cause an infinite 'ping pong' of changing Text values
  * 134415 [iOS] MenuFlyout was not loaded correctly, causing templates containing a MenuFlyout to fail
  * 133247 [iOS] Image performance improvements
+ * 135192 [iOS] Fixed ImageBrush flash/flickering occurs when transitioning to a new page.
  * 135112 [Android] Fix crash in UpdateItemsPanelRoot() in the ItemsControl class.
  * 132014, 134103 [Android] Set the leading edge considering header can push groups out off the screen
  * 131998 [Android] Window bounds set too late

--- a/src/Uno.UI/UI/Xaml/Media/ImageBrush.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageBrush.iOS.cs
@@ -39,24 +39,29 @@ namespace Windows.UI.Xaml.Media
 			{
 				SetImage(null, failIfNull: false);
 				oldValue?.Dispose();
-
-				_imageScheduler.Disposable = CoreDispatcher.Main.RunAsync(
-					CoreDispatcherPriority.Normal,
-					async ct =>
-					{
-						var image = await Task.Run(async () => await newValue.Open(ct));
-
-						if (ct.IsCancellationRequested)
-						{
-							return;
-						}
-						
-						SetImage(image);
-					});
+				OpenImageAsync(newValue);
 			}
 		}
 
-		private void SetImage(UIImage image,  bool failIfNull = true)
+		private async void OpenImageAsync(ImageSource newValue)
+		{
+			CoreDispatcher.CheckThreadAccess();
+
+			var cd = new CancellationDisposable();
+
+			_imageScheduler.Disposable = cd;
+
+			var image = await Task.Run(async () => await newValue.Open(cd.Token));
+
+			if (cd.Token.IsCancellationRequested)
+			{
+				return;
+			}
+
+			SetImage(image);
+		}
+
+		private void SetImage(UIImage image, bool failIfNull = true)
 		{
 			ImageChanged?.Invoke(image);
 


### PR DESCRIPTION
[iOS] Fixed ImageBrush flash/flickering occurs when transitioning to a new page.

Issue: [https://nventive.visualstudio.com/Umbrella/_workitems/edit/135192](https://nventive.visualstudio.com/Umbrella/_workitems/edit/135192)

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->
- Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
ImageBrush flash/flickering occurs when transitioning to a new page.


## What is the new behavior?
No more ImageBrush flash/flickering occurs when transitioning to a new page

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
