### PR TITLE
[Wasm] Fix hosted mode WindowManager.resetStyle

### DIFF
--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -504,7 +504,7 @@ var Uno;
                 * @param styles A dictionary of styles to apply on html element.
                 */
             resetStyle(elementId, names) {
-                this.resetStyleInternal(elementId, name);
+                this.resetStyleInternal(elementId, names);
                 return "ok";
             }
             /**

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -424,7 +424,7 @@
 			* @param styles A dictionary of styles to apply on html element.
 			*/
 		public resetStyle(elementId: number, names: string[]): string {
-			this.resetStyleInternal(elementId, name);
+			this.resetStyleInternal(elementId, names);
 			return "ok";
 		}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Calling WindowManager.resetStyle in hosted mode fails to reset a style, having for effect to prevent collapsed nodes from being visible again.

## What is the new behavior?
Calling WindowManager.resetStyle works properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking change
