### PR TITLE
MediaPlayerElement minor fixes

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -7,6 +7,8 @@
 ### Breaking changes
 
 ### Bug fixes
+ * MediaPlayerElement [iOS] Subtitles are not disable on initial launch anymore
+ * MediaPlayerElement [Android]Player status is now properly updated on media end
 
 
 

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -8254,6 +8254,8 @@
 				Value="False" />
 		<Setter Property="Stretch"
 				Value="Uniform" />
+		<Setter Property="Background"
+				Value="Black" />
 		<Setter Property="Template">
             <Setter.Value>
 				<ControlTemplate TargetType="MediaPlayerElement">
@@ -8268,7 +8270,7 @@
 											  Stretch="{TemplateBinding Stretch}"
 											  MediaPlayer="{TemplateBinding MediaPlayer}"
 											  Visibility="Collapsed"
-											  Background="Black" />
+											  Background="{TemplateBinding Background}" />
 						<ContentPresenter x:Name="TransportControlsPresenter"
 										  Visibility="{TemplateBinding AreTransportControlsEnabled}" />
 						<Grid x:Name="TimedTextSourcePresenter" />

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
@@ -262,6 +262,7 @@ namespace Windows.Media.Playback
 		public void OnCompletion(AndroidMediaPlayer mp)
 		{
 			MediaEnded?.Invoke(this, null);
+			PlaybackSession.PlaybackState = MediaPlaybackState.None;
 		}
 
 		private void OnMediaFailed(global::System.Exception ex = null, string message = null)

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
@@ -138,15 +138,9 @@ namespace Windows.Media.Playback
 
 				// Adapt pitch to prevent "metallic echo" when changing playback rate
 				_player.CurrentItem.AudioTimePitchAlgorithm = AVAudioTimePitchAlgorithm.TimeDomain;
-
-				// Disable subtitles if any
-				var mediaSelectionGroup = _player.CurrentItem.Asset.MediaSelectionGroupForMediaCharacteristic(AVMediaCharacteristic.Legible);
-				if (mediaSelectionGroup != null)
-				{
-					_player.CurrentItem.SelectMediaOption(null, mediaSelectionGroup);
-				}
 				
 				MediaOpened?.Invoke(this, null);
+
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type
Bugfix 

## What is the current behavior?
Player status is not updated properly on media end on Android
On iOS, subtitles are disabled by default. It should not.

## What is the new behavior?
Player status is properly updated on media end on Android
On iOS, default subtitles is displayed

## PR Checklist

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->