### PR TITLE
NavigationView fails when PaneTitle is not set

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -3046,7 +3046,7 @@ namespace Windows.UI.Xaml.Controls
 						width += backButtonWidth;
 					}
 
-					if (!m_isClosedCompact && PaneTitle.Length > 0)
+					if (!m_isClosedCompact && PaneTitle?.Length > 0)
 					{
 						if (splitView.DisplayMode == SplitViewDisplayMode.Overlay && IsPaneOpen)
 						{


### PR DESCRIPTION
## PR TypeWhat kind of change does this PR introduce?
Bugfix

## What is the current behavior?
NavigationView fails when PaneTitle is not set.

## What is the new behavior?
NavigationView displays properly when PaneTitle is not set.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)