### PR TITLE
Fix local html navigation on iOS WebView.

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -35,6 +35,7 @@
  * Adjust compiled binding application ordering when loading controls
  * Ensure the SplitView templated parent is propagated properly for FindName
  * Fix infinite loop when parsing empty Attached Properties on macOS
+ * 103116 [iOS] Navigating to a _second_ local html file with `WebView` doesn't work.
 
 ## Release 1.41
 


### PR DESCRIPTION
## PR Type
- Bugfix

## What is the current behavior?
1. Load a local html file in the iOS WebView on a device.
2. Load a second local html file in a different folder in the same WebView.
Result: Navigation Error.

## What is the new behavior?
Same steps, but no error.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/103116