### PR TITLE
Prevent itemscontrol items to be reloaded too many times

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -39,6 +39,7 @@
  * Adjust .NET template projects versions to 4.6.1
  * Adjust Microsoft.CodeAnalysis versions to avoid restore conflicts
  * Fix element name matching existing types fails to compile (e.g. ContentPresenter)
+ * #382 ItemsControl: template recreated multiple times
 
 ## Release 1.42
 

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -593,11 +593,9 @@ namespace Windows.UI.Xaml.Controls
 			int remainder = GetDisplayGroupCount(section) % itemsPerLine;
 			return remainder == 0 ? itemsPerLine : remainder;
 		}
-
+		
 		protected virtual void OnItemsSourceChanged(DependencyPropertyChangedEventArgs e)
 		{
-			Items?.Clear();
-
 			IsGrouping = (e.NewValue as ICollectionView)?.CollectionGroups != null;
 			SetNeedsUpdateItems();
 			ObserveCollectionChanged();
@@ -865,7 +863,7 @@ namespace Windows.UI.Xaml.Controls
 						PrepareContainerForIndex(container, index);
 						return container;
 					});
-
+				
 				var results = ItemsPanelRoot.Children.UpdateWithResults(containers.OfType<View>(), comparer: new ViewComparer());
 
 				foreach (var removed in results.Removed)
@@ -1041,9 +1039,16 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var item = ItemFromIndex(index);
 
-			var container = IsItemItsOwnContainerOverride(item)
-				? item as DependencyObject
-				: GetContainerForItemOverride();
+			var container = default(DependencyObject);
+
+			if (IsItemItsOwnContainerOverride(item))
+			{
+				container = item as DependencyObject;
+			}
+			else
+			{
+				container = ItemsPanelRoot?.Children?.OfType<ContentPresenter>()?.FirstOrDefault(c => c.Content?.Equals(item) ?? false) ?? GetContainerForItemOverride();
+			}
 
 			container.SetValue(ItemsControlForItemContainerProperty, new WeakReference<ItemsControl>(this));
 


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #382 

## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
When using an ItemsControl, item templates are created multiple times.

## What is the new behavior?
Item container is reused if possible, which limit reload.

## PR Checklist
- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

## Other information
None

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/139686