### PR TITLE
Restore missing android NotImplemented methods.

### DIFF
--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/AutomationPeer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/AutomationPeer.cs
@@ -593,7 +593,7 @@ namespace Windows.UI.Xaml.Automation.Peers
 			throw new global::System.NotImplementedException("The member RawElementProviderRuntimeId AutomationPeer.GenerateRawElementProviderRuntimeId() is not implemented in Uno.");
 		}
 		#endif
-		#if false
+		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static bool ListenerExists( global::Windows.UI.Xaml.Automation.Peers.AutomationEvents eventId)
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/AutomationPeerAnnotation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/AutomationPeerAnnotation.cs
@@ -67,13 +67,7 @@ namespace Windows.UI.Xaml.Automation.Peers
 		}
 		#endif
 		// Forced skipping of method Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation.AutomationPeerAnnotation(Windows.UI.Xaml.Automation.AnnotationType, Windows.UI.Xaml.Automation.Peers.AutomationPeer)
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public AutomationPeerAnnotation() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation", "AutomationPeerAnnotation.AutomationPeerAnnotation()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation.AutomationPeerAnnotation()
 		// Forced skipping of method Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation.AutomationPeerAnnotation()
 		// Forced skipping of method Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation.Type.get
 		// Forced skipping of method Windows.UI.Xaml.Automation.Peers.AutomationPeerAnnotation.Type.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation/AutomationAnnotation.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation/AutomationAnnotation.cs
@@ -67,13 +67,7 @@ namespace Windows.UI.Xaml.Automation
 		}
 		#endif
 		// Forced skipping of method Windows.UI.Xaml.Automation.AutomationAnnotation.AutomationAnnotation(Windows.UI.Xaml.Automation.AnnotationType, Windows.UI.Xaml.UIElement)
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public AutomationAnnotation() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Automation.AutomationAnnotation", "AutomationAnnotation.AutomationAnnotation()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Automation.AutomationAnnotation.AutomationAnnotation()
 		// Forced skipping of method Windows.UI.Xaml.Automation.AutomationAnnotation.AutomationAnnotation()
 		// Forced skipping of method Windows.UI.Xaml.Automation.AutomationAnnotation.Type.get
 		// Forced skipping of method Windows.UI.Xaml.Automation.AutomationAnnotation.Type.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapAnimationKind.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapAnimationKind.cs
@@ -2,24 +2,16 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Maps
 {
-	#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
-	#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public   enum MapAnimationKind 
 	{
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
-		Default,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
-		None,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
-		Linear,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
-		Bow,
-		#endif
+		// Skipping already declared field Windows.UI.Xaml.Controls.Maps.MapAnimationKind.Default
+		// Skipping already declared field Windows.UI.Xaml.Controls.Maps.MapAnimationKind.None
+		// Skipping already declared field Windows.UI.Xaml.Controls.Maps.MapAnimationKind.Linear
+		// Skipping already declared field Windows.UI.Xaml.Controls.Maps.MapAnimationKind.Bow
 	}
 	#endif
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapControl.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapControl.cs
@@ -138,9 +138,11 @@ namespace Windows.UI.Xaml.Controls.Maps
 		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.GetLocationFromOffset(Windows.Foundation.Point, out Windows.Devices.Geolocation.Geopoint)
 		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.GetOffsetFromLocation(Windows.Devices.Geolocation.Geopoint, out Windows.Foundation.Point)
 		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.IsLocationInView(Windows.Devices.Geolocation.Geopoint, out bool)
+		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.TrySetViewBoundsAsync(Windows.Devices.Geolocation.GeoboundingBox, Windows.UI.Xaml.Thickness?, Windows.UI.Xaml.Controls.Maps.MapAnimationKind)
 		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.TrySetViewAsync(Windows.Devices.Geolocation.Geopoint)
 		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.TrySetViewAsync(Windows.Devices.Geolocation.Geopoint, double?)
 		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.TrySetViewAsync(Windows.Devices.Geolocation.Geopoint, double?, double?, double?)
+		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.TrySetViewAsync(Windows.Devices.Geolocation.Geopoint, double?, double?, double?, Windows.UI.Xaml.Controls.Maps.MapAnimationKind)
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapControl.BusinessLandmarksVisible.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapControl.BusinessLandmarksVisible.set
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapControl.TransitFeaturesVisible.get
@@ -188,12 +190,15 @@ namespace Windows.UI.Xaml.Controls.Maps
 		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.TryZoomInAsync()
 		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.TryZoomOutAsync()
 		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.TryZoomToAsync(double)
+		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.TrySetSceneAsync(Windows.UI.Xaml.Controls.Maps.MapScene)
+		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.TrySetSceneAsync(Windows.UI.Xaml.Controls.Maps.MapScene, Windows.UI.Xaml.Controls.Maps.MapAnimationKind)
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapControl.MapRightTapped.add
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapControl.MapRightTapped.remove
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapControl.BusinessLandmarksEnabled.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapControl.BusinessLandmarksEnabled.set
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapControl.TransitFeaturesEnabled.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapControl.TransitFeaturesEnabled.set
+		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapControl.GetVisibleRegion(Windows.UI.Xaml.Controls.Maps.MapVisibleRegionKind)
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapControl.MapProjection.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapControl.MapProjection.set
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapControl.StyleSheet.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapCustomExperience.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapCustomExperience.cs
@@ -7,13 +7,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 	#endif
 	public  partial class MapCustomExperience : global::Windows.UI.Xaml.DependencyObject
 	{
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public MapCustomExperience() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapCustomExperience", "MapCustomExperience.MapCustomExperience()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapCustomExperience.MapCustomExperience()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapCustomExperience.MapCustomExperience()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapElement.cs
@@ -161,13 +161,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapElement), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public MapElement() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapElement", "MapElement.MapElement()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapElement.MapElement()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapElement.MapElement()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapElement.ZIndex.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapElement.ZIndex.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapInputEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapInputEventArgs.cs
@@ -27,13 +27,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 			}
 		}
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public MapInputEventArgs() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapInputEventArgs", "MapInputEventArgs.MapInputEventArgs()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapInputEventArgs.MapInputEventArgs()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapInputEventArgs.MapInputEventArgs()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapInputEventArgs.Position.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapInputEventArgs.Location.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapItemsControl.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapItemsControl.cs
@@ -69,13 +69,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapItemsControl), 
 			new FrameworkPropertyMetadata(default(object)));
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public MapItemsControl() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapItemsControl", "MapItemsControl.MapItemsControl()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapItemsControl.MapItemsControl()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapItemsControl.MapItemsControl()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapItemsControl.ItemsSource.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapItemsControl.ItemsSource.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapLayer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapLayer.cs
@@ -73,13 +73,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapLayer), 
 			new FrameworkPropertyMetadata(default(int)));
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public MapLayer() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapLayer", "MapLayer.MapLayer()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapLayer.MapLayer()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapLayer.MapLayer()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapLayer.MapTabIndex.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapLayer.MapTabIndex.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapModel3D.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapModel3D.cs
@@ -7,13 +7,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 	#endif
 	public  partial class MapModel3D : global::Windows.UI.Xaml.DependencyObject
 	{
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public MapModel3D() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapModel3D", "MapModel3D.MapModel3D()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapModel3D.MapModel3D()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapModel3D.MapModel3D()
 		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapTileDataSource.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapTileDataSource.cs
@@ -7,13 +7,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 	#endif
 	public  partial class MapTileDataSource : global::Windows.UI.Xaml.DependencyObject
 	{
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public MapTileDataSource() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapTileDataSource", "MapTileDataSource.MapTileDataSource()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapTileDataSource.MapTileDataSource()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapTileDataSource.MapTileDataSource()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapTileSource.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapTileSource.cs
@@ -249,13 +249,7 @@ namespace Windows.UI.Xaml.Controls.Maps
 			typeof(global::Windows.UI.Xaml.Controls.Maps.MapTileSource), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.Maps.MapZoomLevelRange)));
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public MapTileSource() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Maps.MapTileSource", "MapTileSource.MapTileSource()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Maps.MapTileSource.MapTileSource()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Maps.MapTileSource.MapTileSource()
 		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapVisibleRegionKind.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Maps/MapVisibleRegionKind.cs
@@ -2,18 +2,14 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Maps
 {
-	#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
-	#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
 	public   enum MapVisibleRegionKind 
 	{
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
-		Near,
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
-		Full,
-		#endif
+		// Skipping already declared field Windows.UI.Xaml.Controls.Maps.MapVisibleRegionKind.Near
+		// Skipping already declared field Windows.UI.Xaml.Controls.Maps.MapVisibleRegionKind.Full
 	}
 	#endif
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/JumpListItemBackgroundConverter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/JumpListItemBackgroundConverter.cs
@@ -51,13 +51,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.JumpListItemBackgroundConverter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public JumpListItemBackgroundConverter() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Primitives.JumpListItemBackgroundConverter", "JumpListItemBackgroundConverter.JumpListItemBackgroundConverter()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Primitives.JumpListItemBackgroundConverter.JumpListItemBackgroundConverter()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.JumpListItemBackgroundConverter.JumpListItemBackgroundConverter()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.JumpListItemBackgroundConverter.Enabled.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.JumpListItemBackgroundConverter.Enabled.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/JumpListItemForegroundConverter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/JumpListItemForegroundConverter.cs
@@ -51,13 +51,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			typeof(global::Windows.UI.Xaml.Controls.Primitives.JumpListItemForegroundConverter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Brush)));
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public JumpListItemForegroundConverter() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.Primitives.JumpListItemForegroundConverter", "JumpListItemForegroundConverter.JumpListItemForegroundConverter()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.Primitives.JumpListItemForegroundConverter.JumpListItemForegroundConverter()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.JumpListItemForegroundConverter.JumpListItemForegroundConverter()
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.JumpListItemForegroundConverter.Enabled.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.JumpListItemForegroundConverter.Enabled.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/DatePickedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/DatePickedEventArgs.cs
@@ -27,13 +27,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public DatePickedEventArgs() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.DatePickedEventArgs", "DatePickedEventArgs.DatePickedEventArgs()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.DatePickedEventArgs.DatePickedEventArgs()
 		// Forced skipping of method Windows.UI.Xaml.Controls.DatePickedEventArgs.DatePickedEventArgs()
 		// Forced skipping of method Windows.UI.Xaml.Controls.DatePickedEventArgs.OldDate.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.DatePickedEventArgs.NewDate.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarCustomPen.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/InkToolbarCustomPen.cs
@@ -7,13 +7,7 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class InkToolbarCustomPen : global::Windows.UI.Xaml.DependencyObject
 	{
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		protected InkToolbarCustomPen() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.InkToolbarCustomPen", "InkToolbarCustomPen.InkToolbarCustomPen()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.InkToolbarCustomPen.InkToolbarCustomPen()
 		// Forced skipping of method Windows.UI.Xaml.Controls.InkToolbarCustomPen.InkToolbarCustomPen()
 		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsPickedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsPickedEventArgs.cs
@@ -27,13 +27,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public ItemsPickedEventArgs() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.ItemsPickedEventArgs", "ItemsPickedEventArgs.ItemsPickedEventArgs()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.ItemsPickedEventArgs.ItemsPickedEventArgs()
 		// Forced skipping of method Windows.UI.Xaml.Controls.ItemsPickedEventArgs.ItemsPickedEventArgs()
 		// Forced skipping of method Windows.UI.Xaml.Controls.ItemsPickedEventArgs.AddedItems.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.ItemsPickedEventArgs.RemovedItems.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsStackPanel.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsStackPanel.cs
@@ -48,7 +48,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if false || false || NET46 || __WASM__ || false
+		#if false || false || NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  int FirstVisibleIndex
 		{
@@ -68,7 +68,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if false || false || NET46 || __WASM__ || false
+		#if false || false || NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  int LastVisibleIndex
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsWrapGrid.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/ItemsWrapGrid.cs
@@ -37,7 +37,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if false || false || NET46 || __WASM__ || false
+		#if false || false || NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  int FirstVisibleIndex
 		{
@@ -57,7 +57,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if false || false || NET46 || __WASM__ || false
+		#if false || false || NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  int LastVisibleIndex
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaPlayerPresenter.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MediaPlayerPresenter.cs
@@ -2,10 +2,10 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.UI.Xaml.Controls
 {
-	#if false || false || NET46 || __WASM__ || __MACOS__
+	#if false || false || false || false || false
 	[global::Uno.NotImplemented]
 	#endif
-	public  partial class MediaPlayerPresenter
+	public  partial class MediaPlayerPresenter 
 	{
 		#if false || false || NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
@@ -73,13 +73,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.MediaPlayerPresenter), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Media.Stretch)));
 		#endif
-		#if false || false || NET46 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public MediaPlayerPresenter() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.MediaPlayerPresenter", "MediaPlayerPresenter.MediaPlayerPresenter()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.MediaPlayerPresenter.MediaPlayerPresenter()
 		// Forced skipping of method Windows.UI.Xaml.Controls.MediaPlayerPresenter.MediaPlayerPresenter()
 		// Forced skipping of method Windows.UI.Xaml.Controls.MediaPlayerPresenter.MediaPlayer.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.MediaPlayerPresenter.MediaPlayer.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuFlyoutItem.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/MenuFlyoutItem.cs
@@ -87,7 +87,7 @@ namespace Windows.UI.Xaml.Controls
 		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutItem.TextProperty.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutItem.CommandProperty.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.MenuFlyoutItem.CommandParameterProperty.get
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
+		#if false || __IOS__ || NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  event global::Windows.UI.Xaml.RoutedEventHandler Click
 		{

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PickerConfirmedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/PickerConfirmedEventArgs.cs
@@ -7,13 +7,7 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class PickerConfirmedEventArgs : global::Windows.UI.Xaml.DependencyObject
 	{
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public PickerConfirmedEventArgs() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.PickerConfirmedEventArgs", "PickerConfirmedEventArgs.PickerConfirmedEventArgs()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.PickerConfirmedEventArgs.PickerConfirmedEventArgs()
 		// Forced skipping of method Windows.UI.Xaml.Controls.PickerConfirmedEventArgs.PickerConfirmedEventArgs()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RatingItemInfo.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/RatingItemInfo.cs
@@ -7,13 +7,7 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class RatingItemInfo : global::Windows.UI.Xaml.DependencyObject
 	{
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public RatingItemInfo() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.RatingItemInfo", "RatingItemInfo.RatingItemInfo()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.RatingItemInfo.RatingItemInfo()
 		// Forced skipping of method Windows.UI.Xaml.Controls.RatingItemInfo.RatingItemInfo()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SwipeItem.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SwipeItem.cs
@@ -161,13 +161,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.SwipeItem), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public SwipeItem() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.SwipeItem", "SwipeItem.SwipeItem()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.SwipeItem.SwipeItem()
 		// Forced skipping of method Windows.UI.Xaml.Controls.SwipeItem.SwipeItem()
 		// Forced skipping of method Windows.UI.Xaml.Controls.SwipeItem.Text.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.SwipeItem.Text.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SwipeItems.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/SwipeItems.cs
@@ -39,13 +39,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.SwipeItems), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Controls.SwipeMode)));
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public SwipeItems() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.SwipeItems", "SwipeItems.SwipeItems()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.SwipeItems.SwipeItems()
 		// Forced skipping of method Windows.UI.Xaml.Controls.SwipeItems.SwipeItems()
 		// Forced skipping of method Windows.UI.Xaml.Controls.SwipeItems.Mode.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.SwipeItems.Mode.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePickedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePickedEventArgs.cs
@@ -27,13 +27,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public TimePickedEventArgs() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TimePickedEventArgs", "TimePickedEventArgs.TimePickedEventArgs()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.TimePickedEventArgs.TimePickedEventArgs()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TimePickedEventArgs.TimePickedEventArgs()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TimePickedEventArgs.OldTime.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.TimePickedEventArgs.NewTime.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeViewItemTemplateSettings.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeViewItemTemplateSettings.cs
@@ -79,13 +79,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Thickness)));
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public TreeViewItemTemplateSettings() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings", "TreeViewItemTemplateSettings.TreeViewItemTemplateSettings()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings.TreeViewItemTemplateSettings()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings.TreeViewItemTemplateSettings()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings.ExpandedGlyphVisibility.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.TreeViewItemTemplateSettings.CollapsedGlyphVisibility.get

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeViewNode.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TreeViewNode.cs
@@ -121,13 +121,7 @@ namespace Windows.UI.Xaml.Controls
 			typeof(global::Windows.UI.Xaml.Controls.TreeViewNode), 
 			new FrameworkPropertyMetadata(default(bool)));
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public TreeViewNode() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.TreeViewNode", "TreeViewNode.TreeViewNode()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Controls.TreeViewNode.TreeViewNode()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TreeViewNode.TreeViewNode()
 		// Forced skipping of method Windows.UI.Xaml.Controls.TreeViewNode.Content.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.TreeViewNode.Content.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/UserControl.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/UserControl.cs
@@ -7,35 +7,9 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class UserControl 
 	{
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Xaml.UIElement Content
-		{
-			get
-			{
-				return (global::Windows.UI.Xaml.UIElement)this.GetValue(ContentProperty);
-			}
-			set
-			{
-				this.SetValue(ContentProperty, value);
-			}
-		}
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty ContentProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			"Content", typeof(global::Windows.UI.Xaml.UIElement), 
-			typeof(global::Windows.UI.Xaml.Controls.UserControl), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.UIElement)));
-		#endif
-		#if false || false || false || false || false
-		[global::Uno.NotImplemented]
-		public UserControl() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Controls.UserControl", "UserControl.UserControl()");
-		}
-		#endif
+		// Skipping already declared property Content
+		// Skipping already declared property ContentProperty
+		// Skipping already declared method Windows.UI.Xaml.Controls.UserControl.UserControl()
 		// Forced skipping of method Windows.UI.Xaml.Controls.UserControl.UserControl()
 		// Forced skipping of method Windows.UI.Xaml.Controls.UserControl.Content.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.UserControl.Content.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/ContentLinkProvider.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Documents/ContentLinkProvider.cs
@@ -7,13 +7,7 @@ namespace Windows.UI.Xaml.Documents
 	#endif
 	public  partial class ContentLinkProvider : global::Windows.UI.Xaml.DependencyObject
 	{
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		protected ContentLinkProvider() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Documents.ContentLinkProvider", "ContentLinkProvider.ContentLinkProvider()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Documents.ContentLinkProvider.ContentLinkProvider()
 		// Forced skipping of method Windows.UI.Xaml.Documents.ContentLinkProvider.ContentLinkProvider()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/KeyboardAccelerator.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/KeyboardAccelerator.cs
@@ -95,13 +95,7 @@ namespace Windows.UI.Xaml.Input
 			typeof(global::Windows.UI.Xaml.Input.KeyboardAccelerator), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DependencyObject)));
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public KeyboardAccelerator() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Input.KeyboardAccelerator", "KeyboardAccelerator.KeyboardAccelerator()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Input.KeyboardAccelerator.KeyboardAccelerator()
 		// Forced skipping of method Windows.UI.Xaml.Input.KeyboardAccelerator.KeyboardAccelerator()
 		// Forced skipping of method Windows.UI.Xaml.Input.KeyboardAccelerator.Key.get
 		// Forced skipping of method Windows.UI.Xaml.Input.KeyboardAccelerator.Key.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ColorKeyFrame.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/ColorKeyFrame.cs
@@ -51,13 +51,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			typeof(global::Windows.UI.Xaml.Media.Animation.ColorKeyFrame), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Color)));
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		protected ColorKeyFrame() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.Animation.ColorKeyFrame", "ColorKeyFrame.ColorKeyFrame()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Media.Animation.ColorKeyFrame.ColorKeyFrame()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrame.ColorKeyFrame()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrame.Value.get
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.ColorKeyFrame.Value.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PointKeyFrame.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Animation/PointKeyFrame.cs
@@ -51,13 +51,7 @@ namespace Windows.UI.Xaml.Media.Animation
 			typeof(global::Windows.UI.Xaml.Media.Animation.PointKeyFrame), 
 			new FrameworkPropertyMetadata(default(global::Windows.Foundation.Point)));
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		protected PointKeyFrame() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.Animation.PointKeyFrame", "PointKeyFrame.PointKeyFrame()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Media.Animation.PointKeyFrame.PointKeyFrame()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.PointKeyFrame.PointKeyFrame()
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.PointKeyFrame.Value.get
 		// Forced skipping of method Windows.UI.Xaml.Media.Animation.PointKeyFrame.Value.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Media3D/Transform3D.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media.Media3D/Transform3D.cs
@@ -7,13 +7,7 @@ namespace Windows.UI.Xaml.Media.Media3D
 	#endif
 	public  partial class Transform3D : global::Windows.UI.Xaml.DependencyObject
 	{
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		protected Transform3D() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.Media3D.Transform3D", "Transform3D.Transform3D()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Media.Media3D.Transform3D.Transform3D()
 		// Forced skipping of method Windows.UI.Xaml.Media.Media3D.Transform3D.Transform3D()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/CacheMode.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/CacheMode.cs
@@ -7,13 +7,7 @@ namespace Windows.UI.Xaml.Media
 	#endif
 	public  partial class CacheMode : global::Windows.UI.Xaml.DependencyObject
 	{
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		protected CacheMode() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.CacheMode", "CacheMode.CacheMode()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Media.CacheMode.CacheMode()
 		// Forced skipping of method Windows.UI.Xaml.Media.CacheMode.CacheMode()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/Projection.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/Projection.cs
@@ -7,13 +7,7 @@ namespace Windows.UI.Xaml.Media
 	#endif
 	public  partial class Projection : global::Windows.UI.Xaml.DependencyObject
 	{
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		protected Projection() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.Projection", "Projection.Projection()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Media.Projection.Projection()
 		// Forced skipping of method Windows.UI.Xaml.Media.Projection.Projection()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/TimelineMarker.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/TimelineMarker.cs
@@ -73,13 +73,7 @@ namespace Windows.UI.Xaml.Media
 			typeof(global::Windows.UI.Xaml.Media.TimelineMarker), 
 			new FrameworkPropertyMetadata(default(string)));
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public TimelineMarker() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.TimelineMarker", "TimelineMarker.TimelineMarker()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Media.TimelineMarker.TimelineMarker()
 		// Forced skipping of method Windows.UI.Xaml.Media.TimelineMarker.TimelineMarker()
 		// Forced skipping of method Windows.UI.Xaml.Media.TimelineMarker.Time.get
 		// Forced skipping of method Windows.UI.Xaml.Media.TimelineMarker.Time.set

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/XamlLight.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Media/XamlLight.cs
@@ -21,13 +21,7 @@ namespace Windows.UI.Xaml.Media
 			}
 		}
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public XamlLight() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Media.XamlLight", "XamlLight.XamlLight()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Media.XamlLight.XamlLight()
 		// Forced skipping of method Windows.UI.Xaml.Media.XamlLight.XamlLight()
 		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Printing/PrintDocument.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Printing/PrintDocument.cs
@@ -25,13 +25,7 @@ namespace Windows.UI.Xaml.Printing
 			typeof(global::Windows.UI.Xaml.Printing.PrintDocument), 
 			new FrameworkPropertyMetadata(default(global::Windows.Graphics.Printing.IPrintDocumentSource)));
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public PrintDocument() : base()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Printing.PrintDocument", "PrintDocument.PrintDocument()");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Printing.PrintDocument.PrintDocument()
 		// Forced skipping of method Windows.UI.Xaml.Printing.PrintDocument.PrintDocument()
 		// Forced skipping of method Windows.UI.Xaml.Printing.PrintDocument.DocumentSource.get
 		// Forced skipping of method Windows.UI.Xaml.Printing.PrintDocument.Paginate.add

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/FrameworkElement.cs
@@ -582,13 +582,7 @@ namespace Windows.UI.Xaml
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.LayoutUpdated.add
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.LayoutUpdated.remove
 		// Skipping already declared method Windows.UI.Xaml.FrameworkElement.FindName(string)
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  void SetBinding( global::Windows.UI.Xaml.DependencyProperty dp,  global::Windows.UI.Xaml.Data.BindingBase binding)
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.FrameworkElement", "void FrameworkElement.SetBinding(DependencyProperty dp, BindingBase binding)");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.FrameworkElement.SetBinding(Windows.UI.Xaml.DependencyProperty, Windows.UI.Xaml.Data.BindingBase)
 		// Skipping already declared method Windows.UI.Xaml.FrameworkElement.MeasureOverride(Windows.Foundation.Size)
 		// Skipping already declared method Windows.UI.Xaml.FrameworkElement.ArrangeOverride(Windows.Foundation.Size)
 		// Skipping already declared method Windows.UI.Xaml.FrameworkElement.OnApplyTemplate()
@@ -596,13 +590,7 @@ namespace Windows.UI.Xaml
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.RequestedTheme.set
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.DataContextChanged.add
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.DataContextChanged.remove
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Xaml.Data.BindingExpression GetBindingExpression( global::Windows.UI.Xaml.DependencyProperty dp)
-		{
-			throw new global::System.NotImplementedException("The member BindingExpression FrameworkElement.GetBindingExpression(DependencyProperty dp) is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.FrameworkElement.GetBindingExpression(Windows.UI.Xaml.DependencyProperty)
 		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		protected virtual bool GoToElementStateCore( string stateName,  bool useTransitions)
@@ -726,22 +714,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
-		#if __ANDROID__ || false || false || false || false
-		[global::Uno.NotImplemented]
-		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Xaml.FrameworkElement, global::Windows.UI.Xaml.DataContextChangedEventArgs> DataContextChanged
-		{
-			[global::Uno.NotImplemented]
-			add
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.FrameworkElement", "event TypedEventHandler<FrameworkElement, DataContextChangedEventArgs> FrameworkElement.DataContextChanged");
-			}
-			[global::Uno.NotImplemented]
-			remove
-			{
-				global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.FrameworkElement", "event TypedEventHandler<FrameworkElement, DataContextChangedEventArgs> FrameworkElement.DataContextChanged");
-			}
-		}
-		#endif
+		// Skipping already declared event Windows.UI.Xaml.FrameworkElement.DataContextChanged
 		#if false || false || NET46 || false || false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Xaml.FrameworkElement, object> Loading

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/UIElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/UIElement.cs
@@ -1131,7 +1131,7 @@ namespace Windows.UI.Xaml
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.UIElement", "void UIElement.UpdateLayout()");
 		}
 		#endif
-		#if false || false || false || false || __MACOS__
+		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		protected virtual global::Windows.UI.Xaml.Automation.Peers.AutomationPeer OnCreateAutomationPeer()
 		{

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -528,7 +528,7 @@ namespace Windows.UI.Xaml
 #if !__IOS__ && !__ANDROID__ && !__MACOS__ // This code is generated in FrameworkElementMixins
 		private AutomationPeer _automationPeer;
 
-		protected virtual AutomationPeer OnCreateAutomationPeer()
+		protected override AutomationPeer OnCreateAutomationPeer()
 		{
 			if (AutomationProperties.GetName(this) is string name && !string.IsNullOrEmpty(name))
 			{

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
@@ -922,7 +922,13 @@ namespace <#= mixin.NamespaceName #>
 		}
 #endif
 
-		protected virtual AutomationPeer OnCreateAutomationPeer()
+		protected
+#if !<#= mixin.IsFrameworkElement #>
+		virtual
+#else
+		override
+#endif
+		AutomationPeer OnCreateAutomationPeer()
 		{
 			if (OnCreateAutomationPeerOverride() is AutomationPeer automationPeer)
 			{

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
@@ -1016,7 +1016,13 @@ namespace <#= mixin.NamespaceName #>
 		}
 #endif
 
-		protected virtual AutomationPeer OnCreateAutomationPeer()
+		protected
+#if !<#= mixin.IsFrameworkElement #>
+		virtual
+#else
+		override
+#endif
+		AutomationPeer OnCreateAutomationPeer()
 		{
 			if (OnCreateAutomationPeerOverride() is AutomationPeer automationPeer)
 			{

--- a/src/Uno.UI/UI/Xaml/Maps/MapAnimationKind.cs
+++ b/src/Uno.UI/UI/Xaml/Maps/MapAnimationKind.cs
@@ -1,0 +1,12 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.UI.Xaml.Controls.Maps
+{
+	public   enum MapAnimationKind 
+	{
+		Default,
+		None,
+		Linear,
+		Bow,
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Maps/MapVisibleRegionKind.cs
+++ b/src/Uno.UI/UI/Xaml/Maps/MapVisibleRegionKind.cs
@@ -1,0 +1,10 @@
+#pragma warning disable 108 // new keyword hiding
+#pragma warning disable 114 // new keyword hiding
+namespace Windows.UI.Xaml.Controls.Maps
+{
+	public   enum MapVisibleRegionKind 
+	{
+		Near,
+		Full,
+	}
+}

--- a/src/Uno.UWPSyncGenerator/Uno.UWPSyncGenerator.csproj
+++ b/src/Uno.UWPSyncGenerator/Uno.UWPSyncGenerator.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
@@ -14,41 +14,42 @@
 		</PackageReference>
 		<PackageReference Include="Microsoft.Build">
 			<ExcludeAssets>runtime</ExcludeAssets>
-			<Version>15.6.82</Version>
+			<Version>15.8.166</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Build.Framework">
 			<ExcludeAssets>runtime</ExcludeAssets>
-			<Version>15.6.82</Version>
+			<Version>15.8.166</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Build.Tasks.Core">
 			<ExcludeAssets>runtime</ExcludeAssets>
-			<Version>15.6.82</Version>
+			<Version>15.8.166</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Build.Utilities.Core">
 			<ExcludeAssets>runtime</ExcludeAssets>
-			<Version>15.6.82</Version>
+			<Version>15.8.166</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.CodeAnalysis">
-			<Version>2.7.0</Version>
+			<Version>2.9.0</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.CodeAnalysis.Common">
-			<Version>2.7.0</Version>
+			<Version>2.9.0</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-			<Version>2.7.0</Version>
+			<Version>2.9.0</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-			<Version>2.7.0</Version>
+			<Version>2.9.0</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.CodeAnalysis.VisualBasic">
-			<Version>2.7.0</Version>
+			<Version>2.9.0</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces">
-			<Version>2.7.0</Version>
+			<Version>2.9.0</Version>
 		</PackageReference>
 		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
-			<Version>2.7.0</Version>
+			<Version>2.9.0</Version>
 		</PackageReference>
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="2.9.0" />
 		<PackageReference Include="Microsoft.Tpl.Dataflow">
 			<Version>4.5.24</Version>
 		</PackageReference>


### PR DESCRIPTION
## PR Type
Bugfix

## What is the current behavior?
Some type members are marked as not implemented on Android that are implemented.

## What is the new behavior?
The types are now properly marked as implemented.

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/137078