### PR TITLE
Fixed broken TimePicker Flyout on android devices.

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -80,6 +80,7 @@
  * Border properties now invalidates measure and arrange on all platforms
  * 141907 [Android] [iOS] The toggle switch is half missing.
  * 142937 [Android] [iOS] Some Button ThemeBrushes are missing.
+ * 143527 [Android] Fixed broken TimePicker Flyout on android devices. 
 
 ## Release 1.42
 

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
@@ -72,16 +72,19 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (_flyoutButton != null)
 			{
-#if __IOS__
+#if __IOS__ || __ANDROID__
 				_flyoutButton.Flyout = new TimePickerFlyout
 				{
+#if __IOS__
 					Placement = FlyoutPlacement,
+#endif
 					Time = this.Time,
 					ClockIdentifier = this.ClockIdentifier
 				};
-#endif
+
 				BindToFlyout(nameof(Time));
 				BindToFlyout(nameof(ClockIdentifier));
+#endif
 			}
 
 			UpdateDisplayedDate();


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
Tap on a TimePicker on an Android device. No TimePicker Flyout is displayed.


## What is the new behavior?
By tapping on a TimePicker on an Android device the TimePicker Flyout is correctly displayed.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/143527