### PR TITLE
[iOS] ListView - fix ScrollIntoView for ungrouped lists

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -29,3 +29,4 @@
  * 134819, 134828 [iOS] Ensures the back gesture is enabled and disabled properly when the CommandBar is visible, collapsed, visible with a navigation command and collapsed with a navigation command. 
  * 135258 [Android] Fixed ImageBrush flash/flickering occurs when transitioning to a new page for the first time.
  * 131768 [iOS] Fixed bug where stale ScrollIntoView() request could overwrite more recent request
+ * 136092 [iOS] ScrollIntoView() throws exception for ungrouped lists

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -1273,7 +1273,7 @@ namespace Windows.UI.Xaml.Controls
 		/// <summary>
 		/// Get extent added by sticky group header for given section, if any.
 		/// </summary>
-		private nfloat GetStickyHeaderExtent(int section) => AreStickyGroupHeadersEnabled && RelativeGroupHeaderPlacement == RelativeHeaderPlacement.Inline ?
+		private nfloat GetStickyHeaderExtent(int section) => XamlParent.IsGrouping && AreStickyGroupHeadersEnabled && RelativeGroupHeaderPlacement == RelativeHeaderPlacement.Inline ?
 			GetExtent(_inlineHeaderFrames[section].Size) :
 			0;
 


### PR DESCRIPTION
Ensure to only check for group header size when source is actually grouped. Fixes exception when calling ScrollIntoView().

Issue: #
https://nventive.visualstudio.com/Umbrella/_workitems/edit/136092