### PR TITLE
Multiple adjustments for Xaml Basics

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,11 +1,8 @@
 phases:
 - phase: VS_Latest
   variables:
-    NUGET_PACKAGES: $(Agent.WorkFolder)\.nuget
-    NUGET_HTTP_CACHE_PATH: $(Agent.WorkFolder)\.nuget-http-cache
     CombinedConfiguration: Release|Any CPU
     CI_Build: true
-
 
   steps:
   - checkout: self

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<PropertyGroup>
 		<TargetFrameworks>xamarinmac20;MonoAndroid80;uap10.0;xamarinios10;netstandard2.0</TargetFrameworks>
-		<TargetFrameworksCI>MonoAndroid71;MonoAndroid80;uap10.0;xamarinios10;netstandard2.0mxamarinmac20</TargetFrameworksCI>
+		<TargetFrameworksCI>MonoAndroid71;MonoAndroid80;uap10.0;xamarinios10;netstandard2.0;xamarinmac20</TargetFrameworksCI>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
 	<PropertyGroup>
-		<TargetFrameworks>MonoAndroid80;uap10.0;xamarinios10;netstandard2.0</TargetFrameworks>
-		<TargetFrameworksCI>MonoAndroid71;MonoAndroid80;uap10.0;xamarinios10;netstandard2.0</TargetFrameworksCI>
+		<TargetFrameworks>xamarinmac20;MonoAndroid80;uap10.0;xamarinios10;netstandard2.0</TargetFrameworks>
+		<TargetFrameworksCI>MonoAndroid71;MonoAndroid80;uap10.0;xamarinios10;netstandard2.0mxamarinmac20</TargetFrameworksCI>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -16,6 +16,9 @@
 
 	<Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
 	<Import Project="..\Uno.CrossTargetting.props" />
+	<ItemGroup>
+	  <Compile Include="..\Uno.UI\Behaviors\VisibleBoundsPadding.cs" Link="VisibleBoundsPadding.cs" />
+	</ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Uno.SourceGenerationTasks">
@@ -29,12 +32,12 @@
 		</PackageReference>
 	</ItemGroup>
 	
-  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == 'MonoAndroid' or  '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' ">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac' ">
 		<Reference Include="System.Numerics" />
 		<Reference Include="System.Numerics.Vectors" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == 'MonoAndroid' or  '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' ">
+	<ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == 'MonoAndroid' or '$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac' ">
 		<Reference Include="System.Numerics" />
 		<Reference Include="System.Numerics.Vectors" />
 	</ItemGroup>
@@ -88,7 +91,7 @@
 		<PackageReference Include="xamarin.build.download" Version="0.4.9" />
 	</ItemGroup>
 
-	<ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='MonoAndroid' or '$(TargetFrameworkIdentifier)'=='Xamarin.iOS' or '$(TargetFrameworkIdentifier)'=='.NETStandard'">
+	<ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='MonoAndroid' or '$(TargetFrameworkIdentifier)'=='Xamarin.iOS' or '$(TargetFrameworkIdentifier)'=='.NETStandard' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
 		<ProjectReference Include="..\Uno.UI\Uno.UI.csproj">
 			<Name>Uno.UI</Name>
 		</ProjectReference>
@@ -114,7 +117,7 @@
 		<UnoUIGeneratorsBinPath>..\SourceGenerators\Uno.UI.SourceGenerators\bin\$(Configuration)</UnoUIGeneratorsBinPath>
 	</PropertyGroup>
 
-	<Import Project="..\SourceGenerators\Uno.UI.SourceGenerators\Content\Uno.UI.SourceGenerators.props" Condition="'$(TargetFrameworkIdentifier)'=='MonoAndroid' or '$(TargetFrameworkIdentifier)'=='Xamarin.iOS'" />
+	<Import Project="..\SourceGenerators\Uno.UI.SourceGenerators\Content\Uno.UI.SourceGenerators.props" Condition="'$(TargetFrameworkIdentifier)'=='MonoAndroid' or '$(TargetFrameworkIdentifier)'=='Xamarin.iOS' or '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'" />
 
 	<Import Project="..\Common.targets" />
 	
@@ -131,7 +134,7 @@
 
 		<Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder)" />
 
-		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_OutputFiles-&gt;'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
-		<Copy SourceFiles="@(_OutputFilesPDB)" DestinationFiles="@(_OutputFilesPDB-&gt;'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename).pdb')" />
+		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+		<Copy SourceFiles="@(_OutputFilesPDB)" DestinationFiles="@(_OutputFilesPDB->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename).pdb')" />
 	</Target>
 </Project>

--- a/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
+++ b/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
@@ -14,8 +14,24 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 #if XAMARIN_IOS
 using UIKit;
+#elif __MACOS__
+using AppKit;
 #endif
 
+#if IS_UNO
+namespace Uno.UI.Behaviors
+{
+	/// <summary>
+	/// Internal Uno behavior, use VisibleBoundsPadding instead.
+	/// </summary>
+	/// <remarks>
+	/// This class is located in the same source file as the VisibleBoundsPadding class to avoid code duplication.
+	/// This is required to ensure that both Uno.UI styles and UWP (through Uno.UI.Toolkit) can use this behavior
+	/// and not have to synchronize two code files. The internal implementation is not supposed to be used outside 
+	/// of the Uno.UI assembly, Uno.UI.Toolkit.VisibleBoundsPadding should be used by dependents.
+	/// </remarks>
+	internal static class InternalVisibleBoundsPadding
+#else
 namespace Uno.UI.Toolkit
 {
 	/// <summary>
@@ -24,6 +40,7 @@ namespace Uno.UI.Toolkit
 	/// or set PaddingMask to another value to enable it only on a particular side or sides.
 	/// </summary>
 	public static class VisibleBoundsPadding
+#endif
 	{
 		[Flags]
 		public enum PaddingMask

--- a/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
+++ b/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
@@ -7,7 +7,6 @@ using System.Text;
 using Uno.Collections;
 using Uno.Extensions;
 using Uno.Logging;
-using Uno.UI.Toolkit.Extensions;
 using Windows.Foundation;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
@@ -16,6 +15,13 @@ using Windows.UI.Xaml.Controls;
 using UIKit;
 #elif __MACOS__
 using AppKit;
+#endif
+
+#if IS_UNO
+using _VisibleBoundsPadding = Uno.UI.Behaviors.InternalVisibleBoundsPadding;
+#else
+using Uno.UI.Toolkit.Extensions;
+using _VisibleBoundsPadding = Uno.UI.Toolkit.VisibleBoundsPadding;
 #endif
 
 #if IS_UNO
@@ -95,7 +101,7 @@ namespace Uno.UI.Toolkit
 			=> obj.SetValue(PaddingMaskProperty, value);
 
 		public static readonly DependencyProperty PaddingMaskProperty =
-			DependencyProperty.RegisterAttached("PaddingMask", typeof(PaddingMask), typeof(VisibleBoundsPadding), new PropertyMetadata(PaddingMask.None, OnIsPaddingMaskChanged));
+			DependencyProperty.RegisterAttached("PaddingMask", typeof(PaddingMask), typeof(_VisibleBoundsPadding), new PropertyMetadata(PaddingMask.None, OnIsPaddingMaskChanged));
 
 		private static void OnIsPaddingMaskChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)
 			=> VisibleBoundsDetails.GetInstance(dependencyObject as FrameworkElement).OnIsPaddingMaskChanged((PaddingMask)args.OldValue, (PaddingMask)args.NewValue);

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -83,7 +83,7 @@ namespace Windows.UI.Xaml.Controls
 
 			if (_togglePaneButton != null && _navigationViewBackButton != null)
 			{
-				_togglePaneButton.Margin = new Thickness(0, _navigationViewBackButton.RenderSize.Height, 0, 0);
+				_togglePaneButton.Margin = new Thickness(0, _navigationViewBackButton.Height, 0, 0);
 			}
 		}
 
@@ -108,7 +108,7 @@ namespace Windows.UI.Xaml.Controls
 
 			if (_togglePaneButton != null && _navigationViewBackButton != null)
 			{
-				_togglePaneButton.Margin = new Thickness(0, _navigationViewBackButton.RenderSize.Height, 0, 0);
+				_togglePaneButton.Margin = new Thickness(0, _navigationViewBackButton.Height, 0, 0);
 			}
 		}
 
@@ -133,7 +133,7 @@ namespace Windows.UI.Xaml.Controls
 
 			if (_togglePaneButton != null && _navigationViewBackButton != null)
 			{
-				_togglePaneButton.Margin = new Thickness(_navigationViewBackButton.RenderSize.Width, 0, 0, 0);
+				_togglePaneButton.Margin = new Thickness(_navigationViewBackButton.Width, 0, 0, 0);
 			}
 		}
 
@@ -241,10 +241,20 @@ namespace Windows.UI.Xaml.Controls
 
 		private void OnMenuItemsHost_ItemClick(object sender, ItemClickEventArgs e)
 		{
+			RaiseItemInvoked(CreateInvokedItemParameter(e.ClickedItem));
+		}
+
+		private void RaiseItemInvoked(NavigationViewItemInvokedEventArgs e)
+		{
 			ItemInvoked?.Invoke(
 				this,
-				CreateInvokedItemParameter(e.ClickedItem)
+				e
 			);
+
+			if(_rootSplitView != null && DisplayMode != NavigationViewDisplayMode.Expanded)
+			{
+				_rootSplitView.IsPaneOpen = false;
+			}
 		}
 
 		private NavigationViewItemInvokedEventArgs CreateInvokedItemParameter(object clickedItem)

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -163,7 +163,19 @@ namespace Windows.UI.Xaml.Controls
 
 			SetValue(SettingsItemProperty, GetTemplateChild("SettingsNavPaneItem"));
 
-			if(_menuItemsHost != null)
+			if (
+				_navigationViewBackButton != null
+				&& (
+				double.IsNaN(_navigationViewBackButton.Height)
+				|| double.IsNaN(_navigationViewBackButton.Width)
+				)
+			)
+			{
+				throw new InvalidOperationException("NavigationViewBackButton must have a Width and Height set");
+			}
+
+
+			if (_menuItemsHost != null)
 			{
 				if (MenuItemsSource == null)
 				{

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -9653,6 +9653,10 @@
                             PaneBackground="{ThemeResource NavigationViewDefaultPaneBackground}">
 
                             <SplitView.Pane>
+								<!--
+								InternalVisibleBoundsPadding is added to this control to make this template compatible
+								with notched devices by default. This behavior is not present in Microsoft's default UWP default.
+								-->
                                 <Grid x:Name="PaneContentGrid"
 										uBehaviors:InternalVisibleBoundsPadding.PaddingMask="All">
                                     <Grid.RowDefinitions>
@@ -9751,7 +9755,13 @@
                             VerticalAlignment="Top"
                             Canvas.ZIndex="100"
 							uBehaviors:InternalVisibleBoundsPadding.PaddingMask="Top,Left">
-							<!-- Canvas.ZIndex is not supported in Uno Grid yet, see https://github.com/nventive/Uno/issues/325 -->
+							<!--
+							Notes:
+							- InternalVisibleBoundsPadding is added to this control to make this template compatible
+							  with notched devices by default. This behavior is not present in Microsoft's default UWP default.
+
+							- Canvas.ZIndex is not supported in Uno Grid yet, see https://github.com/nventive/Uno/issues/325
+							-->
 
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="Auto" />

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -14,6 +14,7 @@
 					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:native_ios="using:UIKit"
 					xmlns:native_android="using:Android.Widget"
+					xmlns:uBehaviors="using:Uno.UI.Behaviors"
 					mc:Ignorable="d xamarin ios android not_wasm wasm">
 
 	<!-- TODO: How does UWP override the default FontFamily value of 11 with 15? -->
@@ -9652,7 +9653,8 @@
                             PaneBackground="{ThemeResource NavigationViewDefaultPaneBackground}">
 
                             <SplitView.Pane>
-                                <Grid x:Name="PaneContentGrid">
+                                <Grid x:Name="PaneContentGrid"
+										uBehaviors:InternalVisibleBoundsPadding.PaddingMask="All">
                                     <Grid.RowDefinitions>
                                         <RowDefinition Height="Auto" />
                                         <RowDefinition Height="0" />
@@ -9747,7 +9749,8 @@
                             Margin="0,0,0,8"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Top"
-                            Canvas.ZIndex="100">
+                            Canvas.ZIndex="100"
+							uBehaviors:InternalVisibleBoundsPadding.PaddingMask="Top,Left">
 							<!-- Canvas.ZIndex is not supported in Uno Grid yet, see https://github.com/nventive/Uno/issues/325 -->
 
                             <Grid.RowDefinitions>


### PR DESCRIPTION
## PR Type
- Bugfix
- Feature

## What is the new behavior?
- Move `VisibleBoundsPadding` inside Uno.UI so Default Styles can use it
- Fix for `NavigationView` toggle button initial location on iOS
- Close the `NavigationView` pane when an item is selected
- Build Uno.UI.Toolkit for Xamarin.Mac

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
