### PR TITLE
[iOS] Ensures the back gesture is enabled and disabled properly when the CommandBar is visible, collapsed, visible with a navigation command and collapsed with a navigation command.

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -26,3 +26,4 @@
  * 131768 [iOS] Improve ListView.ScrollIntoView() when ItemTemplateSelector is set
  * 135202, 131884 [Android] Content occasionally fails to show because binding throws an exception
  * 135646 [Android] Binding MediaPlayerElement.Source causes video to go blank
+ * 134819, 134828 [iOS] Ensures the back gesture is enabled and disabled properly when the CommandBar is visible, collapsed, visible with a navigation command and collapsed with a navigation command. 

--- a/doc/articles/working-with-commandbar.md
+++ b/doc/articles/working-with-commandbar.md
@@ -269,7 +269,10 @@ Unlike the `PrimaryCommands` or `SecondaryCommands`, which appear to the right o
 
 This is typically used for burger menus.
 
-Setting `NavigationCommand` on pages with a back button will replace it (and disable the back gesture on **iOS**).
+On **iOS**, the back gesture can be enabled or disabled using this property.
+
+- When a `CommandBar` (visible or collapsed) is in the visual tree, the back gesture is **enabled**.
+- When a `CommandBar` has a `NavigationCommand`, the back gesture is **disabled**.
 
 On **Android**, only icons are supported (`AppBarButton.Icon`). This is due to a platform limitation, which can be explained by the fact that `CommandBar.Content` is left-aligned.
 


### PR DESCRIPTION
[iOS] Ensures the back gesture is enabled and disabled properly when the CommandBar is visible, collapsed, visible with a navigation command and collapsed with a navigation command.

Issue:
https://nventive.visualstudio.com/Umbrella/_workitems/edit/134819
https://nventive.visualstudio.com/Umbrella/_workitems/edit/134828