### PR TITLE
[iOS] ScrollIntoView - cancel previous dispatched scrolls

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -28,3 +28,4 @@
  * 135646 [Android] Binding MediaPlayerElement.Source causes video to go blank
  * 134819, 134828 [iOS] Ensures the back gesture is enabled and disabled properly when the CommandBar is visible, collapsed, visible with a navigation command and collapsed with a navigation command. 
  * 135258 [Android] Fixed ImageBrush flash/flickering occurs when transitioning to a new page for the first time.
+ * 131768 [iOS] Fixed bug where stale ScrollIntoView() request could overwrite more recent request


### PR DESCRIPTION
Ensure any dispatched requests are cancelled when ScrollIntoView is called, this prevents stale scroll requests being applied over the top of more recent requests.

Issue: #
https://nventive.visualstudio.com/Umbrella/_workitems/edit/131768