### PR TITLE
Fix NRE in Slider when no template is applied

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -65,6 +65,7 @@
  * Don't fail iOS ListView if item Content is null 
  * [Wasm] Implement naive refresh for items manipulation in the ListViewBase
  * 3326 [iOS][ItemsControl] ItemsControl in FlipView does not restore items properly
+ * Fix NRE in Slider when no template is applied
 
 ## Release 1.42
 

--- a/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Slider/Slider.cs
@@ -285,13 +285,19 @@ namespace Windows.UI.Xaml.Controls
 			// The _decreaseRect's height/width is updated, which in turn pushes or pulls the Thumb to its correct position
 			if (Orientation == Orientation.Horizontal)
 			{
-				var maxWidth = ActualWidth - _horizontalThumb.ActualWidth;
-				_horizontalDecreaseRect.Width = (float)((Value - Minimum) / (Maximum - Minimum)) * maxWidth;
+                if (_horizontalThumb != null && _horizontalDecreaseRect != null)
+                {
+                    var maxWidth = ActualWidth - _horizontalThumb.ActualWidth;
+                    _horizontalDecreaseRect.Width = (float)((Value - Minimum) / (Maximum - Minimum)) * maxWidth;
+                }
 			}
 			else
 			{
-				var maxHeight = ActualHeight - _horizontalThumb.ActualHeight;
-				_verticalDecreaseRect.Height = (float)((Value - Minimum) / (Maximum - Minimum)) * maxHeight;
+                if (_verticalThumb != null && _verticalDecreaseRect != null)
+                {
+                    var maxHeight = ActualHeight - _verticalThumb.ActualHeight;
+                    _verticalDecreaseRect.Height = (float)((Value - Minimum) / (Maximum - Minimum)) * maxHeight;
+                }
 			}
 		}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The Slider may crash when the value is updated an no template is applied.


## What is the new behavior?
The Slider control does not crash.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/142696