### PR TITLE
Disable XBox checking in WinUI's SharedHelper.IsOnXbox

### DIFF
--- a/src/Uno.UI/Helpers/WinUI/SharedHelpers.cs
+++ b/src/Uno.UI/Helpers/WinUI/SharedHelpers.cs
@@ -25,9 +25,12 @@ namespace Uno.UI.Helpers.WinUI
 {
 	internal class SharedHelpers
 	{
-		private static bool s_isOnXboxInitialized = false;
+#pragma warning disable CS0414 
+        private static bool s_isOnXboxInitialized = false;
 		private static bool s_isOnXbox = false;
-		private static bool s_isMouseModeEnabledInitialized = false;
+#pragma warning restore CS0414
+
+        private static bool s_isMouseModeEnabledInitialized = false;
 		private static bool s_isMouseModeEnabled = false;
 
 		public static bool IsSystemDll() => false;
@@ -425,6 +428,7 @@ namespace Uno.UI.Helpers.WinUI
 
 		public static bool IsOnXbox()
 		{
+#if HAS_UNO
 			if (!s_isOnXboxInitialized)
 			{
 				var deviceFamily = AnalyticsInfo.VersionInfo.DeviceFamily;
@@ -434,6 +438,9 @@ namespace Uno.UI.Helpers.WinUI
 				s_isOnXboxInitialized = true;
 			}
 			return s_isOnXbox;
+#else
+			return false;
+#endif
 		}
 
 		// Be careful to use this API.


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The NavigationView may fail when checking for XBox environment.

## What is the new behavior?
The NavigationView does not fail when checking for XBox environment.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
