### PR TITLE
Add ability to use internal objects in resource dictionaries

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -43,6 +43,7 @@
  * 138297 [iOS][TextBlock] Measurement is always different since we use Math.Ceiling
  * 137204 [iOS] ListView - fix bug where item view is clipped
  * 137979 [Android] Incorrect offset when applying RotateTransform to stretched view
+ * Now supports internal object in desource dictionaries
 
 ## Release 1.41
 

--- a/src/SourceGenerators/XamlGenerationTests/InternalObject.cs
+++ b/src/SourceGenerators/XamlGenerationTests/InternalObject.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace XamlGenerationTests
+{
+	/// <summary>
+	/// A class internal to the project
+	/// </summary>
+	internal class InternalObject
+	{
+	}
+}

--- a/src/SourceGenerators/XamlGenerationTests/ResourceDictionaryWithInternalItem.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/ResourceDictionaryWithInternalItem.xaml
@@ -1,0 +1,11 @@
+﻿<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:XamlGenerationTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+	<local:InternalObject x:Key="MyInternalObject" />
+
+</ResourceDictionary>


### PR DESCRIPTION
GitHub Issue (If applicable): #354

## PR Type
What kind of change does this PR introduce?
 - Bugfix

## What is the current behavior?
If I create an `internal` object in a resource dictionary, a public property will be generated, so compilation fails.

## What is the new behavior?
- If the type of the declared object is not `public`, the property will be typed as `object`
- When we use a static resource using the public static property, we cast it to the target type even if we know the type of the source property.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
