### PR TITLE
fixed list view scrolls up when tapping an item at the bottom of screen

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -62,6 +62,7 @@
  * #26 The explicit property <Style.Setters> does not intialize style setters properly
  * 104057 [Android] ListView shows overscroll effect even when it doesn't need to scroll
  * #376 iOS project compilation fails: Can't resolve the reference 'System.Void Windows.UI.Xaml.Documents.BlockCollection::Add(Windows.UI.Xaml.Documents.Block)
+ * 138099, 138463 [Android] fixed `ListView` scrolls up when tapping an item at the bottom of screen
 
 ## Release 1.41
 

--- a/src/Uno.UI/KeyboardRectProvider.Android.cs
+++ b/src/Uno.UI/KeyboardRectProvider.Android.cs
@@ -2,6 +2,7 @@
 using Android.App;
 using Android.Graphics;
 using Android.Graphics.Drawables;
+using Android.Util;
 using Android.Views;
 using Android.Widget;
 
@@ -12,18 +13,20 @@ namespace Uno.UI
 	/// </summary>
 	internal class KeyboardRectProvider : PopupWindow, ViewTreeObserver.IOnGlobalLayoutListener
 	{
-		private readonly Activity _activity;
-		private readonly Action<Rect> _onKeyboardRectChanged;
-		private readonly View _popupView;
+		public delegate void LayoutChangedListener(Rect keyboard, Rect navigation, Rect union);
 		
-		public KeyboardRectProvider(Activity activity, Action<Rect> onKeyboardRectChanged) : base(activity)
+		private readonly LayoutChangedListener _onLayoutChanged;
+		private readonly Activity _activity;
+		private readonly View _popupView;
+
+		public KeyboardRectProvider(Activity activity, LayoutChangedListener onLayoutChanged) : base(activity)
 		{
 			_activity = activity;
-			_onKeyboardRectChanged = onKeyboardRectChanged;
 			_popupView = new LinearLayout(_activity.BaseContext)
 			{
 				LayoutParameters = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.MatchParent)
 			};
+			_onLayoutChanged = onLayoutChanged;
 
 			ContentView = _popupView;
 			SoftInputMode = SoftInput.AdjustResize | SoftInput.StateAlwaysVisible;
@@ -65,20 +68,28 @@ namespace Uno.UI
 		/// </summary>
 		void ViewTreeObserver.IOnGlobalLayoutListener.OnGlobalLayout()
 		{
-			var screenSize = new Point();
-			_activity.WindowManager.DefaultDisplay.GetSize(screenSize);
+			var realMetrics = Get<DisplayMetrics>(_activity.WindowManager.DefaultDisplay.GetRealMetrics);
+			var displayRect = Get<Rect>(_activity.WindowManager.DefaultDisplay.GetRectSize);
+			var usableRect = Get<Rect>(_popupView.GetWindowVisibleDisplayFrame);
 
-			var popupRect = new Rect();
-			_popupView.GetWindowVisibleDisplayFrame(popupRect);
+			// we assume that the keyboard and the navigation bar always occupy the bottom area, with the keyboard being above the navigation bar
+			// their placements can be calculated based on the follow observation:
+			// [size] realMetrics	: screen
+			// [rect] displayRect	: display area = screen - (bottom: nav_bar)
+			// [rect] usableRect	: usable area = screen - (top: status_bar) - (bottom: keyboard + nav_bar)
+			var navigationRect = new Rect(0, displayRect.Bottom, realMetrics.WidthPixels, realMetrics.HeightPixels);
+			var keyboardRect = new Rect(0, usableRect.Bottom, realMetrics.WidthPixels, navigationRect.Top);
+			var occupiedRect = new Rect(0, usableRect.Bottom, realMetrics.WidthPixels, realMetrics.HeightPixels);
 
-			var keyboardRect = new Rect(
-				0,
-				popupRect.Bottom,
-				screenSize.X,
-				screenSize.Y
-			);
+			_onLayoutChanged?.Invoke(keyboardRect, navigationRect, occupiedRect);
 
-			_onKeyboardRectChanged?.Invoke(keyboardRect);
+			T Get<T>(Action<T> getter) where T : new()
+			{
+				var result = new T();
+				getter(result);
+
+				return result;
+			}
 		}
 	}
 }

--- a/src/Uno.UI/UI/ViewManagement/InputPane/InputPane.Android.cs
+++ b/src/Uno.UI/UI/ViewManagement/InputPane/InputPane.Android.cs
@@ -22,6 +22,10 @@ namespace Windows.UI.ViewManagement
 	{
 		private IDisposable _padScrollContentPresenter;
 
+		public Rect KeyboardRect { get; internal set; }
+
+		public Rect NavigationBarRect { get; internal set; }
+
 		partial void TryShowPartial()
 		{
 			var activity = (ContextHelper.Current as Activity);

--- a/src/Uno.UI/UI/ViewManagement/InputPane/InputPane.cs
+++ b/src/Uno.UI/UI/ViewManagement/InputPane/InputPane.cs
@@ -35,7 +35,11 @@ namespace Windows.UI.ViewManagement
 
 		public bool Visible
 		{
+#if __ANDROID__
+			get => KeyboardRect.Height > 0;
+#else
 			get => OccludedRect.Height > 0;
+#endif
 			set
 			{
 				if (value)

--- a/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
+++ b/src/Uno.UI/UI/Xaml/ApplicationActivity.Android.cs
@@ -102,16 +102,18 @@ namespace Windows.UI.Xaml
 			Window.ClearFlags(WindowManagerFlags.Fullscreen);
 		}
 
-		private void OnKeyboardRectChanged(Rect keyboardRect)
+		private void OnLayoutChanged(Rect keyboard, Rect navigation, Rect union)
 		{
-			_inputPane.OccludedRect = ViewHelper.PhysicalToLogicalPixels(keyboardRect);
+			_inputPane.KeyboardRect = ViewHelper.PhysicalToLogicalPixels(keyboard);
+			_inputPane.NavigationBarRect = ViewHelper.PhysicalToLogicalPixels(navigation);
+			_inputPane.OccludedRect = ViewHelper.PhysicalToLogicalPixels(union);
 		}
 
 		protected override void OnCreate(Bundle bundle)
 		{
 			base.OnCreate(bundle);
 
-			_keyboardRectProvider = new KeyboardRectProvider(this, OnKeyboardRectChanged);
+			_keyboardRectProvider = new KeyboardRectProvider(this, OnLayoutChanged);
 			RaiseConfigurationChanges();
 		}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
> Bugfix

## What is the current behavior?
On android, `ListView` will scroll up when you tap an item at the bottom of the screen. This also happens if you just hold the press, and the scrolling will occur before you release.

## What is the new behavior?
The above described behavior should only happens when the soft input panel (keyboard) is shown and you focus an item that is blocked by the keyboard.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
This issue started happening with 123bb68362e72c6c331991135fa471a163193f87 from #324

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/138099/
https://nventive.visualstudio.com/Umbrella/_workitems/edit/138463/