### PR TITLE
[Wasm] Fix VirtualizingPanelAdapter measure and arrange

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -13,8 +13,7 @@
  * MediaPlayerElement [Android]Player status is now properly updated on media end
  * #388 Slider: NRE when vertical template is not defined
  * 138117 [Android] Removing a bookmarked/downloaded lesson can duplicate the assets of a different lesson.
-
-
+ * [Wasm] Fix VirtualizingPanelAdapter measure and arrange
 
 ## Release 1.42
 

--- a/src/Uno.Foundation/Runtime.wasm.cs
+++ b/src/Uno.Foundation/Runtime.wasm.cs
@@ -203,7 +203,7 @@ namespace Uno.Foundation
 				command = commandBuilder.ToString();
 			}
 
-			return WebAssembly.Runtime.InvokeJS(command);
+			return InvokeJS(command);
 		}
 
 		[Pure]

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -266,7 +266,7 @@ declare namespace Uno.UI {
             *
             * @param index Position in children list. Appended at end if not specified.
             */
-        addView(parentId: string, childId: string, index?: number): string;
+        addView(parentId: number, childId: number, index?: number): string;
         /**
             * Set a view as a child of another one.
             *

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -684,7 +684,7 @@ var Uno;
                 * @param index Position in children list. Appended at end if not specified.
                 */
             addView(parentId, childId, index) {
-                this.addView(parentId, childId, index);
+                this.addViewInternal(parentId, childId, index);
                 return "ok";
             }
             /**

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -675,8 +675,8 @@
 			*
 			* @param index Position in children list. Appended at end if not specified.
 			*/
-		public addView(parentId: string, childId: string, index?: number): string {
-			this.addView(parentId, childId, index);
+		public addView(parentId: number, childId: number, index?: number): string {
+			this.addViewInternal(parentId, childId, index);
 			return "ok";
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelAdapter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelAdapter.wasm.cs
@@ -63,7 +63,10 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var id = GetItemId(index);
 
-			Console.WriteLine($"{GetMethodTag()} container={container} index={index}");
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().LogDebug($"{GetMethodTag()} container={container} index={index}");
+			}
 
 			var cache = _itemContainerCache.FindOrCreate(id, () => new Stack<FrameworkElement>());
 
@@ -108,8 +111,6 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		private string GetMethodTag([CallerMemberName] string caller = null)
-		{
-			return $"{nameof(VirtualizingPanelGenerator)}.{caller}()";
-		}
+			=> $"{nameof(VirtualizingPanelGenerator)}.{caller}()";
 	}
 }

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -266,9 +266,8 @@ namespace Windows.UI.Xaml
 		internal void MoveViewTo(int oldIndex, int newIndex)
 		{
 			var view = _children[oldIndex];
-			
-			var command = "Uno.UI.WindowManager.current.addView(\"" + HtmlId + "\", \"" + view.HtmlId + "\", " + newIndex + ");";
-			WebAssemblyRuntime.InvokeJS(command);
+
+			Uno.UI.Xaml.WindowManagerInterop.AddView(HtmlId, view.HtmlId, newIndex);
 
 			InvalidateMeasure();
 		}

--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.Wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.Wasm.cs
@@ -92,6 +92,7 @@ namespace Uno.UI.Xaml
 				var isSvgStr = htmlTagIsSvg ? "true" : "false";
 				var isFrameworkElementStr = isFrameworkElement ? "true" : "false";
 				var isFocusableStr = isFocusable ? "true" : "false"; // by default all control are not focusable, it has to be change latter by the control itself
+				var classesParam = classes.Select(c => $"\"{c}\"").JoinBy(",");
 
 				WebAssemblyRuntime.InvokeJS(
 					"Uno.UI.WindowManager.current.createContent({" +
@@ -102,7 +103,7 @@ namespace Uno.UI.Xaml
 					"isSvg:" + isSvgStr + ", " +
 					"isFrameworkElement:" + isFrameworkElementStr + ", " +
 					"isFocusable:" + isFocusableStr + ", " +
-					"classes:[" + classes + "]" +
+					"classes:[" + classesParam + "]" +
 					"});");
 			}
 			else


### PR DESCRIPTION
## PR Type
Bugfix

## What is the current behavior?
If a ListView has more space than its inner panel needs, the content will be centered, and each item will be left aligned.

## What is the new behavior?
If a ListView has more space than its inner panel needs, the panel will take all the available space, and each item is stretched to use the available space.

ListView logging is now moved to debug level.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)