### PR TITLE
[iOS][TextBlock] Invalidate the full layout when the measure is invalidate

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -37,6 +37,8 @@
  * Ensure the SplitView templated parent is propagated properly for FindName
  * Fix infinite loop when parsing empty Attached Properties on macOS
  * 103116 [iOS] Navigating to a _second_ local html file with `WebView` doesn't work.
+ * 137945 [iOS 12] Some UI elements are misaligned after device goes from landscape back to portrait
+ * 138043 [iOS] Text elements misaligned after leaving and returning to the app
 
 ## Release 1.41
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
@@ -84,7 +84,7 @@ namespace Windows.UI.Xaml.Controls
 		protected internal override void OnInvalidateMeasure()
 		{
 			base.OnInvalidateMeasure();
-			SetNeedsDisplay();
+			SetNeedsLayout();
 			_measureInvalidated = true;
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When you go back to an app set on background, TextBlock alignments are not always applied

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
When a TextBlock gets its measurements invalidated, it is fully invalidate (view and subviews).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://nventive.visualstudio.com/Umbrella/_workitems/edit/137945
https://nventive.visualstudio.com/Umbrella/_workitems/edit/138043