### PR TITLE
ManagedWeakReference - ignore natively-collected targets

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -19,4 +19,5 @@
  * 132014, 134103 [Android] Set the leading edge considering header can push groups out off the screen
  * 131998 [Android] Window bounds set too late
  * 131768 [iOS] Improve ListView.ScrollIntoView() when ItemTemplateSelector is set
+ * 135202, 131884 [Android] Content occasionally fails to show because binding throws an exception
  

--- a/src/Uno.UI/DataBinding/ManagedWeakReference.cs
+++ b/src/Uno.UI/DataBinding/ManagedWeakReference.cs
@@ -5,9 +5,9 @@ using System.Text;
 using Uno.Extensions;
 using Uno.Logging;
 #if __ANDROID__
-using _NativeObject = Android.Runtime.IJavaObject;
+using INativeObject = Android.Runtime.IJavaObject;
 #elif __IOS__
-using _NativeObject = ObjCRuntime.INativeObject;
+using INativeObject = ObjCRuntime.INativeObject;
 #endif
 
 namespace Uno.UI.DataBinding
@@ -127,7 +127,7 @@ namespace Uno.UI.DataBinding
 		/// </summary>
 		private static bool IsNativeAlive(object obj)
 		{
-			if (obj is _NativeObject nativeObj)
+			if (obj is INativeObject nativeObj)
 			{
 				return nativeObj.Handle != IntPtr.Zero;
 			}
@@ -150,12 +150,18 @@ namespace Uno.UI.DataBinding
 			_disposed = true;
 		}
 
+	}
+
 #if !__ANDROID__ && !__IOS__
-		// Dummy interface to compile on WASM and unit tests. (Isn't implemented by anything, so IsNativeAlive will always return true)
-		private interface _NativeObject
+#if NET46
+	public
+#else
+		internal
+#endif
+		// Dummy interface to compile on WASM and unit tests. (On WASM isn't implemented by anything, so IsNativeAlive will always return true)
+	interface INativeObject
 		{
 			IntPtr Handle { get; }
 		}
 #endif
-	}
 }


### PR DESCRIPTION
Don't treat a weak-ref target as alive if it's a managed peer whose underlying object has been collected.

This prevents errors from attempting to apply bindings to a collected object, which seem to be particularly prevalent on Android 8 for ImplicitTextBlocks created by ContentPresenter.

Issue: #
[Android][ListView] Group headers can disappear when using ScrollIntoView behavior. https://nventive.visualstudio.com/Umbrella/_workitems/edit/135202
[Android] Contents of button can disappear after a refresh https://nventive.visualstudio.com/Umbrella/_workitems/edit/131884
