### PR TITLE
Fix NRE issue on slider

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -9,6 +9,7 @@
 ### Bug fixes
  * MediaPlayerElement [iOS] Subtitles are not disable on initial launch anymore
  * MediaPlayerElement [Android]Player status is now properly updated on media end
+ * #388 Slider: NRE when vertical template is not defined
 
 
 

--- a/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.cs
@@ -202,9 +202,14 @@ namespace Windows.UI.Xaml.Controls
 #if XAMARIN_ANDROID
 				this.RequestDisallowInterceptTouchEvent(true);
 #endif
-
-				_horizontalInitial = GetSanitizedDimension(_horizontalDecreaseRect.Width);
-				_verticalInitial = GetSanitizedDimension(_verticalDecreaseRect.Height);
+				if (Orientation == Orientation.Horizontal)
+				{
+					_horizontalInitial = GetSanitizedDimension(_horizontalDecreaseRect.Width);
+				}
+				else
+				{
+					_verticalInitial = GetSanitizedDimension(_verticalDecreaseRect.Height);
+				}
 
 				IsPointerPressed = true;
 				UpdateCommonState();


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #388 

## PR Type
What kind of change does this PR introduce?
Bugfix 

## What is the current behavior?
NRE in Slider.OnDragStarted() when vertical template is not defined

## What is the new behavior?
No more NRE

## PR Checklist

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)