### PR TITLE
Video surface remains black on Android when Source is bound

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -21,4 +21,5 @@
  * 131998 [Android] Window bounds set too late
  * 131768 [iOS] Improve ListView.ScrollIntoView() when ItemTemplateSelector is set
  * 135202, 131884 [Android] Content occasionally fails to show because binding throws an exception
+ * 135646 [Android] Binding MediaPlayerElement.Source causes video to go blank
  

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
@@ -55,6 +55,8 @@ namespace Windows.Media.Playback
 			_noisyAudioStreamReceiver = new AudioPlayerBroadcastReceiver(this);
 			var intentFilter = new IntentFilter(AudioManager.ActionAudioBecomingNoisy);
 			Application.Context.RegisterReceiver(_noisyAudioStreamReceiver, intentFilter);
+
+			InitializePlayer();
 		}
 
 		#region Player Initialization
@@ -68,9 +70,6 @@ namespace Windows.Media.Playback
 					_isPlayRequested = false;
 					_isPlayerPrepared = false;
 					_player.Release();
-
-					var surfaceView = RenderSurface as SurfaceView;
-					surfaceView?.Holder?.RemoveCallback(this);
 				}
 				finally
 				{


### PR DESCRIPTION
Issue: #
https://nventive.visualstudio.com/Umbrella/_workitems/edit/135646

## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
Video surface remains black on Android when Source is bound

## What is the new behavior?
Video plays as expected

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
