### PR TITLE
[iOS][TextBlock] Use Ceiling on new size when TextBlock is measured

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -38,6 +38,7 @@
  * Fix infinite loop when parsing empty Attached Properties on macOS
  * 103116 [iOS] Navigating to a _second_ local html file with `WebView` doesn't work.
  * 134573 CommandBar doesn't take the proper space on iOS phones in landscape
+ * 138297 [iOS][TextBlock] Measurement is always different since we use Math.Ceiling
 
 ## Release 1.41
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
@@ -92,17 +92,20 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override Size MeasureOverride(Size size)
 		{
+			// Size used to compare with the previous one. We don't want to use this one for the calculation.
+			var ceiledNewSize = new CGSize(Math.Ceiling(size.Width), Math.Ceiling(size.Height));
+
 			var hasSameDesiredSize =
 				!_measureInvalidated
 				&& _previousAvailableSize != null
-				&& _previousDesiredSize.Width == size.Width
-				&& _previousDesiredSize.Height == size.Height;
+				&& _previousDesiredSize.Width == ceiledNewSize.Width
+				&& _previousDesiredSize.Height == ceiledNewSize.Height;
 
 			var isSingleLineNarrower =
 				!_measureInvalidated
 				&& _previousAvailableSize != null
-				&& _previousDesiredSize.Width <= size.Width
-				&& _previousDesiredSize.Height == size.Height;
+				&& _previousDesiredSize.Width <= ceiledNewSize.Width
+				&& _previousDesiredSize.Height == ceiledNewSize.Height;
 
 			if (hasSameDesiredSize || isSingleLineNarrower)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When a TexBlock is measured, it never have the same size due to the Math.Ceiling applied on the result

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
It also apply Math.Ceiling on the new size for comparison

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://nventive.visualstudio.com/Umbrella/_workitems/edit/138297