### PR TITLE
Fix items reload in ItemsControl

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -64,6 +64,7 @@
  * Fix invalid Border Content type for macOS
  * Don't fail iOS ListView if item Content is null 
  * [Wasm] Implement naive refresh for items manipulation in the ListViewBase
+ * 3326 [iOS][ItemsControl] ItemsControl in FlipView does not restore items properly
 
 ## Release 1.42
 

--- a/src/Uno.UI.Tests/ItemsControlTests/Given_ItemsControl.cs
+++ b/src/Uno.UI.Tests/ItemsControlTests/Given_ItemsControl.cs
@@ -14,7 +14,7 @@ namespace Uno.UI.Tests.ItemsControlTests
 {
 	[TestClass]
 	public class Given_ItemsControl
-    {
+	{
 		[TestMethod]
 		public void When_EarlyItems()
 		{
@@ -95,10 +95,34 @@ namespace Uno.UI.Tests.ItemsControlTests
 			};
 
 			Assert.IsNull(SUT.ItemsPresenter);
-			
+
 			itemsPresenter.ForceLoaded();
 
 			Assert.IsNotNull(SUT.ItemsPresenter);
+		}
+
+		[TestMethod]
+		public void When_OnItemsSourceChanged()
+		{
+			var count = 0;
+			var panel = new StackPanel();
+
+			var SUT = new ItemsControl()
+			{
+				ItemsPanelRoot = panel,
+				InternalItemsPanelRoot = panel,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					count++;
+					return new Border();
+				}),
+				ItemsSource = new[]
+				{
+					"Item1"
+				}
+			};
+			
+			Assert.AreEqual(1, count);
 		}
 	}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -596,7 +596,9 @@ namespace Windows.UI.Xaml.Controls
 
 		protected virtual void OnItemsSourceChanged(DependencyPropertyChangedEventArgs e)
 		{
-			Items?.Clear();
+			// Following line is commented out, since updating Items will trigger a call to SetNeedsUpdateItems() and causes unexpected results
+			// There is no effect to comment out this line, as 1) there is no sync up between Items and ItemsSource and 2) GetItems() will give precedence to ItemsSource
+			// Items?.Clear();
 
 			IsGrouping = (e.NewValue as ICollectionView)?.CollectionGroups != null;
 			SetNeedsUpdateItems();


### PR DESCRIPTION
GitHub Issue (If applicable): #
Related with #382 

## PR Type
Bugfix 

## What is the current behavior?
ItemsControl in FlipView does not restore items properly

## What is the new behavior?
Items are properly materialized again

## PR Checklist
- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

## Other information
None

Internal Issue (If applicable):
https://nventive.visualstudio.com/_workitems/edit/141522