### PR TITLE
Adjust the NavigationView event ordering when selecting the settings

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -327,13 +327,13 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (SettingsItem is NavigationViewItem item)
 			{
-				SelectedItem = SettingsItem;
-				_menuItemsHost.SelectedItem = null;
-
 				ItemInvoked?.Invoke(
 					this,
 					CreateInvokedItemParameter(item)
 				);
+
+				SelectedItem = SettingsItem;
+				_menuItemsHost.SelectedItem = null;
 			}
 		}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The ItemInvoked item is called after the SelectedItem event is called, which is different from the UWP implementation.

## What is the new behavior?
Align the behavior with UWP.
