### PR TITLE
Fix Android Managed Load/Unload traversal for missing actions

### DIFF
--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
@@ -63,7 +63,10 @@ namespace Windows.UI.Xaml
 						// traversal, to avoid paying the cost of overriden method interop
 						e.IsManagedLoaded = true;
 
-						e.PerformOnLoaded();
+						// Calling this method is acceptable as it is an abstract method that
+						// will never do interop with the java class. It is required to invoke
+						// Loaded/Unloaded actions.
+						e.OnNativeLoaded();
 					}
 				}
 			}
@@ -100,7 +103,10 @@ namespace Windows.UI.Xaml
 							// traversal, to avoid paying the cost of overriden method interop
 							e.IsManagedLoaded = false;
 
-							e.PerformOnUnloaded();
+							// Calling this method is acceptable as it is an abstract method that
+							// will never do interop with the java class. It is required to invoke
+							// Loaded/Unloaded actions.
+							e.OnNativeUnloaded();
 						}
 						else if (view is ViewGroup childViewGroup)
 						{


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Some controls (e.g. `Path`) do not get reloaded properly as they are missing loaded/unloaded actions invocations.

## What is the new behavior?
Loaded/Unloaded actions are now called in managed traversal, fixing `Path`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
