### PR TITLE
Allow tap to dismiss controls + reduce flickers

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -5,6 +5,7 @@
 ### Features
 
 * 135799 Implemented MediaPlayer.Dispose()
+* 136259 Add a behavior so that tap makes controls fade out
 
 ### Breaking changes
 

--- a/doc/articles/MediaPlayerElement.md
+++ b/doc/articles/MediaPlayerElement.md
@@ -89,4 +89,3 @@ Add the folowwing to your AndroidManifest.xml
 - `[iOS]` Volume flyout does not display (Uno issue)
 - `[All]` Dynamic width/height not supported when playing audio
 - `[All]` Sometimes flickers during resizing when using dynamic width/height
-- `[Android]` Poster image disappears when putting video to fullscreen

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControls.cs
@@ -99,6 +99,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private Timer _controlsVisibilityTimer;
 		private bool _wasPlaying;
+		private bool _isInteractive;
 		private MediaPlayerElement _mpe;
 
 		public MediaTransportControls() : base()
@@ -269,14 +270,18 @@ namespace Windows.UI.Xaml.Controls
 
 		public void Show()
 		{
+			_isInteractive = true;
+
 			Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 			{
 				VisualStateManager.GoToState(this, "ControlPanelFadeIn", false);
 			});
 		}
-		
+
 		public void Hide()
 		{
+			_isInteractive = false;
+
 			Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 			{
 				if (_mediaPlayer.PlaybackSession.PlaybackState == MediaPlaybackState.Buffering || _mediaPlayer.PlaybackSession.PlaybackState == MediaPlaybackState.Playing)
@@ -288,11 +293,19 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnRootGridTapped(object sender, TappedRoutedEventArgs e)
 		{
-			Show();
-
-			if (ShowAndHideAutomatically)
+			if (_isInteractive)
 			{
-				ResetControlsVisibilityTimer();
+				_controlsVisibilityTimer.Stop();
+				Hide();
+			}
+			else
+			{
+				Show();
+
+				if (ShowAndHideAutomatically)
+				{
+					ResetControlsVisibilityTimer();
+				}
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -8254,6 +8254,7 @@
 											  IsFullWindow="{TemplateBinding IsFullWindow}"
 											  Stretch="{TemplateBinding Stretch}"
 											  MediaPlayer="{TemplateBinding MediaPlayer}"
+											  Visibility="Collapsed"
 											  Background="Black" />
 						<ContentPresenter x:Name="TransportControlsPresenter"
 										  Visibility="{TemplateBinding AreTransportControlsEnabled}" />

--- a/src/Uno.UI/UI/Xaml/Window.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Android.cs
@@ -160,11 +160,13 @@ namespace Windows.UI.Xaml
 			if (element == null)
 			{
 				_fullWindow.Child = null;
+				_rootBorder.Visibility = Visibility.Visible;
 				_fullWindow.Visibility = Visibility.Collapsed;
 			}
 			else
 			{
 				_fullWindow.Visibility = Visibility.Visible;
+				_rootBorder.Visibility = Visibility.Collapsed;
 				_fullWindow.Child = element;
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Window.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.iOS.cs
@@ -151,11 +151,13 @@ namespace Windows.UI.Xaml
 			if (element == null)
 			{
 				_fullWindow.Child = null;
+				_rootBorder.Opacity = 1;
 				_fullWindow.Visibility = Visibility.Collapsed;
 			}
 			else
 			{
 				_fullWindow.Visibility = Visibility.Visible;
+				_rootBorder.Opacity = 0;
 				_fullWindow.Child = element;
 			}
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): #
None

## PR Type
Feature 

## What is the current behavior?
User needs to wait 3sec. before MTC fades out

## What is the new behavior?
User can tap on video player to dismiss MTC

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

## Other information
None

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/136259