### PR TITLE
Include navigation bar in the visible bounds calculation

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -8,6 +8,8 @@
 
 ### Breaking changes
 
+* 132002 [Android] The collapsible button bar is now taken into account by visible bounds calculation. Apps which use VisibleBoundsPadding or have command bars will therefore see an adjustment to the height of their windows on Android.
+
 ### Bug fixes
 
  * 129762 - Updated Android SimpleOrientationSensor calculations based on SensorType.Gravity or based on single angle orientation when the device does not have a Gyroscope.

--- a/src/Uno.UI/UI/OnSystemUiVisibilityChangeListener.Android.cs
+++ b/src/Uno.UI/UI/OnSystemUiVisibilityChangeListener.Android.cs
@@ -1,0 +1,37 @@
+﻿#if XAMARIN_ANDROID
+using Android.App;
+using Android.Runtime;
+using Android.Views;
+using Window = Windows.UI.Xaml.Window;
+
+namespace Uno.UI
+{
+	public class OnSystemUiVisibilityChangeListener : Java.Lang.Object, View.IOnSystemUiVisibilityChangeListener
+	{
+		public void OnSystemUiVisibilityChange([GeneratedEnum] StatusBarVisibility visibility)
+		{
+			var activity = ContextHelper.Current as Activity;
+			var decorView = activity.Window.DecorView;
+			var newUiOptions = (int)decorView.SystemUiVisibility;
+
+			if (((int)visibility & (int)SystemUiFlags.HideNavigation) == 0)
+			{
+				newUiOptions &= ~(int)SystemUiFlags.HideNavigation;
+			}
+			else
+			{
+				newUiOptions |= (int)SystemUiFlags.HideNavigation;
+			}
+
+			// We actually don't want to update the decorView.SystemUiVisibility because of the difference between SystemUiFlags.HideNavigation and SystemUiFlags.LayoutHideNavigation
+			// - HideNavigation : User can show the navigation bar by sliding up from the bottom of the screen but it will disappear after 2-3 seconds
+			// - LayoutHideNavigation : User can show the navigation bar by sliding up from the bottom of the screen and have the option to dock it / undock it
+			// In the case we set the navigation bar to LayoutHideNavigation, when the user hide the bar, HideNavigation will be triggered.
+			// But we don't want to inject it in the decorView.SystemUiVisibility to let the navigation bar dockable again
+			Window.Current.SystemUiVisibility = newUiOptions;
+
+			activity.OnConfigurationChanged(activity.Resources.Configuration);
+		}
+	}
+}
+#endif

--- a/src/Uno.UI/UI/Xaml/Controls/Border/Border.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/Border.Android.cs
@@ -52,7 +52,12 @@ namespace Windows.UI.Xaml.Controls
             AddView(newValue);
         }
 
-        private void UpdateBorder()
+		private void UpdateBorder()
+		{
+			UpdateBorder(false);
+		}
+
+		private void UpdateBorder(bool willUpdateMeasures)
         {
             if (IsLoaded)
             {
@@ -62,8 +67,9 @@ namespace Windows.UI.Xaml.Controls
                     BorderThickness,
                     BorderBrush,
                     CornerRadius,
-                    Padding
-                );
+                    Padding,
+					willUpdateMeasures
+				);
             }
         }
 
@@ -93,7 +99,7 @@ namespace Windows.UI.Xaml.Controls
 
         partial void OnPaddingChangedPartial(Thickness oldValue, Thickness newValue)
         {
-            UpdateBorder();
+            UpdateBorder(true);
         }
 
         partial void OnCornerRadiusUpdatedPartial(CornerRadius oldValue, CornerRadius newValue)

--- a/src/Uno.UI/UI/Xaml/Controls/BorderLayerRenderer.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/BorderLayerRenderer.Android.cs
@@ -44,7 +44,8 @@ namespace Windows.UI.Xaml.Controls
 			Thickness borderThickness,
 			Brush borderBrush,
 			CornerRadius cornerRadius,
-			Thickness padding
+			Thickness padding,
+			bool willUpdateMeasures = false
 			)
 		{
 			// This is required because android Height and Width are hidden by Control.
@@ -88,7 +89,14 @@ namespace Windows.UI.Xaml.Controls
 					}
 				}
 
-				view.Invalidate();
+				if (willUpdateMeasures)
+				{
+					view.RequestLayout();
+				}
+				else
+				{
+					view.Invalidate();
+				}
 
 				_currentState = newState;
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.Android.cs
@@ -63,6 +63,11 @@ namespace Windows.UI.Xaml.Controls
 
 		private void UpdateBorder()
 		{
+			UpdateBorder(false);
+		}
+
+		private void UpdateBorder(bool willUpdateMeasures)
+		{
 			if (IsLoaded)
 			{
 				_borderRenderer.UpdateLayers(
@@ -71,9 +76,15 @@ namespace Windows.UI.Xaml.Controls
 					BorderThickness,
 					BorderBrush,
 					CornerRadius,
-					Padding
+					Padding,
+					willUpdateMeasures
 				);
 			}
+		}
+
+		partial void OnPaddingChangedPartial(Thickness oldValue, Thickness newValue)
+		{
+			UpdateBorder(true);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.cs
@@ -445,8 +445,10 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnPaddingChanged(Thickness oldValue, Thickness newValue)
 		{
-			UpdateBorder();
+			OnPaddingChangedPartial(oldValue, newValue);
 		}
+
+		partial void OnPaddingChangedPartial(Thickness oldValue, Thickness newValue);
 
 		#endregion
 

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.iOS.cs
@@ -74,5 +74,10 @@ namespace Windows.UI.Xaml.Controls
 				);
 			}
 		}
+
+		partial void OnPaddingChangedPartial(Thickness oldValue, Thickness newValue)
+		{
+			UpdateBorder();
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.net.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.net.cs
@@ -38,5 +38,10 @@ namespace Windows.UI.Xaml.Controls
 		private void UpdateBorder()
 		{
 		}
+
+		partial void OnPaddingChangedPartial(Thickness oldValue, Thickness newValue)
+		{
+			UpdateBorder();
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ContentPresenter/ContentPresenter.netstd.cs
@@ -41,5 +41,10 @@ namespace Windows.UI.Xaml.Controls
 		{
 			SetBorder(BorderThickness, BorderBrush, CornerRadius);
 		}
+
+		partial void OnPaddingChangedPartial(Thickness oldValue, Thickness newValue)
+		{
+			UpdateBorder();
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Page/NativePage.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Page/NativePage.Android.cs
@@ -13,12 +13,10 @@ namespace Windows.UI.Xaml.Controls
 
 		public NativePage(IntPtr ptr, Android.Runtime.JniHandleOwnership owner) : base(ptr, owner)
 		{
-
 		}
 
 		public NativePage()
 		{
-
 		}
 
 		protected override void OnCreate(Bundle bundle)
@@ -28,6 +26,11 @@ namespace Windows.UI.Xaml.Controls
 			Style = null;
 			
 			InitializeComponent();
+
+			var decorView = (ContextHelper.Current as Android.App.Activity).Window.DecorView;
+
+			Windows.UI.Xaml.Window.Current.SystemUiVisibility = (int)decorView.SystemUiVisibility;
+			decorView.SetOnSystemUiVisibilityChangeListener(new OnSystemUiVisibilityChangeListener());
 		}
 
 		protected override void OnDestroy()

--- a/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.Android.cs
@@ -44,7 +44,12 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void Initialize();
 
-		public void UpdateBorder()
+		private void UpdateBorder()
+		{
+			UpdateBorder(false);
+		}
+
+		private void UpdateBorder(bool willUpdateMeasures)
 		{
 			if (IsLoaded)
 			{
@@ -54,7 +59,8 @@ namespace Windows.UI.Xaml.Controls
 					BorderThickness,
 					BorderBrush,
 					CornerRadius,
-					Padding
+					Padding,
+					willUpdateMeasures
 				);
 			}
 		}
@@ -73,7 +79,7 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnPaddingChangedPartial(Thickness oldValue, Thickness newValue)
 		{
-			UpdateBorder();
+			UpdateBorder(true);
 		}
 
 		partial void OnBorderBrushChangedPartial(Brush oldValue, Brush newValue)

--- a/src/Uno.UI/UI/Xaml/Window.Desktop.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Desktop.cs
@@ -18,11 +18,6 @@ namespace Windows.UI.Xaml
 		{
 		}
 
-		private void InternalActivate()
-		{
-
-		}
-
 		private void InternalSetContent(UIElement value)
 		{
 

--- a/src/Uno.UI/UI/Xaml/Window.cs
+++ b/src/Uno.UI/UI/Xaml/Window.cs
@@ -42,6 +42,8 @@ namespace Windows.UI.Xaml
 			Activated?.Invoke(this, new WindowActivatedEventArgs(CoreWindowActivationState.CodeActivated));
 		}
 
+		partial void InternalActivate();
+
 		public void Close() { }
 
 		public void SetTitleBar(UIElement value) { }

--- a/src/Uno.UI/UI/Xaml/Window.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.iOS.cs
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml
 			RaiseNativeSizeChanged(ViewHelper.GetScreenSize());
 		}
 
-		private void InternalActivate()
+		partial void InternalActivate()
 		{
 			_window.RootViewController = _mainController;
 			_window.MakeKeyAndVisible();

--- a/src/Uno.UI/UI/Xaml/Window.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Window.wasm.cs
@@ -123,7 +123,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		private void InternalActivate()
+		partial void InternalActivate()
 		{
 			WebAssemblyRuntime.InvokeJS("Uno.UI.WindowManager.current.activate();");
 		}


### PR DESCRIPTION
## Issue: 
On few devices, the navigation can be docked / undocked causing bad visible bounds calculation
<!-- Link to relevant issue. All PRs should be asociated with an issue -->
https://nventive.visualstudio.com/Umbrella/_workitems/edit/132002

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
The navigation bar height / visibility is ignored in the visible bounds

## What is the new behavior?
The navigation bar height / visibility is included in the visible bounds

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
