### PR TITLE
Set Portable PDBs in Android and iOS project templates

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -34,3 +34,4 @@
  * 136092 [iOS] ScrollIntoView() throws exception for ungrouped lists
  * 131768 [iOS] Fixed bug where stale ScrollIntoView() request could overwrite more recent request
  * 136199 [Android] TextBlock.Text isn't visually updated if it changes while device is locked
+ * Fix Android and iOS may fail to break on breakpoints in `.xaml.cs` if the debugging symbol type is Full in projects created from templates

--- a/src/SolutionTemplate/UnoSolutionTemplate/UnoQuickStart.Droid/UnoQuickStart.Droid.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/UnoQuickStart.Droid/UnoQuickStart.Droid.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -33,7 +33,7 @@
     <AndroidLinkMode>None</AndroidLinkMode>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <AndroidManagedSymbols>true</AndroidManagedSymbols>
     <Optimize>true</Optimize>

--- a/src/SolutionTemplate/UnoSolutionTemplate/UnoQuickStart.iOS/UnoQuickStart.iOS.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/UnoQuickStart.iOS/UnoQuickStart.iOS.csproj
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
 		<DebugSymbols>true</DebugSymbols>
-		<DebugType>full</DebugType>
+		<DebugType>portable</DebugType>
 		<Optimize>false</Optimize>
 		<OutputPath>bin\iPhoneSimulator\Debug</OutputPath>
 		<DefineConstants>DEBUG</DefineConstants>
@@ -27,7 +27,7 @@
 		<MtouchDebug>true</MtouchDebug>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
-		<DebugType>none</DebugType>
+		<DebugType>portable</DebugType>
 		<Optimize>true</Optimize>
 		<OutputPath>bin\iPhoneSimulator\Release</OutputPath>
 		<ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
Enhancement

## What is the current behavior?
Android and iOS may fail to break on breakpoints in `.xaml.cs` if the debugging symbol type is Full in projects created from templates.

## What is the new behavior?
Breakpoints work in `.xaml.cs` files

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)