### PR TITLE
Restore DependencyObjectCollection parameterless constructor

### DIFF
--- a/src/Uno.UI/UI/Xaml/DependencyObjectCollection.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyObjectCollection.cs
@@ -191,7 +191,7 @@ namespace Windows.UI.Xaml
 	/// </summary>
 	public partial class DependencyObjectCollection : DependencyObjectCollection<DependencyObject>
 	{
-		internal DependencyObjectCollection()
+		public DependencyObjectCollection()
 		{
 		}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
Missing parameterless constructor in DependencyObjectCollection, which makes XamlBehaviors fail.

## What is the new behavior?
Restores the missing DependencyObjectCollection constructor
