### PR TITLE
Fixes regression in ToggleSwitch where the thumb would not be displayed on Android.

### DIFF
--- a/src/Uno.UI/Controls/BindableSwitchCompat.Android.cs
+++ b/src/Uno.UI/Controls/BindableSwitchCompat.Android.cs
@@ -119,11 +119,13 @@ namespace Uno.UI.Controls
 		public BindableSwitchCompat(Android.Content.Context context, IAttributeSet attrs)
 			: base(context, attrs)
 		{
+			InitializeBinder();
 		}
 
 		public BindableSwitchCompat(Android.Content.Context context, IAttributeSet attrs, int defStyle)
 			: base(context, attrs, defStyle)
 		{
+			InitializeBinder();
 		}
 	}
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
ToggleSwitch's thumb is not displayed on Android.

## What is the new behavior?
ToggleSwitch's thumb is displayed on Android.

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/141907