### PR TITLE
fixed command bar not rendering until reloaded

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -96,6 +96,7 @@
  * 104057 [Android] ListView shows overscroll effect even when it doesn't need to scroll
  * #376 iOS project compilation fails: Can't resolve the reference 'System.Void Windows.UI.Xaml.Documents.BlockCollection::Add(Windows.UI.Xaml.Documents.Block)
  * 138099, 138463 [Android] fixed `ListView` scrolls up when tapping an item at the bottom of screen
+ * 140548 [iOS] fixed `CommandBar` not rendering until reloaded
 
 ## Release 1.41
 

--- a/src/Uno.UI/Controls/CommandBarRenderer.iOS.cs
+++ b/src/Uno.UI/Controls/CommandBarRenderer.iOS.cs
@@ -121,9 +121,10 @@ namespace Uno.UI.Controls
 			Native.BackIndicatorImage = backButtonIcon;
 			Native.BackIndicatorTransitionMaskImage = backButtonIcon;
 
-			Element.Presenter.Height = Native.Hidden
-				? 0
-				: Native.Frame.Size.Height;
+			if (Element.Presenter != null)
+			{
+				Element.Presenter.Height = Native.Hidden ? 0 : Native.Frame.Size.Height;
+			}
 		}
 	}
 }


### PR DESCRIPTION
## PR Type
Bugfix

## What is the current behavior?
`CommandBar` showing *nothing* when it is on "home"(first) page, until the user navigates away and then back. This affects `iOS` only.

## What is the new behavior?
`CommandBar` now renders properly.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
Regression from e35bf4e9 (#357)

Internal Issue (If applicable):
AB#140548
https://nventive.visualstudio.com/Umbrella/_workitems/edit/140548