### PR TITLE
[iOS] Removed unecessary async + await in ImageBrush.iOS

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/ImageBrush.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageBrush.iOS.cs
@@ -51,7 +51,7 @@ namespace Windows.UI.Xaml.Media
 
 			_imageScheduler.Disposable = cd;
 
-			var image = await Task.Run(async () => await newValue.Open(cd.Token));
+			var image = await Task.Run(() => newValue.Open(cd.Token));
 
 			if (cd.Token.IsCancellationRequested)
 			{


### PR DESCRIPTION
Related Issue: https://nventive.visualstudio.com/Umbrella/_workitems/edit/135192
Related PR : https://github.com/nventive/Uno/pull/275
<!-- Link to the relevant issue. All PRs should be asociated with an issue -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->
- Refactoring (no functional changes, no api changes)

## What is the current behavior?
Unnecessary async + await in the OpenImageAsync method in ImageBrush.iOS

## What is the new behavior?
Removed unnecessary async + await in the OpenImageAsync method in ImageBrush.iOS

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->
