### PR TITLE
[iOS] Fix visible bounds calculation and Navigation bar size

### DIFF
--- a/src/Uno.UI/Controls/RootViewController.iOS.cs
+++ b/src/Uno.UI/Controls/RootViewController.iOS.cs
@@ -10,6 +10,8 @@ namespace Uno.UI.Controls
 {
     public class RootViewController : UINavigationController, IRotationAwareViewController
     {
+		internal event Action VisibleBoundsChanged;
+
 		public RootViewController()
 		{
 			// Dismiss on device rotation: this reproduces the windows behavior
@@ -19,6 +21,13 @@ namespace Uno.UI.Controls
 			// Dismiss when the app is entering background
 			UIApplication.Notifications
 				.ObserveWillResignActive((sender, args) => VisualTreeHelper.CloseAllPopups());
+		}
+
+		// This will handle when the status bar is showed / hidden by the system on iPhones
+		public override void ViewSafeAreaInsetsDidChange()
+		{
+			base.ViewSafeAreaInsetsDidChange();
+			VisibleBoundsChanged?.Invoke();
 		}
 
 		public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations()

--- a/src/Uno.UI/UI/Xaml/Window.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.iOS.cs
@@ -42,7 +42,7 @@ namespace Windows.UI.Xaml
 			_mainController = ViewControllerGenerator?.Invoke() ?? new RootViewController();
 			_mainController.View.BackgroundColor = UIColor.White;
 			_mainController.NavigationBarHidden = true;
-
+			
 			ObserveOrientationAndSize();
 
 			Dispatcher = CoreDispatcher.Main;
@@ -66,9 +66,12 @@ namespace Windows.UI.Xaml
 			_window.FrameChanged +=
 				() => RaiseNativeSizeChanged(ViewHelper.GetScreenSize());
 
+			_mainController.VisibleBoundsChanged +=
+				() => RaiseNativeSizeChanged(ViewHelper.GetScreenSize());
+
 			var statusBar = StatusBar.GetForCurrentView();
-			statusBar.Showing += (o, e) => UpdateCoreBounds();
-			statusBar.Hiding += (o, e) => UpdateCoreBounds();
+			statusBar.Showing += (o, e) => RaiseNativeSizeChanged(ViewHelper.GetScreenSize());
+			statusBar.Hiding += (o, e) => RaiseNativeSizeChanged(ViewHelper.GetScreenSize());
 
 			RaiseNativeSizeChanged(ViewHelper.GetScreenSize());
 		}
@@ -125,30 +128,21 @@ namespace Windows.UI.Xaml
 		{
 			var newBounds = new Rect(0, 0, size.Width, size.Height);
 
+			var applicationView = ApplicationView.GetForCurrentView();
+			if (applicationView != null)
+			{
+				applicationView.SetCoreBounds(_window, newBounds);
+			}
+
 			if (Bounds != newBounds)
 			{
 				Bounds = newBounds;
-
-				var applicationView = ApplicationView.GetForCurrentView();
-				if (applicationView != null)
-				{
-					applicationView.SetCoreBounds(_window, newBounds);
-				}
 
 				RaiseSizeChanged(
 					new WindowSizeChangedEventArgs(
 						new Windows.Foundation.Size((float)size.Width, (float)size.Height)
 					)
 				);
-			}
-		}
-
-		private void UpdateCoreBounds()
-		{
-			var applicationView = ApplicationView.GetForCurrentView();
-			if (applicationView != null)
-			{
-				applicationView.SetCoreBounds(_window, Bounds);
 			}
 		}
 

--- a/src/Uno.UWP/UI/ViewManagement/ApplicationView.iOS.cs
+++ b/src/Uno.UWP/UI/ViewManagement/ApplicationView.iOS.cs
@@ -9,40 +9,44 @@ using Windows.UI.Core;
 
 namespace Windows.UI.ViewManagement
 {
-    partial class ApplicationView
+	partial class ApplicationView
 	{
 		private static bool UseSafeAreaInsets => UIDevice.CurrentDevice.CheckSystemVersion(11, 0);
 
 		internal void SetCoreBounds(UIKit.UIWindow keyWindow, Foundation.Rect windowBounds)
 		{
-            var statusBarHeight = UIApplication.SharedApplication.StatusBarFrame.Size.Height;
+			var inset = UseSafeAreaInsets
+					? keyWindow.SafeAreaInsets
+					: new UIEdgeInsets(0, 0, 0, 0);
 
-			UIEdgeInsets inset = new UIEdgeInsets(statusBarHeight, 0, 0, 0);
 			// Not respecting its own documentation. https://developer.apple.com/documentation/uikit/uiview/2891103-safeareainsets?language=objc
-			// iOS returns all zeros for SafeAreaInsets on non-iPhoneX phones. (ignoring nav bars or status bars)
-			// For that reason, we will set the window's visible bounds to the SafeAreaInsets only for iPhones with notches,
-			// other phones will have insets that consider the status bar
-			if (UseSafeAreaInsets)
+			// iOS returns all zeros for SafeAreaInsets on non-iPhones. (ignoring nav bars or status bars)
+			// So we need to update the top inset depending of the status bar visibilty on other devices
+			if (UIDevice.CurrentDevice.UserInterfaceIdiom != UIUserInterfaceIdiom.Phone)
 			{
-				if (keyWindow.SafeAreaInsets != UIEdgeInsets.Zero) // if we have a notch
-				{
-					inset = keyWindow.SafeAreaInsets;
-				}
+				inset.Top = UIApplication.SharedApplication.StatusBarHidden
+					? 0
+					: UIApplication.SharedApplication.StatusBarFrame.Size.Height;
 			}
 
-            VisibleBounds = new Foundation.Rect(
+			var newVisibleBounds = new Foundation.Rect(
 				x: windowBounds.Left + inset.Left,
 				y: windowBounds.Top + inset.Top,
 				width: windowBounds.Width - inset.Right - inset.Left,
 				height: windowBounds.Height - inset.Top - inset.Bottom
 			);
 
-			if(this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+			if (VisibleBounds != newVisibleBounds)
 			{
-				this.Log().Debug($"Updated visible bounds {VisibleBounds}, SafeAreaInsets: {inset}");
-			}
+				VisibleBounds = newVisibleBounds;
 
-			VisibleBoundsChanged?.Invoke(this, null);
+				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				{
+					this.Log().Debug($"Updated visible bounds {VisibleBounds}, SafeAreaInsets: {inset}");
+				}
+
+				VisibleBoundsChanged?.Invoke(this, null);
+			}
 		}
 
 		public bool TryEnterFullScreenMode()


### PR DESCRIPTION
## Issue
<!-- Link to relevant issue. All PRs should be asociated with an issue -->
The navigation bar can have different size depending of orientation and screen size, also impacting visible bounds

https://nventive.visualstudio.com/Umbrella/_workitems/edit/134573

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Different sizes are not handled as it should be

## What is the new behavior?
Different sizes are handled as it should be

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
