### PR TITLE
[Android] Fix Bottom Padding Mask on an element inside a ScrollViewer

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -20,6 +20,7 @@
  * 132004 [Android] Window bounds incorrect for screen with rounded corners
  * #312 [Wasm] Text display was chopped on Wasm.
  * 135839 `WebView` No longer raises NavigationFailed and NavigationCompleted events when navigation is cancelled on iOS.
+ * 136188 [Android] Page elements are aligned differently upon back navigation
 
 ## Release 1.41
 

--- a/src/Uno.UI/KeyboardRectProvider.Android.cs
+++ b/src/Uno.UI/KeyboardRectProvider.Android.cs
@@ -2,6 +2,7 @@
 using Android.App;
 using Android.Graphics;
 using Android.Graphics.Drawables;
+using Android.Util;
 using Android.Views;
 using Android.Widget;
 
@@ -65,17 +66,22 @@ namespace Uno.UI
 		/// </summary>
 		void ViewTreeObserver.IOnGlobalLayoutListener.OnGlobalLayout()
 		{
-			var screenSize = new Point();
-			_activity.WindowManager.DefaultDisplay.GetSize(screenSize);
+			var metrics = new DisplayMetrics();
+			_activity.WindowManager.DefaultDisplay.GetMetrics(metrics);
+
+			var realMetrics = new DisplayMetrics();
+			_activity.WindowManager.DefaultDisplay.GetRealMetrics(realMetrics);
 
 			var popupRect = new Rect();
 			_popupView.GetWindowVisibleDisplayFrame(popupRect);
 
+			// We are only interested in the height above the navigation bar. If the navigation bar visibility changes, it will also raise OnGlobalLayout.
+			// While the keyboard is visible the navigation bar will always also be visible (enabling the close keyboard button).
 			var keyboardRect = new Rect(
 				0,
-				popupRect.Bottom,
-				screenSize.X,
-				screenSize.Y
+				Math.Min(popupRect.Bottom, metrics.HeightPixels),
+				realMetrics.WidthPixels,
+				realMetrics.HeightPixels
 			);
 
 			_onKeyboardRectChanged?.Invoke(keyboardRect);

--- a/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.Android.cs
@@ -69,7 +69,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			base.OnLayoutCore(changed, left, top, right, bottom);
 
-			UpdateBorder();
+			UpdateBorder(changed);
 		}
 
 		protected virtual void OnChildrenChanged()

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
@@ -135,6 +135,10 @@ namespace Windows.UI.Xaml
 				);
 			}
 
+			var previousSize = _actualSize;
+			_actualSize = newSize;
+			RenderSize = _actualSize;
+
 			if (
 				// If the layout has changed, but the final size has not, this is just a translation.
 				// So unless there was a layout requested, we can skip arranging the children.
@@ -153,10 +157,6 @@ namespace Windows.UI.Xaml
 				OnLayoutUpdated();
 				OnAfterArrange();
 			}
-
-			var previousSize = _actualSize;
-			_actualSize = newSize;
-			RenderSize = _actualSize;
 
 			if (previousSize != newSize)
 			{

--- a/src/Uno.UI/UI/Xaml/Window.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Window.Android.cs
@@ -93,11 +93,7 @@ namespace Windows.UI.Xaml
 				height: newBounds.Height - statusBarHeight - navigationBarHeight
 			);
 
-			var applicationView = ApplicationView.GetForCurrentView();
-			if (applicationView != null && applicationView.VisibleBounds != newVisibleBounds)
-			{
-				applicationView.SetCoreBounds(newVisibleBounds);
-			}
+			ApplicationView.GetForCurrentView()?.SetVisibleBounds(newVisibleBounds);
 
 			if (Bounds != newBounds)
 			{

--- a/src/Uno.UI/UI/Xaml/Window.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Window.iOS.cs
@@ -128,11 +128,7 @@ namespace Windows.UI.Xaml
 		{
 			var newBounds = new Rect(0, 0, size.Width, size.Height);
 
-			var applicationView = ApplicationView.GetForCurrentView();
-			if (applicationView != null)
-			{
-				applicationView.SetCoreBounds(_window, newBounds);
-			}
+			ApplicationView.GetForCurrentView()?.SetVisibleBounds(_window, newBounds);
 
 			if (Bounds != newBounds)
 			{

--- a/src/Uno.UWP/UI/ViewManagement/ApplicationView.Android.cs
+++ b/src/Uno.UWP/UI/ViewManagement/ApplicationView.Android.cs
@@ -11,16 +11,19 @@ namespace Windows.UI.ViewManagement
 {
 	partial class ApplicationView
 	{
-		internal void SetCoreBounds(Rect visibleBounds)
+		internal void SetVisibleBounds(Rect newVisibleBounds)
 		{
-			VisibleBounds = visibleBounds;
-
-			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+			if (newVisibleBounds != VisibleBounds)
 			{
-				this.Log().Debug($"Updated visible bounds {VisibleBounds}");
-			}
+				VisibleBounds = newVisibleBounds;
 
-			VisibleBoundsChanged?.Invoke(this, null);
+				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				{
+					this.Log().Debug($"Updated visible bounds {VisibleBounds}");
+				}
+
+				VisibleBoundsChanged?.Invoke(this, null);
+			}
 		}
 
 		public bool TryEnterFullScreenMode()

--- a/src/Uno.UWP/UI/ViewManagement/ApplicationView.iOS.cs
+++ b/src/Uno.UWP/UI/ViewManagement/ApplicationView.iOS.cs
@@ -13,7 +13,7 @@ namespace Windows.UI.ViewManagement
 	{
 		private static bool UseSafeAreaInsets => UIDevice.CurrentDevice.CheckSystemVersion(11, 0);
 
-		internal void SetCoreBounds(UIKit.UIWindow keyWindow, Foundation.Rect windowBounds)
+		internal void SetVisibleBounds(UIKit.UIWindow keyWindow, Foundation.Rect windowBounds)
 		{
 			var inset = UseSafeAreaInsets
 					? keyWindow.SafeAreaInsets


### PR DESCRIPTION
GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
On Android, if a PaddingMask is set inside an element contained by a ScrollViewer and the ScrollViewer Content is smaller than the screen size, the layout just get some weird measurements.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
Everything is well measured when a PaddingMask is set

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://nventive.visualstudio.com/Umbrella/_workitems/edit/136188