### PR TITLE
Ensure the disabled ListViewItem multi-selection state is applied properly

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -42,7 +42,8 @@
  * Adjust .NET template projects versions to 4.6.1
  * Adjust Microsoft.CodeAnalysis versions to avoid restore conflicts
  * Fix element name matching existing types fails to compile (e.g. ContentPresenter)
- * 138735 [Android] Fixed broken DatePicker
+ * 138735 [Android] Fixed broken DatePicker 
+ * Multi-selection Check Boxes in ListViewItems are appearing brielfly (https://github.com/nventive/Uno/issues/403)
  * 140721 [Android] FlipView not visible when navigating back to page
 
 ## Release 1.42

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -546,19 +546,12 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		/// <summary>
-		/// Set appropriate visual state from MultiSelectStates group. (https://msdn.microsoft.com/en-us/library/windows/apps/mt299136.aspx?f=255&MSPPError=-2147217396)
+		/// Apply the multi-selection state to the provided item
 		/// </summary>
 		/// <param name="selectorItem"></param>
 		internal void ApplyMultiSelectState(SelectorItem selectorItem)
 		{
-			if (IsSelectionMultiple)
-			{
-				VisualStateManager.GoToState(selectorItem, "MultiSelectEnabled", useTransitions: true);
-			}
-			else
-			{
-				VisualStateManager.GoToState(selectorItem, "MultiSelectDisabled", useTransitions: true);
-			}
+			selectorItem.IsMultiselectEnabled = IsSelectionMultiple;
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/SelectorItem.cs
@@ -82,6 +82,11 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		}
 
 		private bool _isPressed;
+
+		// The default state of this variable must follow the default state of the
+		// associated UI elements in the generic template.
+		private bool _isMultiSelectedEnabled;
+
 		internal bool IsPressed
 		{
 			get { return _isPressed; }
@@ -95,6 +100,25 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			}
 		}
 
+
+		/// <summary>
+		/// Set appropriate visual state from MultiSelectStates group. (https://msdn.microsoft.com/en-us/library/windows/apps/mt299136.aspx?f=255&MSPPError=-2147217396)
+		/// </summary>
+		internal bool IsMultiselectEnabled
+		{
+			get { return _isMultiSelectedEnabled; }
+			set {
+
+				if (_isMultiSelectedEnabled != value)
+				{
+					// The MultiSelectDisabled state goes through VisibleRect then collapsed, which means Disabled state can't be
+					// invoked if the state is already disabled without having the selected check box appearing briefly. (Issue #403)
+					VisualStateManager.GoToState(this, value ? "MultiSelectEnabled" : "MultiSelectDisabled", useTransitions: true);
+
+					_isMultiSelectedEnabled = value;
+				}
+			}
+		}
 
 		partial void OnIsSelectedChangedPartial(bool oldIsSelected, bool newIsSelected)
 		{


### PR DESCRIPTION
GitHub Issue (If applicable): closes #403 

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
ListViewItems show their multi-select checkbox briefly, even if the current mode does not allow multi-selection.

## What is the new behavior?
Checkboxes don't appear anymore.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
