### PR TITLE
FrameworkTemplatePool - expose manual scavenging

### DIFF
--- a/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplate.cs
@@ -16,7 +16,6 @@ namespace Windows.UI.Xaml
 {
 	public partial class FrameworkTemplate : DependencyObject
 	{
-		private static readonly FrameworkTemplatePool _pool = new FrameworkTemplatePool();
 
 		private readonly Func<View> _viewFactory;
 		private readonly int _hashCode;
@@ -50,7 +49,7 @@ namespace Windows.UI.Xaml
 		/// </remarks>
 		internal View LoadContentCached()
 		{
-			return _pool.DequeueTemplate(this);
+			return FrameworkTemplatePool.Instance.DequeueTemplate(this);
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkTemplatePool.cs
@@ -59,6 +59,7 @@ namespace Windows.UI.Xaml
 	/// </remarks>
 	public class FrameworkTemplatePool
 	{
+		internal static FrameworkTemplatePool Instance { get; } = new FrameworkTemplatePool();
 		public static class TraceProvider
 		{
 			public readonly static Guid Id = Guid.Parse("{266B850B-674C-4D3E-9B58-F680BE653E18}");
@@ -84,7 +85,7 @@ namespace Windows.UI.Xaml
 		/// </summary>
 		public static bool IsPoolingEnabled { get; set; } = true;
 
-		internal FrameworkTemplatePool()
+		private FrameworkTemplatePool()
 		{
 			_watch.Start();
 
@@ -95,12 +96,21 @@ namespace Windows.UI.Xaml
 
 		private async void Scavenger(IdleDispatchedHandlerArgs e)
 		{
+			Scavenge(false);
+
+			await Task.Delay(TimeSpan.FromSeconds(30));
+
+			CoreDispatcher.Main.RunIdleAsync(Scavenger);
+		}
+
+		private void Scavenge(bool isManual)
+		{
 			var now = _watch.Elapsed;
 			var removedInstancesCount = 0;
 
 			foreach (var list in _pooledInstances.Values)
 			{
-				removedInstancesCount += list.RemoveAll(t => now - t.CreationTime > TimeToLive);
+				removedInstancesCount += list.RemoveAll(t => isManual || now - t.CreationTime > TimeToLive);
 			}
 
 			if (removedInstancesCount > 0)
@@ -115,14 +125,17 @@ namespace Windows.UI.Xaml
 
 				// Under iOS and Android, we need to force the collection for the GC
 				// to pick up the orphan instances that we've just released.
-
+				
 				GC.Collect();
 			}
-
-			await Task.Delay(TimeSpan.FromSeconds(30));
-
-			CoreDispatcher.Main.RunIdleAsync(Scavenger);
 		}
+
+		/// <summary>
+		/// Release all templates that are currently held by the pool.
+		/// </summary>
+		/// <remarks>The pool will periodically release templates that haven't been reused within the span of <see cref="TimeToLive"/>, so
+		/// normally you shouldn't need to call this method. It may be useful in advanced memory management scenarios.</remarks>
+		public static void Scavenge() => Instance.Scavenge(true);
 
 		internal View DequeueTemplate(FrameworkTemplate template)
 		{


### PR DESCRIPTION
Expose the option to manually release templates that are held by the FrameworkTemplatePool.

This permits a work around for https://bugzilla.xamarin.com/show_bug.cgi?id=54120 in a specific instance.

Issue: #
https://nventive.visualstudio.com/Umbrella/_workitems/edit/135822

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
