### PR TITLE
[Android] Fix bug when applying transform to stretched view

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -41,6 +41,7 @@
  * Image with partial size constraint now display properly under Wasm.
  * 138297 [iOS][TextBlock] Measurement is always different since we use Math.Ceiling
  * 137204 [iOS] ListView - fix bug where item view is clipped
+ * 137979 [Android] Incorrect offset when applying RotateTransform to stretched view
 
 ## Release 1.41
 

--- a/src/Uno.UI/UI/Xaml/Media/RotateTransform.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RotateTransform.Android.cs
@@ -38,8 +38,8 @@ namespace Windows.UI.Xaml.Media
 
 			if(View != null)
 			{
-				View.PivotX = (float)(Origin.X * View.MeasuredWidth) + ViewHelper.LogicalToPhysicalPixels(CenterX);
-				View.PivotY = (float)(Origin.Y * View.MeasuredHeight) + ViewHelper.LogicalToPhysicalPixels(CenterY);
+				View.PivotX = (float)(Origin.X * View.Width) + ViewHelper.LogicalToPhysicalPixels(CenterX);
+				View.PivotY = (float)(Origin.Y * View.Height) + ViewHelper.LogicalToPhysicalPixels(CenterY);
 				View.Rotation = (float)Angle;
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Media/ScaleTransform.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ScaleTransform.Android.cs
@@ -19,8 +19,8 @@ namespace Windows.UI.Xaml.Media
 		{
 			if (View != null)
 			{
-				View.PivotX = (float)(Origin.X * View.MeasuredWidth) + ViewHelper.LogicalToPhysicalPixels(CenterX);
-				View.PivotY = (float)(Origin.Y * View.MeasuredHeight) + ViewHelper.LogicalToPhysicalPixels(CenterY);
+				View.PivotX = (float)(Origin.X * View.Width) + ViewHelper.LogicalToPhysicalPixels(CenterX);
+				View.PivotY = (float)(Origin.Y * View.Height) + ViewHelper.LogicalToPhysicalPixels(CenterY);
 				View.ScaleX = (float)ScaleX;
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Media/SkewTransform.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/SkewTransform.Android.cs
@@ -16,8 +16,8 @@ namespace Windows.UI.Xaml.Media
 		{
 			if (View != null)
             {
-                View.PivotX = (float)(Origin.X * View.MeasuredWidth) + ViewHelper.LogicalToPhysicalPixels(CenterX);
-                View.PivotY = (float)(Origin.Y * View.MeasuredHeight) + ViewHelper.LogicalToPhysicalPixels(CenterY);
+                View.PivotX = (float)(Origin.X * View.Width) + ViewHelper.LogicalToPhysicalPixels(CenterX);
+                View.PivotY = (float)(Origin.Y * View.Height) + ViewHelper.LogicalToPhysicalPixels(CenterY);
                 View.RotationX = (float)AngleX;
 			}
 		}


### PR DESCRIPTION
When calculating offset for Rotate/Scale/SkewTransform, use Width/Height instead of MeasuredWidth/Height, since the view may have been arranged with different dimensions to its measured (ie desired) size.

Internal issue: https://nventive.visualstudio.com/Umbrella/_workitems/edit/137979