### PR TITLE
Fix WebView raising too many events when cancelling navigation on iOS.

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -19,6 +19,7 @@
  * 136210 [Android] Path is cut off by a pixel
  * 132004 [Android] Window bounds incorrect for screen with rounded corners
  * #312 [Wasm] Text display was chopped on Wasm.
+ * 135839 `WebView` No longer raises NavigationFailed and NavigationCompleted events when navigation is cancelled on iOS.
 
 ## Release 1.41
 


### PR DESCRIPTION
## PR Type
- Bugfix

## What is the current behavior?
WebView's NavigationFailed and NavigationCompleted events are raised when we cancel a navigation on iOS.

## What is the new behavior?
WebView doesn't raise NavigationFailed and NavigationCompleted when navigation is cancelled.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/135839