### PR TITLE
[iOS] ListView - fix bug where item view is clipped

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -40,6 +40,7 @@
  * 134573 CommandBar doesn't take the proper space on iOS phones in landscape
  * Image with partial size constraint now display properly under Wasm.
  * 138297 [iOS][TextBlock] Measurement is always different since we use Math.Ceiling
+ * 137204 [iOS] ListView - fix bug where item view is clipped
 
 ## Release 1.41
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -233,6 +233,10 @@ namespace Windows.UI.Xaml.Controls
 					}
 
 					Owner?.XamlParent?.PrepareContainerForIndex(selectorItem, index);
+
+					// Normally this happens when the SelectorItem.Content is set, but there's an edge case where after a refresh, a
+					// container can be dequeued which happens to have had exactly the same DataContext as the new item.
+					cell.ClearMeasuredSize();
 				}
 
 				Owner?.XamlParent?.TryLoadMoreItems(index);
@@ -705,7 +709,7 @@ namespace Windows.UI.Xaml.Controls
 
 					ContentView.AddSubview(value);
 
-					_measuredContentSize = null;
+					ClearMeasuredSize();
 					_contentChangedDisposable.Disposable = value?.RegisterDisposablePropertyChangedCallback(ContentControl.ContentProperty, (_, __) => _measuredContentSize = null);
 				}
 			}
@@ -748,6 +752,11 @@ namespace Windows.UI.Xaml.Controls
 				ContentView.Frame = Bounds;
 			}
 		}
+
+		/// <summary>
+		/// Clear the cell's measured size, this allows the static template size to be updated with the correct databound size.
+		/// </summary>
+		internal void ClearMeasuredSize() => _measuredContentSize = null;
 
 		public override UICollectionViewLayoutAttributes PreferredLayoutAttributesFittingAttributes(UICollectionViewLayoutAttributes layoutAttributes)
 		{
@@ -862,7 +871,7 @@ namespace Windows.UI.Xaml.Controls
 			{
 				_needsLayout = true;
 				Owner?.NativeLayout?.RefreshLayout();
-				_measuredContentSize = null;
+				ClearMeasuredSize();
 				SetNeedsLayout();
 			}
 		}


### PR DESCRIPTION
Ensure that the databound item is properly measured in the edge case where a view happens to be recycled that already has the same DataContext that it's about to be bound to.

Internal issue: https://nventive.visualstudio.com/Umbrella/_workitems/edit/137204