### PR TITLE
Ensures the right closing punctuation is used when applying a style on a root xaml control.

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -46,9 +46,4 @@
  * 135646 [Android] Binding MediaPlayerElement.Source causes video to go blank
  * 136093, 136172 [iOS] ComboBox does not display its Popup
  * 134819, 134828 [iOS] Ensures the back gesture is enabled and disabled properly when the CommandBar is visible, collapsed, visible with a navigation command and collapsed with a navigation command. 
-
-
-
-
-
-
+ * 137081 Xaml generator doesn't support setting a style on the root control

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -3106,7 +3106,9 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
         private void BuildLiteralProperties(IIndentedStringBuilder writer, XamlObjectDefinition objectDefinition, string closureName = null)
         {
-            BuildStyleProperty(writer, objectDefinition);
+			var closingPunctuation = string.IsNullOrWhiteSpace(closureName) ? "," : ";";
+
+			BuildStyleProperty(writer, objectDefinition, closingPunctuation);
 
             var extendedProperties = GetExtendedProperties(objectDefinition);
 
@@ -3117,17 +3119,16 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
                 foreach (var member in extendedProperties)
                 {
                     var fullValueSetter = string.IsNullOrWhiteSpace(closureName) ? member.Member.Name : "{0}.{1}".InvariantCultureFormat(closureName, member.Member.Name);
-                    var closingPunctuation = string.IsNullOrWhiteSpace(closureName) ? "," : ";";
 
-                    // Exclude attached properties, must be set in the extended apply section.
-                    // If there is no type attached, this can be a binding.
-                    if (IsType(objectDefinition.Type, member.Member.DeclaringType)
+					// Exclude attached properties, must be set in the extended apply section.
+					// If there is no type attached, this can be a binding.
+					if (IsType(objectDefinition.Type, member.Member.DeclaringType)
                         && !IsAttachedProperty(member)
                         && FindEventType(member.Member) == null
 						&& member.Member.Name != "_UnknownContent" // We are defining the elements of a collection explicitly declared in XAML
 					)
-                    {
-                        if (member.Objects.None())
+					{
+						if (member.Objects.None())
                         {
                             if (IsInitializableCollection(member.Member))
                             {
@@ -3136,8 +3137,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
                             else
                             {
                                 if (FindPropertyType(member.Member) != null)
-                                {
-                                    writer.AppendLineInvariant("{0} = {1}{2}", fullValueSetter, BuildLiteralValue(member, objectUid: objectUid), closingPunctuation);
+								{
+									writer.AppendLineInvariant("{0} = {1}{2}", fullValueSetter, BuildLiteralValue(member, objectUid: objectUid), closingPunctuation);
                                 }
                                 else
                                 {
@@ -3165,8 +3166,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
                             }
                         }
                         else
-                        {
-                            var nonBindingObjects = member
+						{
+							var nonBindingObjects = member
                                 .Objects
                                 .Where(m =>
                                     m.Type.Name != "Binding"
@@ -3187,18 +3188,18 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
                                     {
                                         foreach (var child in nonBindingObjects)
                                         {
-                                            BuildChild(writer, member, child);
-                                            writer.AppendLineInvariant(",");
-                                        }
+                                            BuildChild(writer, member, child);											
+											writer.AppendLineInvariant(",");
+										}
                                     }
                                 }
 								else
-                                {
-                                    writer.AppendFormatInvariant($"{fullValueSetter} = ");
+								{
+									writer.AppendFormatInvariant($"{fullValueSetter} = ");
                                     BuildChild(writer, member, nonBindingObjects.First());
                                 }
-
-                                writer.AppendLineInvariant(closingPunctuation);
+								
+								writer.AppendLineInvariant(closingPunctuation);
                             }
                         }
                     }
@@ -3239,7 +3240,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			return false;
 		}
 
-		private void BuildStyleProperty(IIndentedStringBuilder writer, XamlObjectDefinition objectDefinition)
+		private void BuildStyleProperty(IIndentedStringBuilder writer, XamlObjectDefinition objectDefinition, string closingPunctuation)
         {
             var styleMember = FindMember(objectDefinition, "Style");
 
@@ -3247,9 +3248,9 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
             {
                 // Explicitly search for StaticResource, as the style could be set using a binding.
                 if (styleMember.Objects.Any(o => o.Type.Name == "StaticResource"))
-                {
-                    BuildComplexPropertyValue(writer, styleMember, "");
-                    writer.AppendLineInvariant(0, ",");
+				{
+					BuildComplexPropertyValue(writer, styleMember, "");
+                    writer.AppendLineInvariant(0, closingPunctuation);
                 }
             }
         }

--- a/src/SourceGenerators/XamlGenerationTests/StyleTest.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/StyleTest.xaml
@@ -1,47 +1,58 @@
-﻿<UserControl
-    x:Class="XamlGenerationTests.Shared.StyleTest"
-    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:XamlGenerationTests.Shared"
-    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"   
-    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"  
-	xmlns:ios="http://uno.ui/ios"
-    xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-    xmlns:android="http://uno.ui/android"
-	xmlns:xamarin="http://uno.ui/xamarin"
-    mc:Ignorable="d xamarin"
-    d:DesignHeight="300"
-    d:DesignWidth="400"> 
-	<UserControl.Resources>
+﻿<Grid x:Class="XamlGenerationTests.Shared.StyleTest"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:XamlGenerationTests.Shared"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:ios="http://uno.ui/ios"
+	  xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:android="http://uno.ui/android"
+	  xmlns:xamarin="http://uno.ui/xamarin"
+	  mc:Ignorable="d xamarin"
+	  d:DesignHeight="300"
+	  d:DesignWidth="400"
+	  Style="{StaticResource SomeGridStyle}">
+	<Grid.Resources>
 		<x:Double x:Key="MyColumn">42</x:Double>
-		
-		<Style x:Key="testStyle" TargetType="Grid">
-			<Setter Property="Background" Value="Red" />
+
+		<Style x:Key="testStyle"
+			   TargetType="Grid">
+			<Setter Property="Background"
+					Value="Red" />
 		</Style>
-		<Style x:Key="inheritedTestStyle" TargetType="Grid" BasedOn="{StaticResource testStyle}">
-			<Setter Property="Tag" Value="Red" />
-			<Setter Property="Width" Value="42" />
-			<Setter Property="Grid.Row" Value="42" />
-			<Setter Property="Grid.Column" Value="{StaticResource MyColumn}" />
+		<Style x:Key="inheritedTestStyle"
+			   TargetType="Grid"
+			   BasedOn="{StaticResource testStyle}">
+			<Setter Property="Tag"
+					Value="Red" />
+			<Setter Property="Width"
+					Value="42" />
+			<Setter Property="Grid.Row"
+					Value="42" />
+			<Setter Property="Grid.Column"
+					Value="{StaticResource MyColumn}" />
 		</Style>
-    </UserControl.Resources>
-	
+	</Grid.Resources>
+
 	<StackPanel>
-    
+
 		<StackPanel Style="{Binding myBinding}">
 		</StackPanel>
 
 		<StackPanel>
-			<Grid Background="Black" Style="{StaticResource testStyle}">
+			<Grid Background="Black"
+				  Style="{StaticResource testStyle}">
 				<TextBlock />
 			</Grid>
-			<Grid Style="{StaticResource testStyle}" Background="Black">
+			<Grid Style="{StaticResource testStyle}"
+				  Background="Black">
 				<TextBlock />
 			</Grid>
 			<ListView>
 				<ListView.ItemContainerStyle>
 					<Style TargetType="ListViewItem">
-						<Setter Property="Background" Value="Red" />
+						<Setter Property="Background"
+								Value="Red" />
 						<Setter Property="ContentTemplate">
 							<Setter.Value>
 								<DataTemplate>
@@ -53,9 +64,8 @@
 				</ListView.ItemContainerStyle>
 			</ListView>
 		</StackPanel>
-	
+
 	</StackPanel>
 
 
-</UserControl>
-    
+</Grid>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
Can't apply a style on a root control that is not a UserControl. The generator writes a "," instead of a ";"

## What is the new behavior?
The generator properly writes a ";"

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/137081