### PR TITLE
[Android] Fixed ImageBrush flash/flickering upon first navigation

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -27,3 +27,4 @@
  * 135202, 131884 [Android] Content occasionally fails to show because binding throws an exception
  * 135646 [Android] Binding MediaPlayerElement.Source causes video to go blank
  * 134819, 134828 [iOS] Ensures the back gesture is enabled and disabled properly when the CommandBar is visible, collapsed, visible with a navigation command and collapsed with a navigation command. 
+ * 135258 [Android] Fixed ImageBrush flash/flickering occurs when transitioning to a new page for the first time.

--- a/src/Uno.UI/UI/Xaml/Media/ImageBrush.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageBrush.Android.cs
@@ -49,12 +49,7 @@ namespace Windows.UI.Xaml.Media
 			{
 				if (ImageSource != null)
 				{
-					_refreshPaint.Disposable =
-						CoreDispatcher.Main
-						.RunAsync(
-							CoreDispatcherPriority.Normal,
-							async (ct) => await RefreshImage(ct, drawRect
-						));
+					RefreshImageAsync(drawRect);
 				}
 				else
 				{
@@ -63,6 +58,17 @@ namespace Windows.UI.Xaml.Media
 				_imageSourceChanged = false;
 				_lastDrawRect = drawRect;
 			}
+		}
+
+		private async void RefreshImageAsync(Windows.Foundation.Rect drawRect)
+		{
+			CoreDispatcher.CheckThreadAccess();
+
+			var cd = new CancellationDisposable();
+
+			_refreshPaint.Disposable = cd;
+
+			await RefreshImage(cd.Token, drawRect);
 		}
 
 		private async Task RefreshImage(CancellationToken ct, Windows.Foundation.Rect drawRect)
@@ -81,7 +87,7 @@ namespace Windows.UI.Xaml.Media
 						OnImageFailed();
 					}
 				}
-				catch(Exception ex)
+				catch (Exception ex)
 				{
 					this.Log().Error("RefreshImage failed", ex);
 					OnImageFailed();
@@ -218,7 +224,7 @@ namespace Windows.UI.Xaml.Media
 
 			var sourceRect = new Foundation.Rect(0, 0, bitmap.Width, bitmap.Height);
 			var destinationRect = GetArrangedImageRect(sourceRect.Size, drawRect);
-			
+
 			matrix.SetRectToRect(sourceRect.ToRectF(), destinationRect.ToRectF(), Android.Graphics.Matrix.ScaleToFit.Fill);
 
 			RelativeTransform?.ToNativeTransform(matrix, new Size(drawRect.Width, drawRect.Height), isBrush: true);


### PR DESCRIPTION
Issue: https://nventive.visualstudio.com/Umbrella/_workitems/edit/135258

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix 


## What is the current behavior?
ImageBrush flash/flickering occurs when transitioning to a new page for the first time on Android.


## What is the new behavior?
No more ImageBrush flash/flickering occurs when transitioning to a new page for the first time on Android.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
