### PR TITLE
Match the default UniversalWindowsPlatform from MSBuild SDK Extras

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -30,7 +30,7 @@
 * Fixed fallback support for Style property set via ThemeResource
 * Add support for multiple resw folders with upri resource generation 
 * Add support for `ThicknessHelper`
-* ResourceLoader adjustments … 
+* ResourceLoader adjustments â€¦ 
   * CurrentUICulture and CurrentCulture are set when setting ResourceLoader .DefaultCulture
   * upri load now ignores resources not used by the current culture
 * Add BrushConverter support for Color input 
@@ -39,6 +39,7 @@
 * Add support for IsItemItsOwnContainer iOS ListView 
 * Add missing Android Sample App symbols font
 * Raise Application.UnhandledException event on failed navigation
+* Adjusts the `Microsoft.NETCore.UniversalWindowsPlatform` version in the UWP head template to avoid assembly loading issues when using the Uno library template in the sample solution.
 
 ### Breaking changes
 * Refactored ToggleSwitch Default Native XAML Styles. (cf. 'NativeDefaultToggleSwitch' styles in Generic.Native.xaml)

--- a/src/SolutionTemplate/UnoSolutionTemplate/UWP/UnoQuickStart.Uwp.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/UWP/UnoQuickStart.Uwp.csproj
@@ -1,9 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.1.7</Version>
+			<!-- 
+			If, in the same solution, you are referencing a project that uses https://github.com/onovotny/MSBuildSdkExtras,
+			you need to make sure that the version provided here matches https://github.com/onovotny/MSBuildSdkExtras/blob/master/Source/MSBuild.Sdk.Extras/DefaultItems/ImplicitPackages.targets#L11.
+			This is not an issue when libraries are referenced through nuget packages. See https://github.com/nventive/Uno/issues/446 for more details.
+			-->
+      <Version>6.2.2</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #446.

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
Adjust the version of the `Microsoft.NETCore.UniversalWindowsPlatform` nuget package reference to avoid issues caused by versions mismatch when a project reference uses MSBuild Extras.

Also adjusts the msbuild version.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)