### PR TITLE
[Android] TextBlock - ensure Text change is applied after device unlocks

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -33,3 +33,4 @@
  * 131768 [iOS] Fixed bug where stale ScrollIntoView() request could overwrite more recent request
  * 136092 [iOS] ScrollIntoView() throws exception for ungrouped lists
  * 131768 [iOS] Fixed bug where stale ScrollIntoView() request could overwrite more recent request
+ * 136199 [Android] TextBlock.Text isn't visually updated if it changes while device is locked

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.Android.cs
@@ -359,6 +359,7 @@ namespace Windows.UI.Xaml.Controls
 				LogicalToPhysicalPixels(padding.Left),
 				LogicalToPhysicalPixels(padding.Top)
 			);
+			Invalidate(); // This ensures that OnDraw() will be called, which is typically the case anyway after OnLayout() but not always (eg, if device is being unlocked).
 		}
 
 		/// <summary>


### PR DESCRIPTION
Call Invalidate() when native text layouting changes, to ensure that OnDraw() is called.

Internal issue:
https://nventive.visualstudio.com/Umbrella/_workitems/edit/136199