### PR TITLE
[Android] Add support for ListViewItem instances provided via the ItemsSource property

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -40,6 +40,7 @@
 * Add missing Android Sample App symbols font
 * Raise Application.UnhandledException event on failed navigation
 * Adjusts the `Microsoft.NETCore.UniversalWindowsPlatform` version in the UWP head template to avoid assembly loading issues when using the Uno library template in the sample solution.
+* [Android] Add support for ListViewItem instances provided via the ItemsSource property
 
 ### Breaking changes
 * Refactored ToggleSwitch Default Native XAML Styles. (cf. 'NativeDefaultToggleSwitch' styles in Generic.Native.xaml)

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBaseAdapter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/NativeListViewBaseAdapter.Android.cs
@@ -26,6 +26,7 @@ namespace Windows.UI.Xaml.Controls
 		private const int NoTemplateGroupHeaderType = -1;
 		private const int HeaderItemType = -2;
 		private const int FooterItemType = -3;
+		private const int IsOwnContainerType = -4;
 
 		private const int MaxRecycledViewsPerViewType = 10;
 
@@ -87,6 +88,10 @@ namespace Windows.UI.Xaml.Controls
 				container.ContentTemplate = dataTemplate;
 				container.Binding("Content", "");
 			}
+			else if(viewType == IsOwnContainerType)
+			{
+				holder.ItemView = parent?.GetContainerForIndex(index) as View;
+			}
 			else
 			{
 				parent.PrepareContainerForIndex(container, index);
@@ -125,7 +130,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private ContentControl GenerateContainer(int viewType)
 		{
-			if (viewType == HeaderItemType || viewType == FooterItemType)
+			if (viewType == HeaderItemType || viewType == FooterItemType || viewType == IsOwnContainerType)
 			{
 				return ContentControl.CreateItemContainer();
 			}
@@ -159,7 +164,14 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else
 			{
-				viewType = isGroupHeader ? NoTemplateGroupHeaderType : NoTemplateItemType;
+				if (XamlParent?.IsItemItsOwnContainer(item) ?? false)
+				{
+					viewType = IsOwnContainerType;
+				}
+				else
+				{
+					viewType = isGroupHeader ? NoTemplateGroupHeaderType : NoTemplateItemType;
+				}
 			}
 
 			if (isGroupHeader)


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Providing `ListViewItem` instances through `ItemsSource` makes the items visualy wrapped inside another `ListViewItem.

## What is the new behavior?
`ListViewItem` instances provided by an `ItemsSource` are now reused as-is.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
or internal) -->