### PR TITLE
[iOS] ImageSource - use NSUrlSession

### DIFF
--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.iOS.cs
@@ -13,6 +13,7 @@ using UIKit;
 using Uno.Logging;
 using Windows.UI.Core;
 using Uno.Disposables;
+using Microsoft.Extensions.Logging;
 
 namespace Windows.UI.Xaml.Media
 {
@@ -27,6 +28,17 @@ namespace Windows.UI.Xaml.Media
 		{
 			SupportsAsyncFromBundle = UIDevice.CurrentDevice.CheckSystemVersion(9, 0);
 			SupportsFromBundle = UIDevice.CurrentDevice.CheckSystemVersion(8, 0);
+		}
+
+		private static NSUrlSession _defaultSession;
+		/// <summary>
+		/// The <see cref="NSUrlSession"/> to use for remote url downloads, if using the platform downloader.
+		/// By default <see cref="NSUrlSession.SharedSession"/> will be used.
+		/// </summary>
+		public static NSUrlSession DefaultSession
+		{
+			get => _defaultSession ?? NSUrlSession.SharedSession;
+			set => _defaultSession = value;
 		}
 
 		protected ImageSource()
@@ -190,44 +202,65 @@ namespace Windows.UI.Xaml.Media
 		/// </summary>
 		private async Task OpenUsingPlatformDownloader(CancellationToken ct)
 		{
-			if (SupportsAsyncFromBundle)
+			if (ct.IsCancellationRequested)
 			{
-				DownloadUsingPlatformDownloader();
+				return;
 			}
-			else
-			{
-				await CoreDispatcher.Main.RunAsync(
-					CoreDispatcherPriority.Normal,
-					() =>
-					{
-						DownloadUsingPlatformDownloader();
-					}
-				).AsTask(ct);
-			}
-		}
 
-		private void DownloadUsingPlatformDownloader()
-		{
 			using (var url = new NSUrl(WebUri.OriginalString))
 			{
-				NSError error;
-
-				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				using (var request = NSUrlRequest.FromUrl(url))
 				{
-					this.Log().Debug($"Loading image from [{WebUri.OriginalString}]");
-				}
+					NSUrlSessionDataTask task;
+					var awaitable = DefaultSession.CreateDataTaskAsync(request, out task);
+					ct.Register(OnCancel);
+					try
+					{
+						task.Resume(); // We need to call this manually https://bugzilla.xamarin.com/show_bug.cgi?id=28425#c3
+						var result = await awaitable;
+						task = null;
+						var response = result.Response as NSHttpUrlResponse;
 
-				// fallback on the platform's loader
-				using (var data = NSData.FromUrl(url, NSDataReadingOptions.Coordinated, out error))
-				{
-					if (error != null)
-					{
-						this.Log().Error(error.LocalizedDescription);
+						if (ct.IsCancellationRequested)
+						{
+							return;
+						}
+						else if (!IsSuccessful(response.StatusCode))
+						{
+							if (this.Log().IsEnabled(LogLevel.Error))
+							{
+								this.Log().LogError(NSHttpUrlResponse.LocalizedStringForStatusCode(response.StatusCode));
+							}
+
+						}
+						else
+						{
+							ImageData = UIImage.LoadFromData(result.Data);
+						}
 					}
-					else
+					catch (NSErrorException e)
 					{
-						ImageData = UIImage.LoadFromData(data);
+						// This can occur for various reasons: download was cancelled, NSAppTransportSecurity blocks download, host couldn't be resolved...
+						if (ct.IsCancellationRequested)
+						{
+							if (this.Log().IsEnabled(LogLevel.Debug))
+							{
+								this.Log().LogDebug(e.ToString());
+							}
+						}
+						else if (this.Log().IsEnabled(LogLevel.Error))
+						{
+							this.Log().LogError(e.ToString());
+						}
 					}
+
+					void OnCancel()
+					{
+						// Cancel the current download
+						task?.Cancel();
+					}
+
+					bool IsSuccessful(nint status) => status < 300;
 				}
 			}
 		}


### PR DESCRIPTION
When downloading remote urls and no external downloader is set, use NSUrlSession instead of NSData.FromUrl. This enables response caching, download interruption, etc.

Issue: #
Internal: https://nventive.visualstudio.com/Umbrella/_workitems/edit/133247

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
Feature

Improved performance with downloaded images on iOS.
