### PR TITLE
Implement MediaPlayer.Dispose()

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+* 135799 Implemented MediaPlayer.Dispose()
+
 ### Breaking changes
 
 ### Bug fixes
@@ -22,4 +24,3 @@
  * 131768 [iOS] Improve ListView.ScrollIntoView() when ItemTemplateSelector is set
  * 135202, 131884 [Android] Content occasionally fails to show because binding throws an exception
  * 135646 [Android] Binding MediaPlayerElement.Source causes video to go blank
- 

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlayer.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlayer.cs
@@ -477,7 +477,7 @@ namespace Windows.Media.Playback
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.Media.Playback.MediaPlayer", "void MediaPlayer.RemoveAllEffects()");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__
+		#if false || false || NET46 || __WASM__
 		[global::Uno.NotImplemented]
 		public  void Dispose()
 		{

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
@@ -468,6 +468,7 @@ namespace Windows.Media.Playback
 
 		protected override void Dispose(bool disposing)
 		{
+			TryDisposePlayer();
 			Application.Context.UnregisterReceiver(_noisyAudioStreamReceiver);
 			base.Dispose(disposing);
 		}

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
@@ -380,5 +380,10 @@ namespace Windows.Media.Playback
 		{
 			_videoLayer.VideoGravity = gravity;
 		}
+
+		protected override void Dispose(bool disposing)
+		{
+			TryDisposePlayer();
+		}
 	}
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
Feature implementation

## What is the current behavior?
MediaPlayer.Dispose() is wrongly marked as NotImplemented, which generates a warning in debug/an error in release at build time.

## What is the new behavior?
MediaPlayer.Dispose() can be called, in order to stop the video when you leave its page.

## Other information
Internal work item: 135799