### PR TITLE
Improve Android FrameworkElement.Load and Unload propagation performance

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -38,6 +38,8 @@
 * Add CoreApplication.GetCurrentView() Dispatcher and TitleBar stubs support 
 * Add support for IsItemItsOwnContainer iOS ListView 
 * Add missing Android Sample App symbols font
+* Improve UIElement inner Children enumeration performance and memory usage
+* Add `FeatureConfiguration.FrameworkElement.AndroidUseManagedLoadedUnloaded` to control the native or managed propagation performance of Loaded/Unloaded events through the visual tree
 * Raise Application.UnhandledException event on failed navigation
 * Adjusts the `Microsoft.NETCore.UniversalWindowsPlatform` version in the UWP head template to avoid assembly loading issues when using the Uno library template in the sample solution.
 * [Android] Add support for ListViewItem instances provided via the ItemsSource property

--- a/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoViewGroup.java
+++ b/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoViewGroup.java
@@ -21,6 +21,8 @@ public abstract class UnoViewGroup
     private boolean _childBlockedTouchEvent;
     private boolean _childIsUnoViewGroup;
 
+    private boolean _isManagedLoaded;
+
 	private boolean _isPointerCaptured;
 	private boolean _isPointInView;
 
@@ -537,7 +539,11 @@ public abstract class UnoViewGroup
     protected final void onAttachedToWindow()
     {
         super.onAttachedToWindow();
-        onNativeLoaded();
+
+		if(!_isManagedLoaded) {
+			onNativeLoaded();
+			_isManagedLoaded = true;
+		}
     }
 
     protected abstract void onNativeLoaded();
@@ -545,10 +551,31 @@ public abstract class UnoViewGroup
     protected final void onDetachedFromWindow()
     {
         super.onDetachedFromWindow();
-        onNativeUnloaded();
+
+		if(_isManagedLoaded) {
+			onNativeUnloaded();
+			_isManagedLoaded = false;
+		}
     }
 
     protected abstract void onNativeUnloaded();
+
+	/**
+	 * Marks this view as loaded from the managed side, so onAttachedToWindow can skip
+	 * calling onNativeLoaded.
+	 */
+	public final void setIsManagedLoaded(boolean value)
+    {
+        _isManagedLoaded = value;
+    }
+
+	/**
+	 * Gets if this view is loaded from the managed side.
+	 */
+    public final boolean getIsManagedLoaded()
+    {
+        return _isManagedLoaded;
+    }
 
     public final void setVisibility(int visibility)
     {

--- a/src/Uno.UI/Configuration.cs
+++ b/src/Uno.UI/Configuration.cs
@@ -38,6 +38,19 @@ namespace Uno.UI
 			/// is set to <see cref="false"/>.
 			/// </summary>
 			public static bool ClearPreviousOnStyleChange { get; set; } = true;
+
+#if __ANDROID__
+			/// <summary>
+			/// Controls the propagation of <see cref="FrameworkElement.Loaded"/> and
+			/// <see cref="FrameworkElement.AndroidUseManagedLoadedUnloaded"/> events through managed
+			/// or native visual tree traversal. 
+			/// </summary>
+			/// <remarks>
+			/// This setting impacts significatly the loading performance of controls on Android.
+			/// Setting it to <see cref="true"/> avoids the use of costly Java->C# interop.
+			/// </remarks>
+			public static bool AndroidUseManagedLoadedUnloaded { get; set; } = true;
+#endif
 		}
 
 		public static class Style

--- a/src/Uno.UI/Controls/BindableNSView.macOS.cs
+++ b/src/Uno.UI/Controls/BindableNSView.macOS.cs
@@ -21,7 +21,7 @@ namespace Uno.UI.Controls
 	{
 		private List<NSView> _shadowChildren = new List<NSView>();
 
-		IReadOnlyList<NSView> IShadowChildrenProvider.ChildrenShadow => _shadowChildren;
+		List<NSView> IShadowChildrenProvider.ChildrenShadow => _shadowChildren;
 
 		internal IReadOnlyList<NSView> ChildrenShadow => _shadowChildren;
 

--- a/src/Uno.UI/Controls/BindableUIView.iOS.cs
+++ b/src/Uno.UI/Controls/BindableUIView.iOS.cs
@@ -27,7 +27,7 @@ namespace Uno.UI.Controls
 	{
 		private List<UIView> _shadowChildren = new List<UIView>();
 
-		IReadOnlyList<UIView> IShadowChildrenProvider.ChildrenShadow => _shadowChildren;
+		List<UIView> IShadowChildrenProvider.ChildrenShadow => _shadowChildren;
 
 		internal IReadOnlyList<UIView> ChildrenShadow => _shadowChildren;
 

--- a/src/Uno.UI/Controls/BindableView.Android.cs
+++ b/src/Uno.UI/Controls/BindableView.Android.cs
@@ -82,7 +82,7 @@ namespace Uno.UI.Controls
 		/// <summary>
 		/// Provides a shadowed list of views, used to limit the impact of the marshalling.
 		/// </summary>
-		IReadOnlyList<View> IShadowChildrenProvider.ChildrenShadow => _childrenShadow;
+		List<View> IShadowChildrenProvider.ChildrenShadow => _childrenShadow;
 
 		internal List<View>.Enumerator GetChildrenEnumerator() => _childrenShadow.GetEnumerator();
 
@@ -136,6 +136,15 @@ namespace Uno.UI.Controls
 		/// observer.</remarks>
 		public new virtual void RemoveView(View view)
 		{
+			if (FeatureConfiguration.FrameworkElement.AndroidUseManagedLoadedUnloaded)
+			{
+				if (view is FrameworkElement fe)
+				{
+					fe.IsManagedLoaded = false;
+					fe.PerformOnUnloaded();
+				}
+			}
+
 			_childrenShadow.Remove(view);
 			base.RemoveViewFast(view);
 
@@ -151,6 +160,15 @@ namespace Uno.UI.Controls
 		public new virtual void RemoveViewAt(int index)
 		{
 			var removedView = _childrenShadow[index];
+
+			if (FeatureConfiguration.FrameworkElement.AndroidUseManagedLoadedUnloaded)
+			{
+				if (removedView is FrameworkElement fe)
+				{
+					fe.IsManagedLoaded = false;
+					fe.PerformOnUnloaded();
+				}
+			}
 
 			_childrenShadow.RemoveAt(index);
 			base.RemoveViewAtFast(index);

--- a/src/Uno.UI/UI/Xaml/Controls/IShadowChildrenProvider.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/IShadowChildrenProvider.cs
@@ -22,7 +22,11 @@ namespace Uno.UI.Controls
         /// <summary>
         /// An enumerable of children views.
         /// </summary>
-        IReadOnlyList<View> ChildrenShadow { get; }
+		/// <remarks>
+		/// This property is exposed as a concrete <see cref="List{T}"/> to benefit from
+		/// allocation-less enumeration of the shadow children.
+		/// </remarks>
+        List<View> ChildrenShadow { get; }
 	}
 }
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollContentPresenter/ScrollContentPresenter.Android.cs
@@ -19,6 +19,8 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class ScrollContentPresenter : UnoTwoDScrollView, IShadowChildrenProvider, DependencyObject
 	{
+		private readonly static List<View> _emptyList = new List<View>(0);
+
 		private ScrollBarVisibility _verticalScrollBarVisibility;
 		public ScrollBarVisibility VerticalScrollBarVisibility
 		{
@@ -97,7 +99,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		IReadOnlyList<View> IShadowChildrenProvider.ChildrenShadow => Content != null ? new[] { Content } : new View[0];
+		List<View> IShadowChildrenProvider.ChildrenShadow => Content != null ? new List<View>(1) { Content } : _emptyList;
 
 		partial void OnContentChanged(View previousView, View newView)
 		{
@@ -306,6 +308,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		private Thickness _occludedRectPadding;
+
 		private void SetOccludedRectPadding(Thickness occludedRectPadding)
 		{
 			_occludedRectPadding = occludedRectPadding;

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
@@ -38,52 +38,6 @@ namespace <#= mixin.NamespaceName #>
 	{
 		private readonly static IEventProvider _trace = Tracing.Get(FrameworkElement.TraceProvider.Id);
 
-#if <#= mixin.OverridesAttachedToWindow #>
-		protected override void OnNativeLoaded()
-		{
-			try
-			{
-				((IDependencyObjectStoreProvider)this).Store.Parent = base.Parent;
-				OnLoading();
-				OnLoaded();
-
-				base.OnNativeLoaded();
-			}
-			catch (Exception ex)
-			{
-				this.Log().Error("OnNativeLoaded failed in FrameworkElementMixins", ex);
-				Application.Current.RaiseRecoverableUnhandledException(ex);
-			}
-		}
-
-		protected override void OnNativeUnloaded()
-		{
-			try
-			{
-				OnUnloaded();
-
-				base.OnNativeUnloaded();
-			}
-			catch(Exception ex)
-			{
-				this.Log().Error("OnNativeUnloaded failed in FrameworkElementMixins", ex);
-				Application.Current.RaiseRecoverableUnhandledException(ex);
-			}
-		}
-			
-		/// <summary>
-		/// Notifies that this view has been removed from its parent. This method is only 
-		/// called when the parent is an UnoViewGroup.
-		/// </summary>
-		protected override void OnRemovedFromParent()
-            {
-			base.OnRemovedFromParent();
-
-                ((IDependencyObjectStoreProvider)this).Store.Parent = null;
-            }
-		
-#endif
-
 		public event DependencyPropertyChangedEventHandler IsEnabledChanged;
 
         public event TypedEventHandler<DependencyObject, object> Loading;


### PR DESCRIPTION
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
- Performance

## What is the new behavior?
- Move OnNativeLoaded and OnNativeUnloaded from .tt to android specific FrameworkElement.
- Adjust IChildrenShadowProvider interface to expose List<View> to benefit from allocation less children enumerion
- Add `FeatureConfiguration.FrameworkElement.AndroidUseManagedLoadedUnloaded` to control the native or managed propagation performance of Loaded/Unloaded events through the visual tree.
In the Uno.Gallery application, the main page goes from 293 OnNativeLoaded interop invocations to 34, and the GridView sample from 457 to 83. OnNativeUnloaded calls from GridView sample are down from 247 to 116.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Internal Issue (If applicable):
https://nventive.visualstudio.com/DefaultCollection/Umbrella/_workitems/edit/142697