### PR TITLE
Add missing Mono.Cecil dependency for the XAML source generator

### DIFF
--- a/build/Uno.UI.nuspec
+++ b/build/Uno.UI.nuspec
@@ -169,6 +169,9 @@
 	<file src="..\src\SourceGenerators\Uno.UI.SourceGenerators\Bin\Release\Uno.Xaml.dll" target="tools" />
 	<file src="..\src\SourceGenerators\Uno.UI.SourceGenerators\Bin\Release\Uno.Xaml.pdb" target="tools" />
 	<file src="..\src\SourceGenerators\Uno.UI.SourceGenerators\Bin\Release\Uno.UI.SourceGenerators.pdb" target="tools" />
+	<file src="..\src\SourceGenerators\Uno.UI.SourceGenerators\Bin\Release\Mono.Cecil.*.dll" target="tools" />
+	<file src="..\src\SourceGenerators\Uno.UI.SourceGenerators\Bin\Release\Mono.Cecil.*.pdb" target="tools" />
+    
 	<file src="..\src\SourceGenerators\Uno.UI.Tasks\Bin\Release\*.dll" target="build\Uno.UI.Tasks" />
 	<file src="..\src\SourceGenerators\Uno.UI.Tasks\Bin\Release\*.pdb" target="build\Uno.UI.Tasks" />
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Building an application fails with this error:
```
Generation failed: System.AggregateException: One or more errors occurred. 
---> System.InvalidOperationException: Generation failed for Uno.UI.SourceGenerators.XamlGenerator.XamlCodeGenerator. System.AggregateException: One or more errors occurred. 
---> System.IO.FileLoadException: Could not load file or assembly 'Mono.Cecil, Version=0.10.1.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040) 
---> System.IO.FileLoadException: The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)
```

## What is the new behavior?
The build does not fail.

The Mono.Cecil assemblies loaded by the SourceGeneration tasks do not match the cecil version that must be loaded by the Xaml generation tasks. This PR adds the missing files in the Uno.UI nuget package.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes
