### PR TITLE
fixed broken DatePicker on android devices

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -39,6 +39,7 @@
  * Adjust .NET template projects versions to 4.6.1
  * Adjust Microsoft.CodeAnalysis versions to avoid restore conflicts
  * Fix element name matching existing types fails to compile (e.g. ContentPresenter)
+ * 138735 [Android] Fixed broken DatePicker 
 
 ## Release 1.42
 

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
@@ -177,19 +177,21 @@ namespace Windows.UI.Xaml.Controls
 
 		private void SetupFlyoutButton()
 		{
-#if __IOS__
+#if __IOS__ || __ANDROID__
 			_flyoutButton.Flyout = new DatePickerFlyout()
 			{
+#if __IOS__
                 Placement = FlyoutPlacement,
+#endif
 				Date = Date,
 				MinYear = MinYear,
 				MaxYear = MaxYear
 			};
-#endif
 
 			BindToFlyout("Date");
 			BindToFlyout("MinYear");
 			BindToFlyout("MaxYear");
+#endif
 		}
 
 		private void BindToFlyout(string propertyName)


### PR DESCRIPTION
## PR Type
Bugfix

## What is the current behavior?
`DatePicker` is broken on android devices:
- displaying jan 01, 0000
- unresponsive to click
-  `default(DateTimeOffset)` is pushed back to binding source (view-model's property)

## What is the new behavior?
`DatePicker` working properly on android.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
Caused by https://github.com/nventive/Uno/commit/e7dd73100e7f23d4adf3fc0ce6cb92a7892a2518#diff-d4a82890a95f33d1c168f36da63a34e7
Use this to see change:

    git show e7dd7310 -- src\Uno.UI\UI\Xaml\Controls\DatePicker\DatePicker.cs

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/138735/