### PR TITLE
Fix Frame does not unset Page.Frame

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -66,6 +66,7 @@
  * [Wasm] Implement naive refresh for items manipulation in the ListViewBase
  * 3326 [iOS][ItemsControl] ItemsControl in FlipView does not restore items properly
  * Fix NRE in Slider when no template is applied
+ * Fix `Frame` does not unset `Page.Frame` when a page is removed
 
 ## Release 1.42
 

--- a/src/Uno.UI.Tests/Frame/Given_Frame.cs
+++ b/src/Uno.UI.Tests/Frame/Given_Frame.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions;
+using Windows.Foundation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+
+namespace Uno.UI.Tests.FrameTests
+{
+	[TestClass]
+	public class Given_Frame
+	{
+		[TestMethod]
+		public void When_RemovedPage()
+		{
+			var SUT = new Frame()
+			{
+			};
+
+			SUT.Navigate(typeof(MyPage));
+
+			var myPage1 = SUT.Content as MyPage;
+			Assert.IsNotNull(myPage1);
+			Assert.AreEqual(SUT, myPage1.Frame);
+
+			SUT.Navigate(typeof(MyPage));
+
+			var myPage2 = SUT.Content as MyPage;
+			Assert.IsNotNull(myPage2);
+			Assert.AreEqual(SUT, myPage2.Frame);
+
+			SUT.GoBack();
+
+			Assert.AreEqual(myPage1, SUT.Content);
+			Assert.IsNotNull(myPage2.Frame);
+
+			SUT.Navigate(typeof(MyPage));
+
+			var myPage3 = SUT.Content as MyPage;
+
+			Assert.AreEqual(myPage3, SUT.Content);
+			Assert.IsNull(myPage2.Frame);
+		}
+	}
+
+	class MyPage : Page
+	{
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Frame/Frame.cs
@@ -346,6 +346,11 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		private void ReleasePages(IList<PageStackEntry> pageStackEntries)
 		{
+			foreach (var entry in pageStackEntries)
+			{
+				entry.Instance.Frame = null;
+			}
+
 			if (!FeatureConfiguration.Page.IsPoolingEnabled)
 			{
 				return;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
When a page goes out of the backstack, its `Page.Frame` property is not reset, leading to a potential memory leak.

## What is the new behavior?
`Page.Frame` is now set to null.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
