### PR TITLE
Fixed text is wrongly measured in wasm.

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -28,7 +28,7 @@
  * 135202, 131884 [Android] Content occasionally fails to show because binding throws an exception
  * 135646 [Android] Binding MediaPlayerElement.Source causes video to go blank
  * 136093, 136172 [iOS] ComboBox does not display its Popup
- * 134819, 134828 [iOS] Ensures the back gesture is enabled and disabled properly when the CommandBar is visible, collapsed, visible with a navigation command and collapsed with a navigation command. 
+ * 134819, 134828 [iOS] Ensures the back gesture is enabled and disabled properly when the CommandBar is visible, collapsed, visible with a navigation command and collapsed with a navigation command.
  * 135258 [Android] Fixed ImageBrush flash/flickering occurs when transitioning to a new page for the first time.
  * 131768 [iOS] Fixed bug where stale ScrollIntoView() request could overwrite more recent request
  * 136092 [iOS] ScrollIntoView() throws exception for ungrouped lists
@@ -37,3 +37,4 @@
  * Fix Android and iOS may fail to break on breakpoints in `.xaml.cs` if the debugging symbol type is Full in projects created from templates
  * 136210 [Android] Path is cut off by a pixel
  * 132004 [Android] Window bounds incorrect for screen with rounded corners
+ * #312 [Wasm] Text display was chopped on Wasm.

--- a/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
+++ b/src/Uno.UI.Wasm/WasmCSS/Uno.UI.css
@@ -26,7 +26,6 @@
 	-moz-user-select: none; /* Firefox */
 	-ms-user-select: none; /* Internet Explorer/Edge */
 	user-select: none; /* Non-prefixed version, currently supported by Chrome and Opera */
-	line-height: 120%; /* Magic number to be clarified, based on visual observation of the UWP behavior */
 }
 
 .uno-buttonbase {


### PR DESCRIPTION
GitHub Issue (If applicable): #312 

## PR Type
Bugfix

## Description / Fix
The `line-height` in the CSS has been removed: it was causing the problem.

## PR Checklist
- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)