### PR TITLE
[Android] Fixed FontStyle is not applied anymore on the TextBox's content

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -14,6 +14,8 @@
  * #388 Slider: NRE when vertical template is not defined
  * 138117 [Android] Removing a bookmarked/downloaded lesson can duplicate the assets of a different lesson.
  * [Wasm] Fix VirtualizingPanelAdapter measure and arrange
+ * 137892 [Android] Fixed FontFamily, FontSize and FontWeight are not applied anymore on the TextBox's content.
+
 
 ## Release 1.42
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -48,6 +48,12 @@ namespace Windows.UI.Xaml.Controls
 		{
 			_isPassword = false;
 			InitializeVisualStates();
+			this.RegisterParentChangedCallback(this, OnParentChanged);
+		}
+
+		private void OnParentChanged(object instance, object key, DependencyObjectParentChangedEventArgs args)
+		{
+			UpdateFontPartial(this);
 		}
 
 		protected TextBox(bool isPassword)


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
[Android] FontFamily, FontSize and FontWeight are not applied anymore on the TextBox's content.


## What is the new behavior?
[Android] FontFamily, FontSize and FontWeight are correctly applied on the TextBox's content.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable): https://nventive.visualstudio.com/Umbrella/_workitems/edit/137892