### PR TITLE
[Android] Notify dataset changed when the current item changed

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -42,7 +42,8 @@
  * Adjust .NET template projects versions to 4.6.1
  * Adjust Microsoft.CodeAnalysis versions to avoid restore conflicts
  * Fix element name matching existing types fails to compile (e.g. ContentPresenter)
- * 138735 [Android] Fixed broken DatePicker 
+ * 138735 [Android] Fixed broken DatePicker
+ * 140721 [Android] FlipView not visible when navigating back to page
 
 ## Release 1.42
 

--- a/src/Uno.UI/UI/Xaml/Controls/FlipView/FlipView.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/FlipView/FlipView.Android.cs
@@ -32,18 +32,16 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void OnSelectedIndexChangedPartial(int oldValue, int newValue, bool animateChange)
 		{
-			var pager = PagedView;
-			if (pager == null)
+			if (PagedView?.CurrentItem != newValue)
 			{
 				return;
 			}
-			if (newValue != pager.CurrentItem)
-			{
-				//Update PagedView state if necessary, to avoid an IllegalStateException
-				UpdateItemsIfNeeded();
 
-				pager.SetCurrentItem(newValue, smoothScroll: animateChange);
-			}
+			//Update PagedView state if necessary, to avoid an IllegalStateException
+			UpdateItemsIfNeeded();
+
+			PagedView.SetCurrentItem(newValue, smoothScroll: animateChange);
+			PagedView.Adapter.NotifyDataSetChanged();
 		}
 
 		private class FlipViewPageChangeListener : Android.Support.V4.View.ViewPager.SimpleOnPageChangeListener


### PR DESCRIPTION
GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When navigating back to a page with a FlipView, it disappears. If you navigate to a new page again and go back to the FlipView page, it reappears.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
The FlipView is always displayed

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://nventive.visualstudio.com/Umbrella/_workitems/edit/140721