### PR TITLE
Adjust Wasm image when only one of Width or Height is specified

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -38,6 +38,7 @@
  * Fix infinite loop when parsing empty Attached Properties on macOS
  * 103116 [iOS] Navigating to a _second_ local html file with `WebView` doesn't work.
  * 134573 CommandBar doesn't take the proper space on iOS phones in landscape
+ * Image with partial size constraint now display properly under Wasm.
 
 ## Release 1.41
 

--- a/src/Uno.UI/UI/Xaml/Controls/Image/Image.netstd.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Image/Image.netstd.cs
@@ -167,7 +167,7 @@ namespace Windows.UI.Xaml.Controls
 
 			if (
 				double.IsInfinity(availableSize.Width)
-				|| double.IsInfinity(availableSize.Height)
+				&& double.IsInfinity(availableSize.Height)
 			)
 			{
 				ret = measuredSize;


### PR DESCRIPTION
## PR Type
Bugfix

## What is the current behavior?
Images defined as follows: 
```
<Image Width="25" Source="http://myimage" />
```

will be displayed using the image's natural size instead of following the provided constraint.

## What is the new behavior?
The partial image constraint is now observed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
