### PR TITLE
[iOS] Fix Popup bug where children lose TemplatedParent

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -26,7 +26,9 @@
  * 131768 [iOS] Improve ListView.ScrollIntoView() when ItemTemplateSelector is set
  * 135202, 131884 [Android] Content occasionally fails to show because binding throws an exception
  * 135646 [Android] Binding MediaPlayerElement.Source causes video to go blank
+ * 136093, 136172 [iOS] ComboBox does not display its Popup
  * 134819, 134828 [iOS] Ensures the back gesture is enabled and disabled properly when the CommandBar is visible, collapsed, visible with a navigation command and collapsed with a navigation command. 
  * 135258 [Android] Fixed ImageBrush flash/flickering occurs when transitioning to a new page for the first time.
  * 131768 [iOS] Fixed bug where stale ScrollIntoView() request could overwrite more recent request
  * 136092 [iOS] ScrollIntoView() throws exception for ungrouped lists
+ * 131768 [iOS] Fixed bug where stale ScrollIntoView() request could overwrite more recent request

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.iOS.cs
@@ -26,12 +26,6 @@ namespace Windows.UI.Xaml.Controls
 				if (_mainWindow == null)
 				{
 					_mainWindow = UIApplication.SharedApplication.KeyWindow ?? UIApplication.SharedApplication.Windows[0];
-
-					PopupPanel = new PopupPanel(this);
-
-					MainWindow.AddSubview(PopupPanel);
-
-					UpdateDismissTriggers();
 				}
 
 				return _mainWindow;
@@ -77,7 +71,13 @@ namespace Windows.UI.Xaml.Controls
 
 		private void RegisterPopupPanel()
 		{
-			if (PopupPanel?.Superview == null)
+			if (PopupPanel == null)
+			{
+				PopupPanel = new PopupPanel(this);
+				UpdateDismissTriggers();
+			}
+
+			if (PopupPanel.Superview == null)
 			{
 				MainWindow.AddSubview(PopupPanel);
 			}

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.iOS.cs
@@ -55,6 +55,12 @@ namespace Windows.UI.Xaml.Controls
 			{
 				if (Child != null)
 				{
+					// Make sure that the child does not find itself without a TemplatedParent
+					if (PopupPanel.TemplatedParent == null)
+					{
+						PopupPanel.TemplatedParent = TemplatedParent;
+					}
+
 					PopupPanel.AddSubview(Child);
 				}
 


### PR DESCRIPTION
## PR Type

Bugfix

## What is the current behavior?
ComboBox on iOS does not display its Popup

## What is the new behavior?
ComboBox on iOS now displays its Popup

## Other information
Internal issues: 136093  & 136172 