### PR TITLE
Add support for Windows.ApplicationModel.DataTransfer.Clipboard

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -6,6 +6,7 @@
 * [Wasm] Improve general performance and memory pressure by removing Javascript interop evaluations.
 * Add support for Windows 10 SDK 17763 (1809)
 * Improve the Uno.UI solution memory consumption for Android targets
+* 35178 Added recipe for copying text to clipboard
 
 ### Breaking changes
 

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.Android.cs
@@ -13,9 +13,10 @@ namespace Windows.ApplicationModel.DataTransfer
 		{
 			if (content?.Text == null)
 			{
-				var manager = (ClipboardManager)ContextHelper.Current.GetSystemService(Context.ClipboardService);
-
-				manager.Text = content.Text;
+				if (ContextHelper.Current.GetSystemService(Context.ClipboardService) is ClipboardManager manager)
+				{
+					manager.Text = content.Text;
+				}
 			}
 		}
 	}

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.Android.cs
@@ -1,0 +1,20 @@
+﻿#if __ANDROID__
+using Android.Content;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Uno.UI;
+
+namespace Windows.ApplicationModel.DataTransfer
+{
+	public static partial class Clipboard
+	{
+		public static void SetContent(DataPackage content)
+		{
+			var manager = (ClipboardManager)ContextHelper.Current.GetSystemService(Context.ClipboardService);
+
+			manager.Text = content.Text;
+		}
+	}
+}
+#endif

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.Android.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.Android.cs
@@ -11,9 +11,12 @@ namespace Windows.ApplicationModel.DataTransfer
 	{
 		public static void SetContent(DataPackage content)
 		{
-			var manager = (ClipboardManager)ContextHelper.Current.GetSystemService(Context.ClipboardService);
+			if (content?.Text == null)
+			{
+				var manager = (ClipboardManager)ContextHelper.Current.GetSystemService(Context.ClipboardService);
 
-			manager.Text = content.Text;
+				manager.Text = content.Text;
+			}
 		}
 	}
 }

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.iOS.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.iOS.cs
@@ -7,7 +7,10 @@ namespace Windows.ApplicationModel.DataTransfer
 	{
 		public static void SetContent(DataPackage content)
 		{
-			UIPasteboard.General.String = content.Text;
+			if (content.Text != null)
+			{
+				UIPasteboard.General.String = content.Text;
+			}
 		}
 	}
 }

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.iOS.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.iOS.cs
@@ -1,0 +1,14 @@
+﻿#if __IOS__
+using UIKit;
+
+namespace Windows.ApplicationModel.DataTransfer
+{
+	public static partial class Clipboard
+	{
+		public static void SetContent(DataPackage content)
+		{
+			UIPasteboard.General.String = content.Text;
+		}
+	}
+}
+#endif

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
@@ -6,10 +6,13 @@ namespace Windows.ApplicationModel.DataTransfer
 	{
 		public static void SetContent(DataPackage content)
 		{
-			var text = WebAssemblyRuntime.EscapeJs(content.Text);
-			var command = $"Uno.Utils.Clipboard.setText(\"{text}\");";
+			if (content?.Text != null)
+			{
+				var text = WebAssemblyRuntime.EscapeJs(content.Text);
+				var command = $"Uno.Utils.Clipboard.setText(\"{text}\");";
 
-			WebAssemblyRuntime.InvokeJS(command);
+				WebAssemblyRuntime.InvokeJS(command);
+			}
 		}
 	}
 }

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/Clipboard.wasm.cs
@@ -2,12 +2,13 @@
 
 namespace Windows.ApplicationModel.DataTransfer
 {
-	public partial class Clipboard
+	public static partial class Clipboard
 	{
 		public static void SetContent(DataPackage content)
 		{
 			var text = WebAssemblyRuntime.EscapeJs(content.Text);
 			var command = $"Uno.Utils.Clipboard.setText(\"{text}\");";
+
 			WebAssemblyRuntime.InvokeJS(command);
 		}
 	}

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.cs
@@ -8,9 +8,11 @@ namespace Windows.ApplicationModel.DataTransfer
 	{
 		internal string Text { get; private set; }
 
+#if !(NET46 || __MACOS__)
 		public void SetText(string text)
 		{
 			this.Text = text;
 		}
+#endif
 	}
 }

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.ApplicationModel.DataTransfer
+{
+	public partial class DataPackage
+	{
+		internal string Text { get; private set; }
+
+		public void SetText(string text)
+		{
+			this.Text = text;
+		}
+	}
+}

--- a/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.wasm.cs
+++ b/src/Uno.UWP/ApplicationModel/DataTransfer/DataPackage.wasm.cs
@@ -4,13 +4,6 @@ namespace Windows.ApplicationModel.DataTransfer
 {
 	public partial class DataPackage
 	{
-		internal string Text;
-
-		public void SetText(string value)
-		{
-			Text = value;
-		}
-
 		public void SetUri(Uri value)
 		{
 			// URI is treat as text in WASM

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.DataTransfer/Clipboard.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.DataTransfer/Clipboard.cs
@@ -69,7 +69,7 @@ namespace Windows.ApplicationModel.DataTransfer
 			throw new global::System.NotImplementedException("The member DataPackageView Clipboard.GetContent() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || false || __MACOS__
+		#if false || false || NET46 || false || __MACOS__
 		[global::Uno.NotImplemented]
 		public static void SetContent( global::Windows.ApplicationModel.DataTransfer.DataPackage content)
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.DataTransfer/DataPackage.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.ApplicationModel.DataTransfer/DataPackage.cs
@@ -77,7 +77,7 @@ namespace Windows.ApplicationModel.DataTransfer
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.ApplicationModel.DataTransfer.DataPackage", "void DataPackage.SetDataProvider(string formatId, DataProviderHandler delayRenderer)");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || false || __MACOS__
+		#if false || false || NET46 || false || __MACOS__
 		[global::Uno.NotImplemented]
 		public  void SetText( string value)
 		{


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
Feature

## What is the current behavior?
No implementation in Uno, other than for wasm.

## What is the new behavior?
`Clipboard.SetContent` is made available for uwp, ios, and android.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information

Internal Issue (If applicable):
https://feedback.nventive.com/communities/1/topics/831-need-a-recipe-to-copy-to-clipboard
https://nventive.visualstudio.com/Umbrella/_workitems/edit/35178/