### PR TITLE
Enable SourceGeneratorHost build to reduce VS memory consumption

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -5,6 +5,7 @@
 ### Features
 * [Wasm] Improve general performance and memory pressure by removing Javascript interop evaluations.
 * Add support for Windows 10 SDK 17763 (1809)
+* Improve the Uno.UI solution memory consumption for Android targets
 
 ### Breaking changes
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -19,6 +19,8 @@
 
 	<Product>$(AssemblyName) ($(TargetFramework))</Product>
 	<DefaultLanguage>en-US</DefaultLanguage>
+
+	<UnoSourceGeneratorUseGenerationHost>true</UnoSourceGeneratorUseGenerationHost>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+++ b/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
@@ -61,7 +61,7 @@
   </ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.178</Version>
+			<Version>1.29.0-dev.182</Version>
 			<NoWarn>NU1701</NoWarn>
 		</PackageReference>
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.0-dev.112" />

--- a/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+++ b/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
@@ -61,7 +61,7 @@
   </ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.161</Version>
+			<Version>1.29.0-dev.178</Version>
 			<NoWarn>NU1701</NoWarn>
 		</PackageReference>
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.0-dev.112" />

--- a/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+++ b/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
@@ -61,7 +61,7 @@
   </ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.157</Version>
+			<Version>1.29.0-dev.161</Version>
 			<NoWarn>NU1701</NoWarn>
 		</PackageReference>
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.0-dev.112" />

--- a/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
+++ b/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
@@ -32,7 +32,7 @@
 	
   <ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.161</Version>
+			<Version>1.29.0-dev.178</Version>
 			<NoWarn>NU1701</NoWarn>
 		</PackageReference>
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.0-dev.117" />

--- a/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
+++ b/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
@@ -32,7 +32,7 @@
 	
   <ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.157</Version>
+			<Version>1.29.0-dev.161</Version>
 			<NoWarn>NU1701</NoWarn>
 		</PackageReference>
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.0-dev.117" />

--- a/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
+++ b/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
@@ -32,7 +32,7 @@
 	
   <ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.178</Version>
+			<Version>1.29.0-dev.182</Version>
 			<NoWarn>NU1701</NoWarn>
 		</PackageReference>
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.0-dev.117" />

--- a/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
+++ b/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
@@ -107,7 +107,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.157</Version>
+      <Version>1.29.0-dev.161</Version>
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />

--- a/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
+++ b/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
@@ -107,7 +107,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.161</Version>
+      <Version>1.29.0-dev.178</Version>
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />

--- a/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
+++ b/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
@@ -107,7 +107,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.178</Version>
+      <Version>1.29.0-dev.182</Version>
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />

--- a/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
+++ b/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
@@ -62,7 +62,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.161</Version>
+			<Version>1.29.0-dev.178</Version>
 			<NoWarn>NU1701</NoWarn>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />

--- a/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
+++ b/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
@@ -62,7 +62,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.157</Version>
+			<Version>1.29.0-dev.161</Version>
 			<NoWarn>NU1701</NoWarn>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />

--- a/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
+++ b/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
@@ -62,7 +62,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.178</Version>
+			<Version>1.29.0-dev.182</Version>
 			<NoWarn>NU1701</NoWarn>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
@@ -64,10 +64,10 @@
       <Version>1.25.0-dev.56</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGeneration">
-      <Version>1.29.0-dev.161</Version>
+      <Version>1.29.0-dev.178</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.161</Version>
+      <Version>1.29.0-dev.178</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
@@ -1,173 +1,172 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-	<PropertyGroup>
-		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-		<ProjectGuid>{68E667C4-AAED-4242-A47F-3D77C33C489E}</ProjectGuid>
-		<OutputType>Library</OutputType>
-		<AppDesignerFolder>Properties</AppDesignerFolder>
-		<RootNamespace>Uno.UI.SourceGenerators</RootNamespace>
-		<AssemblyName>Uno.UI.SourceGenerators</AssemblyName>
-		<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-		<FileAlignment>512</FileAlignment>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-		<DebugSymbols>true</DebugSymbols>
-		<DebugType>pdbonly</DebugType>
-		<Optimize>false</Optimize>
-		<OutputPath>bin\Debug\</OutputPath>
-		<DefineConstants>DEBUG;TRACE</DefineConstants>
-		<ErrorReport>prompt</ErrorReport>
-		<WarningLevel>4</WarningLevel>
-	</PropertyGroup>
-	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-		<DebugType>pdbonly</DebugType>
-		<Optimize>true</Optimize>
-		<OutputPath>bin\Release\</OutputPath>
-		<DefineConstants>TRACE</DefineConstants>
-		<ErrorReport>prompt</ErrorReport>
-		<WarningLevel>4</WarningLevel>
-	</PropertyGroup>
-	<ItemGroup>
-		<Reference Include="System" />
-		<Reference Include="System.Core" />
-		<Reference Include="System.Drawing" />
-		<Reference Include="System.Xaml">
-			<Aliases>__ms</Aliases>
-		</Reference>
-		<Reference Include="System.Xml.Linq" />
-		<Reference Include="System.Data.DataSetExtensions" />
-		<Reference Include="Microsoft.CSharp" />
-		<Reference Include="System.Data" />
-		<Reference Include="System.Net.Http" />
-		<Reference Include="System.Xml" />
-	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.Common">
-			<Version>2.3.1</Version>
-			<ExcludeAssets>runtime</ExcludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp">
-			<Version>2.3.1</Version>
-			<ExcludeAssets>runtime</ExcludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-			<Version>2.3.1</Version>
-			<ExcludeAssets>runtime</ExcludeAssets>
-		</PackageReference>
-		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
-			<Version>2.3.1</Version>
-			<ExcludeAssets>runtime</ExcludeAssets>
-		</PackageReference>
-
-		<PackageReference Include="Uno.Core">
-			<Version>1.25.0-dev.56</Version>
-		</PackageReference>
-		<PackageReference Include="Uno.SourceGeneration">
-			<Version>1.28.0-dev.145</Version>
-		</PackageReference>
-		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.28.0-dev.145</Version>
-		</PackageReference>
-	</ItemGroup>
-	<ItemGroup>
-		<Compile Include="..\..\Uno.Foundation\Point.cs">
-			<Link>XamlGenerator\XamlPathParser\Point.cs</Link>
-		</Compile>
-		<Compile Include="..\..\Uno.Foundation\Size.cs">
-			<Link>XamlGenerator\XamlPathParser\Size.cs</Link>
-		</Compile>
-		<Compile Include="..\..\Uno.Foundation\SizeConverter.cs">
-			<Link>XamlGenerator\XamlPathParser\SizeConverter.cs</Link>
-		</Compile>
-		<Compile Include="..\..\Uno.UI\Media\PathMarkupParser.cs">
-			<Link>XamlGenerator\XamlPathParser\PathMarkupParser.cs</Link>
-		</Compile>
-		<Compile Include="..\..\Uno.UI\Media\StreamGeometryContext.cs">
-			<Link>XamlGenerator\XamlPathParser\StreamGeometryContext.cs</Link>
-		</Compile>
-		<Compile Include="..\..\Uno.UI\UI\Xaml\Media\FillRule.cs">
-			<Link>XamlGenerator\XamlPathParser\FillRule.cs</Link>
-		</Compile>
-		<Compile Include="..\..\Uno.UI\UI\Xaml\Media\SweepDirection.cs">
-			<Link>XamlGenerator\XamlPathParser\SweepDirection.cs</Link>
-		</Compile>
-		<Compile Include="..\..\Uno.UI\UI\Xaml\GridLength.cs">
-			<Link>Helpers\GridLength.cs</Link>
-		</Compile>
-		<Compile Include="..\..\Uno.UI\UI\Xaml\GridLengthHelper.cs">
-			<Link>Helpers\GridLengthHelper.cs</Link>
-		</Compile>
-		<Compile Include="..\..\Uno.UI\UI\Xaml\GridUnitType.cs">
-			<Link>Helpers\GridUnitType.cs</Link>
-		</Compile>
-		<Compile Include="BindableTypeProviders\BindableTypeProvidersGenerationTask.cs" />
-		<Compile Include="DependencyObject\DependencyObjectGenerator.cs" />
-		<Compile Include="DependencyObject\MethodCallFinder.cs" />
-		<Compile Include="Helpers\AnalyzerSuppressions.cs" />
-		<Compile Include="Helpers\HashBuilder.cs" />
-		<Compile Include="Helpers\PathHelper.cs" />
-		<Compile Include="Helpers\RoslynMetadataHelper.cs" />
-		<Compile Include="Helpers\SymbolExtensions.cs" />
-		<Compile Include="NativeCtor\NativeCtorsGenerator.cs" />
-		<Compile Include="Properties\AssemblyInfo.cs" />
-		<Compile Include="XamlGenerator\BackingFieldDefinition.cs" />
-		<Compile Include="XamlGenerator\NameScope.cs" />
-		<Compile Include="XamlGenerator\PlatformHelper.cs" />
-		<Compile Include="XamlGenerator\XamlPathParser\GeneratedStreamGeometryContext.cs" />
-		<Compile Include="XamlGenerator\XamlRedirection\XamlConfig.cs" />
-		<Compile Include="XamlGenerator\XamlRedirection\XamlXmlReaderSettings.cs" />
-		<Compile Include="XamlGenerator\XamlRedirection\XamlNodeType.cs" />
-		<Compile Include="XamlGenerator\XamlRedirection\XamlXmlReader.cs" />
-		<Compile Include="XamlGenerator\XamlRedirection\NamespaceDeclaration.cs" />
-		<Compile Include="XamlGenerator\Subclass.cs" />
-		<Compile Include="XamlGenerator\Utils\ColorCodeParser.cs" />
-		<Compile Include="XamlGenerator\XamlCodeGeneration.cs" />
-		<Compile Include="XamlGenerator\XamlCodeGenerator.cs" />
-		<Compile Include="XamlGenerator\XamlConstants.cs" />
-		<Compile Include="XamlGenerator\XamlFileDefinition.cs" />
-		<Compile Include="XamlGenerator\XamlFileGenerator.cs" />
-		<Compile Include="XamlGenerator\XamlFileParser.cs" />
-		<Compile Include="XamlGenerator\XamlGlobalStaticResourcesMap.cs" />
-		<Compile Include="XamlGenerator\XamlLazyApplyBlockIIndentedStringBuilder.cs" />
-		<Compile Include="XamlGenerator\XamlRedirection\XamlSchemaContext.cs" />
-		<Compile Include="XamlGenerator\XamlRedirection\XamlMember.cs" />
-		<Compile Include="XamlGenerator\XamlMemberDefinition.cs" />
-		<Compile Include="XamlGenerator\XamlObjectDefinition.cs" />
-		<Compile Include="XamlGenerator\XamlPathParser\Parsers.cs" />
-		<Compile Include="XamlGenerator\XamlRedirection\XamlType.cs" />
-	</ItemGroup>
-	<ItemGroup>
-		<None Include="Content\Uno.UI.SourceGenerators.props" />
-	</ItemGroup>
-	<ItemGroup>
-		<ProjectReference Include="..\System.Xaml\Uno.Xaml.csproj">
-			<Project>{1627740a-19d2-4d21-a0b2-66667038daf6}</Project>
-			<Name>Uno.Xaml</Name>
-			<Aliases>__uno</Aliases>
-		</ProjectReference>
-	</ItemGroup>
-	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-	<Target Name="_UnoToolkitOverrideNuget" AfterTargets="AfterBuild" DependsOnTargets="BuiltProjectOutputGroup" Condition="'$(UnoNugetOverrideVersion)'!=''">
-		<PropertyGroup>
-			<_OverrideTargetFramework>$(TargetFramework)</_OverrideTargetFramework>
-			<_TargetNugetFolder>$(USERPROFILE)\.nuget\packages\Uno.UI\$(UnoNugetOverrideVersion)\tools\$(_OverrideTargetFramework)</_TargetNugetFolder>
-		</PropertyGroup>
-		<ItemGroup>
-			<_OutputFiles Include="$(TargetDir)*.*" />
-		</ItemGroup>
-		<MakeDir Directories="$(_TargetNugetFolder)" />
-		<Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder)" />
-		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_OutputFiles-&gt;'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
-		<Copy SourceFiles="@(_OutputFilesPDB)" DestinationFiles="@(_OutputFilesPDB-&gt;'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename).pdb')" />
-	</Target>
-	<!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{68E667C4-AAED-4242-A47F-3D77C33C489E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Uno.UI.SourceGenerators</RootNamespace>
+    <AssemblyName>Uno.UI.SourceGenerators</AssemblyName>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Xaml">
+      <Aliases>__ms</Aliases>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common">
+      <Version>2.3.1</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp">
+      <Version>2.3.1</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
+      <Version>2.3.1</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
+      <Version>2.3.1</Version>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
+    <PackageReference Include="Uno.Core">
+      <Version>1.25.0-dev.56</Version>
+    </PackageReference>
+    <PackageReference Include="Uno.SourceGeneration">
+      <Version>1.29.0-dev.161</Version>
+    </PackageReference>
+    <PackageReference Include="Uno.SourceGenerationTasks">
+      <Version>1.29.0-dev.161</Version>
+    </PackageReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Uno.Foundation\Point.cs">
+      <Link>XamlGenerator\XamlPathParser\Point.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Uno.Foundation\Size.cs">
+      <Link>XamlGenerator\XamlPathParser\Size.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Uno.Foundation\SizeConverter.cs">
+      <Link>XamlGenerator\XamlPathParser\SizeConverter.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Uno.UI\Media\PathMarkupParser.cs">
+      <Link>XamlGenerator\XamlPathParser\PathMarkupParser.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Uno.UI\Media\StreamGeometryContext.cs">
+      <Link>XamlGenerator\XamlPathParser\StreamGeometryContext.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Uno.UI\UI\Xaml\Media\FillRule.cs">
+      <Link>XamlGenerator\XamlPathParser\FillRule.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Uno.UI\UI\Xaml\Media\SweepDirection.cs">
+      <Link>XamlGenerator\XamlPathParser\SweepDirection.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Uno.UI\UI\Xaml\GridLength.cs">
+      <Link>Helpers\GridLength.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Uno.UI\UI\Xaml\GridLengthHelper.cs">
+      <Link>Helpers\GridLengthHelper.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Uno.UI\UI\Xaml\GridUnitType.cs">
+      <Link>Helpers\GridUnitType.cs</Link>
+    </Compile>
+    <Compile Include="BindableTypeProviders\BindableTypeProvidersGenerationTask.cs" />
+    <Compile Include="DependencyObject\DependencyObjectGenerator.cs" />
+    <Compile Include="DependencyObject\MethodCallFinder.cs" />
+    <Compile Include="Helpers\AnalyzerSuppressions.cs" />
+    <Compile Include="Helpers\HashBuilder.cs" />
+    <Compile Include="Helpers\PathHelper.cs" />
+    <Compile Include="Helpers\RoslynMetadataHelper.cs" />
+    <Compile Include="Helpers\SymbolExtensions.cs" />
+    <Compile Include="NativeCtor\NativeCtorsGenerator.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="XamlGenerator\BackingFieldDefinition.cs" />
+    <Compile Include="XamlGenerator\NameScope.cs" />
+    <Compile Include="XamlGenerator\PlatformHelper.cs" />
+    <Compile Include="XamlGenerator\XamlPathParser\GeneratedStreamGeometryContext.cs" />
+    <Compile Include="XamlGenerator\XamlRedirection\XamlConfig.cs" />
+    <Compile Include="XamlGenerator\XamlRedirection\XamlXmlReaderSettings.cs" />
+    <Compile Include="XamlGenerator\XamlRedirection\XamlNodeType.cs" />
+    <Compile Include="XamlGenerator\XamlRedirection\XamlXmlReader.cs" />
+    <Compile Include="XamlGenerator\XamlRedirection\NamespaceDeclaration.cs" />
+    <Compile Include="XamlGenerator\Subclass.cs" />
+    <Compile Include="XamlGenerator\Utils\ColorCodeParser.cs" />
+    <Compile Include="XamlGenerator\XamlCodeGeneration.cs" />
+    <Compile Include="XamlGenerator\XamlCodeGenerator.cs" />
+    <Compile Include="XamlGenerator\XamlConstants.cs" />
+    <Compile Include="XamlGenerator\XamlFileDefinition.cs" />
+    <Compile Include="XamlGenerator\XamlFileGenerator.cs" />
+    <Compile Include="XamlGenerator\XamlFileParser.cs" />
+    <Compile Include="XamlGenerator\XamlGlobalStaticResourcesMap.cs" />
+    <Compile Include="XamlGenerator\XamlLazyApplyBlockIIndentedStringBuilder.cs" />
+    <Compile Include="XamlGenerator\XamlRedirection\XamlSchemaContext.cs" />
+    <Compile Include="XamlGenerator\XamlRedirection\XamlMember.cs" />
+    <Compile Include="XamlGenerator\XamlMemberDefinition.cs" />
+    <Compile Include="XamlGenerator\XamlObjectDefinition.cs" />
+    <Compile Include="XamlGenerator\XamlPathParser\Parsers.cs" />
+    <Compile Include="XamlGenerator\XamlRedirection\XamlType.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Content\Uno.UI.SourceGenerators.props" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\System.Xaml\Uno.Xaml.csproj">
+      <Project>{1627740a-19d2-4d21-a0b2-66667038daf6}</Project>
+      <Name>Uno.Xaml</Name>
+      <Aliases>__uno</Aliases>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="_UnoToolkitOverrideNuget" AfterTargets="AfterBuild" DependsOnTargets="BuiltProjectOutputGroup" Condition="'$(UnoNugetOverrideVersion)'!=''">
+    <PropertyGroup>
+      <_OverrideTargetFramework>$(TargetFramework)</_OverrideTargetFramework>
+      <_TargetNugetFolder>$(USERPROFILE)\.nuget\packages\Uno.UI\$(UnoNugetOverrideVersion)\tools\$(_OverrideTargetFramework)</_TargetNugetFolder>
+    </PropertyGroup>
+    <ItemGroup>
+      <_OutputFiles Include="$(TargetDir)*.*" />
+    </ItemGroup>
+    <MakeDir Directories="$(_TargetNugetFolder)" />
+    <Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder)" />
+    <Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+    <Copy SourceFiles="@(_OutputFilesPDB)" DestinationFiles="@(_OutputFilesPDB->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename).pdb')" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
   <Target Name="AfterBuild">
   </Target>
   -->
-	<Import Project="..\..\Common.targets" />
+  <Import Project="..\..\Common.targets" />
 </Project>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Uno.UI.SourceGenerators</RootNamespace>
     <AssemblyName>Uno.UI.SourceGenerators</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -64,10 +64,10 @@
       <Version>1.25.0-dev.56</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGeneration">
-      <Version>1.29.0-dev.178</Version>
+      <Version>1.29.0-dev.182</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.178</Version>
+      <Version>1.29.0-dev.182</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/Uno.UI.SourceGenerators.csproj
@@ -1,160 +1,173 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{68E667C4-AAED-4242-A47F-3D77C33C489E}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Uno.UI.SourceGenerators</RootNamespace>
-    <AssemblyName>Uno.UI.SourceGenerators</AssemblyName>
-    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Xaml">
-      <Aliases>__ms</Aliases>
-    </Reference>
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis">
-      <Version>2.3.1</Version>
-    </PackageReference>
-    <PackageReference Include="Uno.Core">
-      <Version>1.26.0-dev.58</Version>
-    </PackageReference>
-    <PackageReference Include="Uno.SourceGeneration">
-      <Version>1.29.0-dev.157</Version>
-    </PackageReference>
-    <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.157</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="..\..\Uno.Foundation\Point.cs">
-      <Link>XamlGenerator\XamlPathParser\Point.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Uno.Foundation\Size.cs">
-      <Link>XamlGenerator\XamlPathParser\Size.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Uno.Foundation\SizeConverter.cs">
-      <Link>XamlGenerator\XamlPathParser\SizeConverter.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Uno.UI\Media\PathMarkupParser.cs">
-      <Link>XamlGenerator\XamlPathParser\PathMarkupParser.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Uno.UI\Media\StreamGeometryContext.cs">
-      <Link>XamlGenerator\XamlPathParser\StreamGeometryContext.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Uno.UI\UI\Xaml\Media\FillRule.cs">
-      <Link>XamlGenerator\XamlPathParser\FillRule.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Uno.UI\UI\Xaml\Media\SweepDirection.cs">
-      <Link>XamlGenerator\XamlPathParser\SweepDirection.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Uno.UI\UI\Xaml\GridLength.cs">
-      <Link>Helpers\GridLength.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Uno.UI\UI\Xaml\GridLengthHelper.cs">
-      <Link>Helpers\GridLengthHelper.cs</Link>
-    </Compile>
-    <Compile Include="..\..\Uno.UI\UI\Xaml\GridUnitType.cs">
-      <Link>Helpers\GridUnitType.cs</Link>
-    </Compile>
-    <Compile Include="BindableTypeProviders\BindableTypeProvidersGenerationTask.cs" />
-    <Compile Include="DependencyObject\DependencyObjectGenerator.cs" />
-    <Compile Include="DependencyObject\MethodCallFinder.cs" />
-    <Compile Include="Helpers\AnalyzerSuppressions.cs" />
-    <Compile Include="Helpers\HashBuilder.cs" />
-    <Compile Include="Helpers\PathHelper.cs" />
-    <Compile Include="Helpers\RoslynMetadataHelper.cs" />
-    <Compile Include="Helpers\SymbolExtensions.cs" />
-    <Compile Include="NativeCtor\NativeCtorsGenerator.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TSBindings\TSBindingsGenerator.cs" />
-    <Compile Include="XamlGenerator\BackingFieldDefinition.cs" />
-    <Compile Include="XamlGenerator\NameScope.cs" />
-    <Compile Include="XamlGenerator\PlatformHelper.cs" />
-    <Compile Include="XamlGenerator\XamlPathParser\GeneratedStreamGeometryContext.cs" />
-    <Compile Include="XamlGenerator\XamlRedirection\XamlConfig.cs" />
-    <Compile Include="XamlGenerator\XamlRedirection\XamlXmlReaderSettings.cs" />
-    <Compile Include="XamlGenerator\XamlRedirection\XamlNodeType.cs" />
-    <Compile Include="XamlGenerator\XamlRedirection\XamlXmlReader.cs" />
-    <Compile Include="XamlGenerator\XamlRedirection\NamespaceDeclaration.cs" />
-    <Compile Include="XamlGenerator\Subclass.cs" />
-    <Compile Include="XamlGenerator\Utils\ColorCodeParser.cs" />
-    <Compile Include="XamlGenerator\XamlCodeGeneration.cs" />
-    <Compile Include="XamlGenerator\XamlCodeGenerator.cs" />
-    <Compile Include="XamlGenerator\XamlConstants.cs" />
-    <Compile Include="XamlGenerator\XamlFileDefinition.cs" />
-    <Compile Include="XamlGenerator\XamlFileGenerator.cs" />
-    <Compile Include="XamlGenerator\XamlFileParser.cs" />
-    <Compile Include="XamlGenerator\XamlGlobalStaticResourcesMap.cs" />
-    <Compile Include="XamlGenerator\XamlLazyApplyBlockIIndentedStringBuilder.cs" />
-    <Compile Include="XamlGenerator\XamlRedirection\XamlSchemaContext.cs" />
-    <Compile Include="XamlGenerator\XamlRedirection\XamlMember.cs" />
-    <Compile Include="XamlGenerator\XamlMemberDefinition.cs" />
-    <Compile Include="XamlGenerator\XamlObjectDefinition.cs" />
-    <Compile Include="XamlGenerator\XamlPathParser\Parsers.cs" />
-    <Compile Include="XamlGenerator\XamlRedirection\XamlType.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Content\Uno.UI.SourceGenerators.props" />
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\System.Xaml\Uno.Xaml.csproj">
-      <Project>{1627740a-19d2-4d21-a0b2-66667038daf6}</Project>
-      <Name>Uno.Xaml</Name>
-      <Aliases>__uno</Aliases>
-    </ProjectReference>
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="_UnoToolkitOverrideNuget" AfterTargets="AfterBuild" DependsOnTargets="BuiltProjectOutputGroup" Condition="'$(UnoNugetOverrideVersion)'!=''">
-    <PropertyGroup>
-      <_OverrideTargetFramework>$(TargetFramework)</_OverrideTargetFramework>
-      <_TargetNugetFolder>$(USERPROFILE)\.nuget\packages\Uno.UI\$(UnoNugetOverrideVersion)\tools\$(_OverrideTargetFramework)</_TargetNugetFolder>
-    </PropertyGroup>
-    <ItemGroup>
-      <_OutputFiles Include="$(TargetDir)*.*" />
-    </ItemGroup>
-    <MakeDir Directories="$(_TargetNugetFolder)" />
-    <Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder)" />
-    <Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
-    <Copy SourceFiles="@(_OutputFilesPDB)" DestinationFiles="@(_OutputFilesPDB->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename).pdb')" />
-  </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+	<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<ProjectGuid>{68E667C4-AAED-4242-A47F-3D77C33C489E}</ProjectGuid>
+		<OutputType>Library</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<RootNamespace>Uno.UI.SourceGenerators</RootNamespace>
+		<AssemblyName>Uno.UI.SourceGenerators</AssemblyName>
+		<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+		<FileAlignment>512</FileAlignment>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DebugSymbols>true</DebugSymbols>
+		<DebugType>pdbonly</DebugType>
+		<Optimize>false</Optimize>
+		<OutputPath>bin\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>pdbonly</DebugType>
+		<Optimize>true</Optimize>
+		<OutputPath>bin\Release\</OutputPath>
+		<DefineConstants>TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+	</PropertyGroup>
+	<ItemGroup>
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Drawing" />
+		<Reference Include="System.Xaml">
+			<Aliases>__ms</Aliases>
+		</Reference>
+		<Reference Include="System.Xml.Linq" />
+		<Reference Include="System.Data.DataSetExtensions" />
+		<Reference Include="Microsoft.CSharp" />
+		<Reference Include="System.Data" />
+		<Reference Include="System.Net.Http" />
+		<Reference Include="System.Xml" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.Common">
+			<Version>2.3.1</Version>
+			<ExcludeAssets>runtime</ExcludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp">
+			<Version>2.3.1</Version>
+			<ExcludeAssets>runtime</ExcludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
+			<Version>2.3.1</Version>
+			<ExcludeAssets>runtime</ExcludeAssets>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
+			<Version>2.3.1</Version>
+			<ExcludeAssets>runtime</ExcludeAssets>
+		</PackageReference>
+
+		<PackageReference Include="Uno.Core">
+			<Version>1.25.0-dev.56</Version>
+		</PackageReference>
+		<PackageReference Include="Uno.SourceGeneration">
+			<Version>1.28.0-dev.145</Version>
+		</PackageReference>
+		<PackageReference Include="Uno.SourceGenerationTasks">
+			<Version>1.28.0-dev.145</Version>
+		</PackageReference>
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="..\..\Uno.Foundation\Point.cs">
+			<Link>XamlGenerator\XamlPathParser\Point.cs</Link>
+		</Compile>
+		<Compile Include="..\..\Uno.Foundation\Size.cs">
+			<Link>XamlGenerator\XamlPathParser\Size.cs</Link>
+		</Compile>
+		<Compile Include="..\..\Uno.Foundation\SizeConverter.cs">
+			<Link>XamlGenerator\XamlPathParser\SizeConverter.cs</Link>
+		</Compile>
+		<Compile Include="..\..\Uno.UI\Media\PathMarkupParser.cs">
+			<Link>XamlGenerator\XamlPathParser\PathMarkupParser.cs</Link>
+		</Compile>
+		<Compile Include="..\..\Uno.UI\Media\StreamGeometryContext.cs">
+			<Link>XamlGenerator\XamlPathParser\StreamGeometryContext.cs</Link>
+		</Compile>
+		<Compile Include="..\..\Uno.UI\UI\Xaml\Media\FillRule.cs">
+			<Link>XamlGenerator\XamlPathParser\FillRule.cs</Link>
+		</Compile>
+		<Compile Include="..\..\Uno.UI\UI\Xaml\Media\SweepDirection.cs">
+			<Link>XamlGenerator\XamlPathParser\SweepDirection.cs</Link>
+		</Compile>
+		<Compile Include="..\..\Uno.UI\UI\Xaml\GridLength.cs">
+			<Link>Helpers\GridLength.cs</Link>
+		</Compile>
+		<Compile Include="..\..\Uno.UI\UI\Xaml\GridLengthHelper.cs">
+			<Link>Helpers\GridLengthHelper.cs</Link>
+		</Compile>
+		<Compile Include="..\..\Uno.UI\UI\Xaml\GridUnitType.cs">
+			<Link>Helpers\GridUnitType.cs</Link>
+		</Compile>
+		<Compile Include="BindableTypeProviders\BindableTypeProvidersGenerationTask.cs" />
+		<Compile Include="DependencyObject\DependencyObjectGenerator.cs" />
+		<Compile Include="DependencyObject\MethodCallFinder.cs" />
+		<Compile Include="Helpers\AnalyzerSuppressions.cs" />
+		<Compile Include="Helpers\HashBuilder.cs" />
+		<Compile Include="Helpers\PathHelper.cs" />
+		<Compile Include="Helpers\RoslynMetadataHelper.cs" />
+		<Compile Include="Helpers\SymbolExtensions.cs" />
+		<Compile Include="NativeCtor\NativeCtorsGenerator.cs" />
+		<Compile Include="Properties\AssemblyInfo.cs" />
+		<Compile Include="XamlGenerator\BackingFieldDefinition.cs" />
+		<Compile Include="XamlGenerator\NameScope.cs" />
+		<Compile Include="XamlGenerator\PlatformHelper.cs" />
+		<Compile Include="XamlGenerator\XamlPathParser\GeneratedStreamGeometryContext.cs" />
+		<Compile Include="XamlGenerator\XamlRedirection\XamlConfig.cs" />
+		<Compile Include="XamlGenerator\XamlRedirection\XamlXmlReaderSettings.cs" />
+		<Compile Include="XamlGenerator\XamlRedirection\XamlNodeType.cs" />
+		<Compile Include="XamlGenerator\XamlRedirection\XamlXmlReader.cs" />
+		<Compile Include="XamlGenerator\XamlRedirection\NamespaceDeclaration.cs" />
+		<Compile Include="XamlGenerator\Subclass.cs" />
+		<Compile Include="XamlGenerator\Utils\ColorCodeParser.cs" />
+		<Compile Include="XamlGenerator\XamlCodeGeneration.cs" />
+		<Compile Include="XamlGenerator\XamlCodeGenerator.cs" />
+		<Compile Include="XamlGenerator\XamlConstants.cs" />
+		<Compile Include="XamlGenerator\XamlFileDefinition.cs" />
+		<Compile Include="XamlGenerator\XamlFileGenerator.cs" />
+		<Compile Include="XamlGenerator\XamlFileParser.cs" />
+		<Compile Include="XamlGenerator\XamlGlobalStaticResourcesMap.cs" />
+		<Compile Include="XamlGenerator\XamlLazyApplyBlockIIndentedStringBuilder.cs" />
+		<Compile Include="XamlGenerator\XamlRedirection\XamlSchemaContext.cs" />
+		<Compile Include="XamlGenerator\XamlRedirection\XamlMember.cs" />
+		<Compile Include="XamlGenerator\XamlMemberDefinition.cs" />
+		<Compile Include="XamlGenerator\XamlObjectDefinition.cs" />
+		<Compile Include="XamlGenerator\XamlPathParser\Parsers.cs" />
+		<Compile Include="XamlGenerator\XamlRedirection\XamlType.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="Content\Uno.UI.SourceGenerators.props" />
+	</ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\System.Xaml\Uno.Xaml.csproj">
+			<Project>{1627740a-19d2-4d21-a0b2-66667038daf6}</Project>
+			<Name>Uno.Xaml</Name>
+			<Aliases>__uno</Aliases>
+		</ProjectReference>
+	</ItemGroup>
+	<Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+	<Target Name="_UnoToolkitOverrideNuget" AfterTargets="AfterBuild" DependsOnTargets="BuiltProjectOutputGroup" Condition="'$(UnoNugetOverrideVersion)'!=''">
+		<PropertyGroup>
+			<_OverrideTargetFramework>$(TargetFramework)</_OverrideTargetFramework>
+			<_TargetNugetFolder>$(USERPROFILE)\.nuget\packages\Uno.UI\$(UnoNugetOverrideVersion)\tools\$(_OverrideTargetFramework)</_TargetNugetFolder>
+		</PropertyGroup>
+		<ItemGroup>
+			<_OutputFiles Include="$(TargetDir)*.*" />
+		</ItemGroup>
+		<MakeDir Directories="$(_TargetNugetFolder)" />
+		<Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder)" />
+		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_OutputFiles-&gt;'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+		<Copy SourceFiles="@(_OutputFilesPDB)" DestinationFiles="@(_OutputFilesPDB-&gt;'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename).pdb')" />
+	</Target>
+	<!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
   <Target Name="AfterBuild">
   </Target>
   -->
-  <Import Project="..\..\Common.targets" />
+	<Import Project="..\..\Common.targets" />
 </Project>

--- a/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
+++ b/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
@@ -58,7 +58,7 @@
       <Version>1.26.0-dev.58</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.157</Version>
+      <Version>1.29.0-dev.161</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
+++ b/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
@@ -58,7 +58,7 @@
       <Version>1.26.0-dev.58</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.178</Version>
+      <Version>1.29.0-dev.182</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
+++ b/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
@@ -58,7 +58,7 @@
       <Version>1.26.0-dev.58</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.161</Version>
+      <Version>1.29.0-dev.178</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/SourceGenerators/XamlGenerationTests.Core/XamlGenerationTests.Core.csproj
+++ b/src/SourceGenerators/XamlGenerationTests.Core/XamlGenerationTests.Core.csproj
@@ -14,7 +14,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.178</Version>
+			<Version>1.29.0-dev.182</Version>
 			<ExcludeAssets>Runtime</ExcludeAssets>
 		</PackageReference>
 		<PackageReference Include="Uno.Core.Build">

--- a/src/SourceGenerators/XamlGenerationTests.Core/XamlGenerationTests.Core.csproj
+++ b/src/SourceGenerators/XamlGenerationTests.Core/XamlGenerationTests.Core.csproj
@@ -14,7 +14,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.157</Version>
+			<Version>1.29.0-dev.161</Version>
 			<ExcludeAssets>Runtime</ExcludeAssets>
 		</PackageReference>
 		<PackageReference Include="Uno.Core.Build">

--- a/src/SourceGenerators/XamlGenerationTests.Core/XamlGenerationTests.Core.csproj
+++ b/src/SourceGenerators/XamlGenerationTests.Core/XamlGenerationTests.Core.csproj
@@ -14,7 +14,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.161</Version>
+			<Version>1.29.0-dev.178</Version>
 			<ExcludeAssets>Runtime</ExcludeAssets>
 		</PackageReference>
 		<PackageReference Include="Uno.Core.Build">

--- a/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
+++ b/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
@@ -14,7 +14,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.178</Version>
+			<Version>1.29.0-dev.182</Version>
 			<ExcludeAssets>Runtime</ExcludeAssets>
 		</PackageReference>
 		<PackageReference Include="Uno.Core.Build">

--- a/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
+++ b/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
@@ -14,7 +14,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.157</Version>
+			<Version>1.29.0-dev.161</Version>
 			<ExcludeAssets>Runtime</ExcludeAssets>
 		</PackageReference>
 		<PackageReference Include="Uno.Core.Build">

--- a/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
+++ b/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
@@ -14,7 +14,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.161</Version>
+			<Version>1.29.0-dev.178</Version>
 			<ExcludeAssets>Runtime</ExcludeAssets>
 		</PackageReference>
 		<PackageReference Include="Uno.Core.Build">

--- a/src/Uno.Foundation/Uno.Foundation.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.csproj
@@ -17,7 +17,7 @@
 	<ItemGroup>
 		<PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.161</Version>
+      <Version>1.29.0-dev.178</Version>
       <ExcludeAssets>Runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Uno.Core">

--- a/src/Uno.Foundation/Uno.Foundation.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.csproj
@@ -17,7 +17,7 @@
 	<ItemGroup>
 		<PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.157</Version>
+      <Version>1.29.0-dev.161</Version>
       <ExcludeAssets>Runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Uno.Core">

--- a/src/Uno.Foundation/Uno.Foundation.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.csproj
@@ -17,7 +17,7 @@
 	<ItemGroup>
 		<PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.178</Version>
+      <Version>1.29.0-dev.182</Version>
       <ExcludeAssets>Runtime</ExcludeAssets>
     </PackageReference>
     <PackageReference Include="Uno.Core">

--- a/src/Uno.UI.Maps/Uno.UI.Maps.csproj
+++ b/src/Uno.UI.Maps/Uno.UI.Maps.csproj
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.157</Version>
+			<Version>1.29.0-dev.161</Version>
 		</PackageReference>
 		<PackageReference Include="Uno.Core">
 			<Version>1.26.0-dev.58</Version>

--- a/src/Uno.UI.Maps/Uno.UI.Maps.csproj
+++ b/src/Uno.UI.Maps/Uno.UI.Maps.csproj
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.178</Version>
+			<Version>1.29.0-dev.182</Version>
 		</PackageReference>
 		<PackageReference Include="Uno.Core">
 			<Version>1.26.0-dev.58</Version>

--- a/src/Uno.UI.Maps/Uno.UI.Maps.csproj
+++ b/src/Uno.UI.Maps/Uno.UI.Maps.csproj
@@ -22,7 +22,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.161</Version>
+			<Version>1.29.0-dev.178</Version>
 		</PackageReference>
 		<PackageReference Include="Uno.Core">
 			<Version>1.26.0-dev.58</Version>

--- a/src/Uno.UI.Tests.Performance/Uno.UI.Tests.Performance.csproj
+++ b/src/Uno.UI.Tests.Performance/Uno.UI.Tests.Performance.csproj
@@ -45,7 +45,7 @@
       <Version>1.3.1</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.157</Version>
+      <Version>1.29.0-dev.161</Version>
     </PackageReference>
     <PackageReference Include="Uno.Core">
       <Version>1.26.0-dev.58</Version>

--- a/src/Uno.UI.Tests.Performance/Uno.UI.Tests.Performance.csproj
+++ b/src/Uno.UI.Tests.Performance/Uno.UI.Tests.Performance.csproj
@@ -45,7 +45,7 @@
       <Version>1.3.1</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.178</Version>
+      <Version>1.29.0-dev.182</Version>
     </PackageReference>
     <PackageReference Include="Uno.Core">
       <Version>1.26.0-dev.58</Version>

--- a/src/Uno.UI.Tests.Performance/Uno.UI.Tests.Performance.csproj
+++ b/src/Uno.UI.Tests.Performance/Uno.UI.Tests.Performance.csproj
@@ -45,7 +45,7 @@
       <Version>1.3.1</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.161</Version>
+      <Version>1.29.0-dev.178</Version>
     </PackageReference>
     <PackageReference Include="Uno.Core">
       <Version>1.26.0-dev.58</Version>

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -45,7 +45,7 @@
       <Version>1.3.1</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.157</Version>
+      <Version>1.29.0-dev.161</Version>
     </PackageReference>
     <PackageReference Include="Uno.Core">
       <Version>1.26.0-dev.58</Version>

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -45,7 +45,7 @@
       <Version>1.3.1</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.178</Version>
+      <Version>1.29.0-dev.182</Version>
     </PackageReference>
     <PackageReference Include="Uno.Core">
       <Version>1.26.0-dev.58</Version>

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -45,7 +45,7 @@
       <Version>1.3.1</Version>
     </PackageReference>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.161</Version>
+      <Version>1.29.0-dev.178</Version>
     </PackageReference>
     <PackageReference Include="Uno.Core">
       <Version>1.26.0-dev.58</Version>

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.161</Version>
+      <Version>1.29.0-dev.178</Version>
     </PackageReference>
     <PackageReference Include="Uno.Core">
       <Version>1.26.0-dev.58</Version>

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.178</Version>
+      <Version>1.29.0-dev.182</Version>
     </PackageReference>
     <PackageReference Include="Uno.Core">
       <Version>1.26.0-dev.58</Version>

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -22,7 +22,7 @@
 
   <ItemGroup>
     <PackageReference Include="Uno.SourceGenerationTasks">
-      <Version>1.29.0-dev.157</Version>
+      <Version>1.29.0-dev.161</Version>
     </PackageReference>
     <PackageReference Include="Uno.Core">
       <Version>1.26.0-dev.58</Version>

--- a/src/Uno.UI.Wasm/Uno.UI.Wasm.csproj
+++ b/src/Uno.UI.Wasm/Uno.UI.Wasm.csproj
@@ -36,7 +36,7 @@
 		<PackageReference Include="Microsoft.TypeScript.Compiler" Version="2.8.3" />
 		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="2.8.3" />
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.178</Version>
+			<Version>1.29.0-dev.182</Version>
 		</PackageReference>
 	</ItemGroup>
 

--- a/src/Uno.UI.Wasm/Uno.UI.Wasm.csproj
+++ b/src/Uno.UI.Wasm/Uno.UI.Wasm.csproj
@@ -36,7 +36,7 @@
 		<PackageReference Include="Microsoft.TypeScript.Compiler" Version="2.8.3" />
 		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="2.8.3" />
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.161</Version>
+			<Version>1.29.0-dev.178</Version>
 		</PackageReference>
 	</ItemGroup>
 

--- a/src/Uno.UI.Wasm/Uno.UI.Wasm.csproj
+++ b/src/Uno.UI.Wasm/Uno.UI.Wasm.csproj
@@ -36,7 +36,7 @@
 		<PackageReference Include="Microsoft.TypeScript.Compiler" Version="2.8.3" />
 		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="2.8.3" />
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.157</Version>
+			<Version>1.29.0-dev.161</Version>
 		</PackageReference>
 	</ItemGroup>
 

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<PropertyGroup>
 		<TargetFrameworks>xamarinmac20;MonoAndroid80;xamarinios10;net46;netstandard2.0</TargetFrameworks>
 		<TargetFrameworksCI>MonoAndroid71;MonoAndroid80;xamarinios10;net46;netstandard2.0;xamarinmac20</TargetFrameworksCI>
@@ -29,7 +29,11 @@
 
 	<Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 	<Import Project="..\Uno.CrossTargetting.props" />
-
+	
+	<ItemGroup>
+		<UpToDateCheckInput Include="**\*.cs" Exclude="bin\**\*.cs;obj\**\*.cs;" />
+	</ItemGroup>
+	
 	<ItemGroup>
 		<Compile Remove="Mixins\**\*.cs" />
 
@@ -147,7 +151,7 @@
 	<ItemGroup>
 		<PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.157</Version> 
+			<Version>1.29.0-dev.161</Version> 
 		</PackageReference>
 		<PackageReference Include="Uno.Core">
 			<Version>1.26.0-dev.58</Version>

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -151,7 +151,7 @@
 	<ItemGroup>
 		<PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.178</Version> 
+			<Version>1.29.0-dev.182</Version> 
 		</PackageReference>
 		<PackageReference Include="Uno.Core">
 			<Version>1.26.0-dev.58</Version>

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -151,7 +151,7 @@
 	<ItemGroup>
 		<PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.161</Version> 
+			<Version>1.29.0-dev.178</Version> 
 		</PackageReference>
 		<PackageReference Include="Uno.Core">
 			<Version>1.26.0-dev.58</Version>

--- a/src/Uno.UWP/Uno.csproj
+++ b/src/Uno.UWP/Uno.csproj
@@ -30,7 +30,7 @@
 		<PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
 		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0-preview1-26216-02" />
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.161</Version>
+			<Version>1.29.0-dev.178</Version>
 		</PackageReference>
 		<PackageReference Include="Uno.Core">
 			<Version>1.26.0-dev.58</Version>

--- a/src/Uno.UWP/Uno.csproj
+++ b/src/Uno.UWP/Uno.csproj
@@ -30,7 +30,7 @@
 		<PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
 		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0-preview1-26216-02" />
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.178</Version>
+			<Version>1.29.0-dev.182</Version>
 		</PackageReference>
 		<PackageReference Include="Uno.Core">
 			<Version>1.26.0-dev.58</Version>

--- a/src/Uno.UWP/Uno.csproj
+++ b/src/Uno.UWP/Uno.csproj
@@ -30,7 +30,7 @@
 		<PackageReference Include="MSBuild.Sdk.Extras" Version="1.6.55" PrivateAssets="All" />
 		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0-preview1-26216-02" />
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.157</Version>
+			<Version>1.29.0-dev.161</Version>
 		</PackageReference>
 		<PackageReference Include="Uno.Core">
 			<Version>1.26.0-dev.58</Version>


### PR DESCRIPTION
- Expand Microsoft.CodeAnalysis to use individual packages
- Add UnoSourceGeneratorUseGenerationHost for all projects

## PR Type
What kind of change does this PR introduce?
- Enhancement

## What is the current behavior?
The source generation host runs in devenv.exe for android targets, creating additional memory stress.

## What is the new behavior?
The SourceGeneration tasks host is now used.

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
