### PR TITLE
[Wasm] RotateTransform were not considering TransformOrigin

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -86,6 +86,8 @@
  * 143527 [Android] Fixed broken TimePicker Flyout on android devices.
  * 143596 [Wasm] Images stretching is incorrect
  * 143595 [Wasm] Wasm ListView Resizing is not working - Limitation: items can't change its size yet, but it's now getting measured/arranged correctly.
+ * 143527 [Android] Fixed broken TimePicker Flyout on android devices.
+ * 143598 [Wasm] Wasm Animation rotation center is incorrect
 
 ## Release 1.42
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -349,6 +349,58 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Border_With_CompositeTransform.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Border_With_Off_Centre_RotateTransform.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Border_With_Off_Centre_ScaleTransform.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Border_With_RotateTransform.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Border_With_ScaleTransform.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Border_With_TranslateTransform.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Grid_With_RotateTransform_And_Button.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Image_With_RotateTransform.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Polygon_With_RotateTransform.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Rectangle_With_RotateTransform.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\TextBox_With_RotateTransform.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\TransformToVisual_Simple.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\TransformToVisual_Translate2d.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\ShapeControlsPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -616,6 +668,45 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\NavigationViewTests\SettingsPage.xaml.cs">
       <DependentUpon>SettingsPage.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Border_With_CompositeTransform.xaml.cs">
+      <DependentUpon>Border_With_CompositeTransform.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Border_With_Off_Centre_RotateTransform.xaml.cs">
+      <DependentUpon>Border_With_Off_Centre_RotateTransform.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Border_With_Off_Centre_ScaleTransform.xaml.cs">
+      <DependentUpon>Border_With_Off_Centre_ScaleTransform.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Border_With_RotateTransform.xaml.cs">
+      <DependentUpon>Border_With_RotateTransform.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Border_With_ScaleTransform.xaml.cs">
+      <DependentUpon>Border_With_ScaleTransform.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Border_With_TranslateTransform.xaml.cs">
+      <DependentUpon>Border_With_TranslateTransform.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Grid_With_RotateTransform_And_Button.xaml.cs">
+      <DependentUpon>Grid_With_RotateTransform_And_Button.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Image_With_RotateTransform.xaml.cs">
+      <DependentUpon>Image_With_RotateTransform.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Polygon_With_RotateTransform.xaml.cs">
+      <DependentUpon>Polygon_With_RotateTransform.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\Rectangle_With_RotateTransform.xaml.cs">
+      <DependentUpon>Rectangle_With_RotateTransform.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\TextBox_With_RotateTransform.xaml.cs">
+      <DependentUpon>TextBox_With_RotateTransform.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\TransformToVisual_Simple.xaml.cs">
+      <DependentUpon>TransformToVisual_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\Transform\TransformToVisual_Translate2d.xaml.cs">
+      <DependentUpon>TransformToVisual_Translate2d.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Shapes\ShapeControlsPage.xaml.cs">
       <DependentUpon>ShapeControlsPage.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_CompositeTransform.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_CompositeTransform.xaml
@@ -1,0 +1,93 @@
+<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform.Border_With_CompositeTransform" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://nventive.com/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://nventive.com/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Description for sample of Border_With_CompositeTransform">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<ScrollViewer>
+					<StackPanel>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<CompositeTransform Rotation="30"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="MintCream">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<CompositeTransform TranslateX="40" Rotation="30"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<CompositeTransform TranslateX="40" Rotation="30" ScaleY="2"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+					</StackPanel>
+				</ScrollViewer>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_CompositeTransform.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_CompositeTransform.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform
+{
+	[SampleControlInfo("Transform", "Border_With_CompositeTransform")]
+	public sealed partial class Border_With_CompositeTransform : UserControl
+	{
+		public Border_With_CompositeTransform()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_Off_Centre_RotateTransform.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_Off_Centre_RotateTransform.xaml
@@ -1,0 +1,137 @@
+<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform.Border_With_Off_Centre_RotateTransform" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://nventive.com/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://nventive.com/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Description for sample of Border_With_Off_Centre_RotateTransform">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<ScrollViewer>
+					<StackPanel>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="1,1">
+								<Border.RenderTransform>
+									<RotateTransform Angle="0"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="MintCream">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="1,1">
+								<Border.RenderTransform>
+									<RotateTransform Angle="45"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0,1">
+								<Border.RenderTransform>
+									<RotateTransform Angle="45"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="MintCream">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin=".75,.75">
+								<Border.RenderTransform>
+									<RotateTransform Angle="45"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin=".25,.75">
+								<Border.RenderTransform>
+									<RotateTransform Angle="45"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+					</StackPanel>
+				</ScrollViewer>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_Off_Centre_RotateTransform.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_Off_Centre_RotateTransform.xaml.cs
@@ -1,0 +1,14 @@
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform
+{
+	[SampleControlInfo("Transform", "Border_With_Off_Centre_RotateTransform")]
+	public sealed partial class Border_With_Off_Centre_RotateTransform : UserControl
+	{
+		public Border_With_Off_Centre_RotateTransform()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_Off_Centre_ScaleTransform.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_Off_Centre_ScaleTransform.xaml
@@ -1,0 +1,41 @@
+<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform.Border_With_Off_Centre_ScaleTransform" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Border with ScaleTransform with CenterX and CentreY set. Blue outline shows original location.">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<Grid Height="300"
+							Width="300"
+							Background="Gray">
+					<Border Height="100"
+									Width="100"
+									Background="Tomato"
+									Opacity="0.8">
+						<Border.RenderTransform>
+							<ScaleTransform ScaleX="1.5"
+															ScaleY="1.5"
+															CenterX="80"
+															CenterY="80"/>
+						</Border.RenderTransform>
+					</Border>
+					<Border Height="100"
+									Width="100"
+									BorderBrush="Blue"
+									BorderThickness="1"/>
+				</Grid>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_Off_Centre_ScaleTransform.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_Off_Centre_ScaleTransform.xaml.cs
@@ -1,0 +1,15 @@
+using Uno.UI.Samples.Controls;
+
+using Windows.UI.Xaml.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform
+{
+	[SampleControlInfo("Transform", "Border_With_Off_Centre_ScaleTransform")]
+	public sealed partial class Border_With_Off_Centre_ScaleTransform : UserControl
+	{
+		public Border_With_Off_Centre_ScaleTransform()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_RotateTransform.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_RotateTransform.xaml
@@ -1,0 +1,181 @@
+<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform.Border_With_RotateTransform" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://nventive.com/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://nventive.com/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Each solid black Border has a different RotateTransform. Blue outline shows original bounds.">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<ScrollViewer>
+					<StackPanel>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<RotateTransform Angle="0"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="MintCream">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<RotateTransform Angle="10"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<RotateTransform Angle="20"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="MintCream">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<RotateTransform Angle="30"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<RotateTransform Angle="40"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="MintCream">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<RotateTransform Angle="50"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<RotateTransform Angle="60"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+					</StackPanel>
+				</ScrollViewer>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_RotateTransform.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_RotateTransform.xaml.cs
@@ -1,0 +1,14 @@
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform
+{
+	[SampleControlInfo("Transform", "Border_With_RotateTransform")]
+	public sealed partial class Border_With_RotateTransform : UserControl
+	{
+		public Border_With_RotateTransform()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_ScaleTransform.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_ScaleTransform.xaml
@@ -1,0 +1,115 @@
+<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform.Border_With_ScaleTransform" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://nventive.com/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://nventive.com/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Each solid black Border has a different ScaleTransform. Blue outline shows original bounds.">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<ScrollViewer>
+					<StackPanel>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<ScaleTransform ScaleX="1" ScaleY="1"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="MintCream">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<ScaleTransform ScaleX="2" ScaleY="2"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<ScaleTransform ScaleX="2.5" ScaleY="1.5"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="MintCream">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<ScaleTransform ScaleX="2.5" ScaleY="1.5" CenterX="20" CenterY="50"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+					</StackPanel>
+				</ScrollViewer>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_ScaleTransform.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_ScaleTransform.xaml.cs
@@ -1,0 +1,14 @@
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform
+{
+	[SampleControlInfo("Transform", "Border_With_ScaleTransform")]
+	public sealed partial class Border_With_ScaleTransform : UserControl
+	{
+		public Border_With_ScaleTransform()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_TranslateTransform.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_TranslateTransform.xaml
@@ -1,0 +1,181 @@
+<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform.Border_With_TranslateTransform" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://nventive.com/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://nventive.com/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Each solid black Border has a different TranslateTransform. Blue outline shows original bounds.">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<ScrollViewer>
+					<StackPanel>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<TranslateTransform X="0" Y="0"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="MintCream">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<TranslateTransform X="50" Y="0"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<TranslateTransform X="50" Y="50"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="MintCream">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<TranslateTransform X="0" Y="50"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<TranslateTransform X="-50" Y="50"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="MintCream">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<TranslateTransform X="-50" Y="0"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Border
+								 Width="50"
+								 Height="50"
+								 Background="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Border.RenderTransform>
+									<TranslateTransform X="-50" Y="-50"/>
+								</Border.RenderTransform>
+							</Border>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+					</StackPanel>
+				</ScrollViewer>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_TranslateTransform.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Border_With_TranslateTransform.xaml.cs
@@ -1,0 +1,14 @@
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform
+{
+	[SampleControlInfo("Transform", "Border_With_TranslateTransform")]
+	public sealed partial class Border_With_TranslateTransform : UserControl
+	{
+		public Border_With_TranslateTransform()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Grid_With_RotateTransform_And_Button.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Grid_With_RotateTransform_And_Button.xaml
@@ -1,0 +1,53 @@
+<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform.Grid_With_RotateTransform_And_Button"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<StackPanel HorizontalAlignment="Center"
+				Background="LightGray"
+				Margin="50">
+		<TextBlock x:Name="ClickCountTextBlock"
+				   Text="Not clicked"
+				   Margin="20" />
+		<Grid Width="300"
+			  Height="300"
+			  BorderBrush="Gray"
+			  BorderThickness="2">
+			<Grid Width="200"
+				  Height="200"
+				  HorizontalAlignment="Center"
+				  VerticalAlignment="Center"
+				  BorderBrush="Black"
+				  BorderThickness="2"
+				  RenderTransformOrigin=".5,.5">
+				<Grid.RenderTransform>
+					<RotateTransform Angle="135" />
+				</Grid.RenderTransform>
+				<Button HorizontalAlignment="Left"
+						VerticalAlignment="Top"
+						Click="IncrementCounter">
+					<Button.Template>
+						<ControlTemplate>
+							<Border Width="60"
+									Height="60"
+									BorderBrush="Blue"
+									BorderThickness="1"
+									Background="Red"
+									CornerRadius="20" />
+						</ControlTemplate>
+					</Button.Template>
+				</Button>
+			</Grid>
+		</Grid>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Grid_With_RotateTransform_And_Button.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Grid_With_RotateTransform_And_Button.xaml.cs
@@ -1,0 +1,22 @@
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform
+{
+	[SampleControlInfo("Transform", "Grid_With_RotateTransform_And_Button", description:"Rotated Grid with Button inside. Button should be clickable.")]
+	public sealed partial class Grid_With_RotateTransform_And_Button : UserControl
+	{
+		public Grid_With_RotateTransform_And_Button()
+		{
+			this.InitializeComponent();
+		}
+
+		private int counter;
+		private void IncrementCounter(object sender, RoutedEventArgs e)
+		{
+			counter++;
+			ClickCountTextBlock.Text = $"Button clicked {counter} times.";
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Image_With_RotateTransform.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Image_With_RotateTransform.xaml
@@ -1,0 +1,188 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.Transform.Image_With_RotateTransform" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://nventive.com/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://nventive.com/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Each Image has a different RotateTransform. Blue outline shows original bounds.">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<ScrollViewer>
+					<StackPanel>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Image 
+								 Width="50"
+								 Height="50"
+								 Source="http://homepages.cae.wisc.edu/~ece533/images/baboon.png"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 Stretch="Fill"
+								 RenderTransformOrigin="0.5,0.5">
+								<Image.RenderTransform>
+									<RotateTransform Angle="0"/>
+								</Image.RenderTransform>
+							</Image>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="MintCream">
+							<Image 
+								 Width="50"
+								 Height="50"
+								 Source="http://homepages.cae.wisc.edu/~ece533/images/baboon.png"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 Stretch="Fill"
+								 RenderTransformOrigin="0.5,0.5">
+								<Image.RenderTransform>
+									<RotateTransform Angle="10"/>
+								</Image.RenderTransform>
+							</Image>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Image 
+								 Width="50"
+								 Height="50"
+								 Source="http://homepages.cae.wisc.edu/~ece533/images/baboon.png"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 Stretch="Fill"
+								 RenderTransformOrigin="0.5,0.5">
+								<Image.RenderTransform>
+									<RotateTransform Angle="20"/>
+								</Image.RenderTransform>
+							</Image>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="MintCream">
+							<Image 
+								 Width="50"
+								 Height="50"
+								 Source="http://homepages.cae.wisc.edu/~ece533/images/baboon.png"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 Stretch="Fill"
+								 RenderTransformOrigin="0.5,0.5">
+								<Image.RenderTransform>
+									<RotateTransform Angle="30"/>
+								</Image.RenderTransform>
+							</Image>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Image 
+								 Width="50"
+								 Height="50"
+								 Source="http://homepages.cae.wisc.edu/~ece533/images/baboon.png"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 Stretch="Fill"
+								 RenderTransformOrigin="0.5,0.5">
+								<Image.RenderTransform>
+									<RotateTransform Angle="40"/>
+								</Image.RenderTransform>
+							</Image>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="MintCream">
+							<Image 
+								 Width="50"
+								 Height="50"
+								 Source="http://homepages.cae.wisc.edu/~ece533/images/baboon.png"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 Stretch="Fill"
+								 RenderTransformOrigin="0.5,0.5">
+								<Image.RenderTransform>
+									<RotateTransform Angle="50"/>
+								</Image.RenderTransform>
+							</Image>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Image 
+								 Width="50"
+								 Height="50"
+								 Source="http://homepages.cae.wisc.edu/~ece533/images/baboon.png"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 Stretch="Fill"
+								 RenderTransformOrigin="0.5,0.5">
+								<Image.RenderTransform>
+									<RotateTransform Angle="60"/>
+								</Image.RenderTransform>
+							</Image>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+					</StackPanel>
+				</ScrollViewer>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Image_With_RotateTransform.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Image_With_RotateTransform.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.Transform
+{
+	[SampleControlInfoAttribute("Transform", "Image_With_RotateTransform")]
+	public sealed partial class Image_With_RotateTransform : UserControl
+	{
+		public Image_With_RotateTransform()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Polygon_With_RotateTransform.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Polygon_With_RotateTransform.xaml
@@ -1,0 +1,97 @@
+<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform.Polygon_With_RotateTransform" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://nventive.com/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://nventive.com/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Each arrow-shaped Polygon has a different RotateTransform set.">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<ScrollViewer>
+					<StackPanel>
+						<Border Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Polygon
+								 Points="0,0 8,0 4,4"
+								 Fill="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Polygon.RenderTransform>
+									<RotateTransform Angle="0"/>
+								</Polygon.RenderTransform>
+							</Polygon>
+						</Border>
+						<Border Width="200"
+							Height="200"
+							Background="MintCream">
+							<Polygon
+								 Points="0,0 8,0 4,4"
+								 Fill="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Polygon.RenderTransform>
+									<RotateTransform Angle="30" />
+								</Polygon.RenderTransform>
+							</Polygon>
+						</Border>
+						<Border Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Polygon
+								 Points="0,0 8,0 4,4"
+								 Fill="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Polygon.RenderTransform>
+									<RotateTransform Angle="60"/>
+								</Polygon.RenderTransform>
+							</Polygon>
+						</Border>
+						<Border Width="200"
+							Height="200"
+							Background="MintCream">
+							<Polygon
+								 Points="0,0 8,0 4,4"
+								 Fill="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Polygon.RenderTransform>
+									<RotateTransform Angle="90" />
+								</Polygon.RenderTransform>
+							</Polygon>
+						</Border>
+						<Border Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Polygon
+								 Points="0,0 8,0 4,4"
+								 Fill="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Polygon.RenderTransform>
+									<RotateTransform Angle="120"/>
+								</Polygon.RenderTransform>
+							</Polygon>
+						</Border>
+					</StackPanel>
+				</ScrollViewer>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Polygon_With_RotateTransform.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Polygon_With_RotateTransform.xaml.cs
@@ -1,0 +1,14 @@
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform
+{
+	[SampleControlInfo("Transform", "Polygon_With_RotateTransform")]
+	public sealed partial class Polygon_With_RotateTransform : UserControl
+	{
+		public Polygon_With_RotateTransform()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Rectangle_With_RotateTransform.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Rectangle_With_RotateTransform.xaml
@@ -1,0 +1,45 @@
+<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform.Rectangle_With_RotateTransform" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://nventive.com/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://nventive.com/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Rectangle_With_RotateTransform">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+						<Grid Width="200"
+							Height="200"
+							Background="LemonChiffon">
+							<Rectangle 
+								 Width="50"
+								 Height="50"
+								Fill="Black"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"
+								 RenderTransformOrigin="0.5,0.5">
+								<Rectangle.RenderTransform>
+									<RotateTransform Angle="30"/>
+								</Rectangle.RenderTransform>
+							</Rectangle>
+							<Border
+								 Width="50"
+								 Height="50"
+								 BorderBrush="Blue"
+								BorderThickness="1"
+								 VerticalAlignment="Center"
+								 HorizontalAlignment="Center"/>
+						</Grid>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Rectangle_With_RotateTransform.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/Rectangle_With_RotateTransform.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform
+{
+	[SampleControlInfoAttribute("Transform", "Rectangle_With_RotateTransform")]
+	public sealed partial class Rectangle_With_RotateTransform : UserControl
+	{
+		public Rectangle_With_RotateTransform()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/TextBox_With_RotateTransform.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/TextBox_With_RotateTransform.xaml
@@ -1,0 +1,196 @@
+<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform.TextBox_With_RotateTransform"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://nventive.com/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://nventive.com/android"
+	xmlns:xamarin="http://nventive.com/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Each TextBox has a different RotateTransform. Blue outline shows original bounds.">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<ScrollViewer>
+					<StackPanel>
+						<Grid Width="200"
+											  Height="200"
+											  Background="LemonChiffon">
+							<TextBox xamarin:Style="{StaticResource XamlDefaultTextBox}"
+									 Width="50"
+									 Height="50"
+									 Text="WORD"
+									 Foreground="Cornsilk"
+									 Background="Black"
+									 VerticalAlignment="Center"
+									 HorizontalAlignment="Center"
+									 RenderTransformOrigin="0.5,0.5">
+								<TextBox.RenderTransform>
+									<RotateTransform Angle="0"/>
+								</TextBox.RenderTransform>
+							</TextBox>
+							<Border
+								Width="50"
+								Height="50"
+								BorderBrush="Blue"
+								BorderThickness="1"
+								VerticalAlignment="Center"
+								HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+											  Height="200"
+											  Background="MintCream">
+							<TextBox xamarin:Style="{StaticResource XamlDefaultTextBox}"
+									 Width="50"
+									 Height="50"
+									 Text="WORD"
+									 Foreground="Cornsilk"
+									 Background="Black"
+									 VerticalAlignment="Center"
+									 HorizontalAlignment="Center"
+									 RenderTransformOrigin="0.5,0.5">
+								<TextBox.RenderTransform>
+									<RotateTransform Angle="10"/>
+								</TextBox.RenderTransform>
+							</TextBox>
+							<Border
+								Width="50"
+								Height="50"
+								BorderBrush="Blue"
+								BorderThickness="1"
+								VerticalAlignment="Center"
+								HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+											  Height="200"
+											  Background="LemonChiffon">
+							<TextBox xamarin:Style="{StaticResource XamlDefaultTextBox}"
+									 Width="50"
+									 Height="50"
+									 Text="WORD"
+									 Foreground="Cornsilk"
+									 Background="Black"
+									 VerticalAlignment="Center"
+									 HorizontalAlignment="Center"
+									 RenderTransformOrigin="0.5,0.5">
+								<TextBox.RenderTransform>
+									<RotateTransform Angle="20"/>
+								</TextBox.RenderTransform>
+							</TextBox>
+							<Border
+								Width="50"
+								Height="50"
+								BorderBrush="Blue"
+								BorderThickness="1"
+								VerticalAlignment="Center"
+								HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+											  Height="200"
+											  Background="MintCream">
+							<TextBox xamarin:Style="{StaticResource XamlDefaultTextBox}"
+									 Width="50"
+									 Height="50"
+									 Text="WORD"
+									 Foreground="Cornsilk"
+									 Background="Black"
+									 VerticalAlignment="Center"
+									 HorizontalAlignment="Center"
+									 RenderTransformOrigin="0.5,0.5">
+								<TextBox.RenderTransform>
+									<RotateTransform Angle="30"/>
+								</TextBox.RenderTransform>
+							</TextBox>
+							<Border
+								Width="50"
+								Height="50"
+								BorderBrush="Blue"
+								BorderThickness="1"
+								VerticalAlignment="Center"
+								HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+											  Height="200"
+											  Background="LemonChiffon">
+							<TextBox xamarin:Style="{StaticResource XamlDefaultTextBox}"
+									 Width="50"
+									 Height="50"
+									 Text="WORD"
+									 Foreground="Cornsilk"
+									 Background="Black"
+									 VerticalAlignment="Center"
+									 HorizontalAlignment="Center"
+									 RenderTransformOrigin="0.5,0.5">
+								<TextBox.RenderTransform>
+									<RotateTransform Angle="40"/>
+								</TextBox.RenderTransform>
+							</TextBox>
+							<Border
+								Width="50"
+								Height="50"
+								BorderBrush="Blue"
+								BorderThickness="1"
+								VerticalAlignment="Center"
+								HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+											  Height="200"
+											  Background="MintCream">
+							<TextBox xamarin:Style="{StaticResource XamlDefaultTextBox}"
+									 Width="50"
+									 Height="50"
+									 Text="WORD"
+									 Foreground="Cornsilk"
+									 Background="Black"
+									 VerticalAlignment="Center"
+									 HorizontalAlignment="Center"
+									 RenderTransformOrigin="0.5,0.5">
+								<TextBox.RenderTransform>
+									<RotateTransform Angle="50"/>
+								</TextBox.RenderTransform>
+							</TextBox>
+							<Border
+								Width="50"
+								Height="50"
+								BorderBrush="Blue"
+								BorderThickness="1"
+								VerticalAlignment="Center"
+								HorizontalAlignment="Center"/>
+						</Grid>
+						<Grid Width="200"
+											  Height="200"
+											  Background="LemonChiffon">
+							<TextBox xamarin:Style="{StaticResource XamlDefaultTextBox}"
+									 Width="50"
+									 Height="50"
+									 Text="WORD"
+									 Foreground="Cornsilk"
+									 Background="Black"
+									 VerticalAlignment="Center"
+									 HorizontalAlignment="Center"
+									 RenderTransformOrigin="0.5,0.5">
+								<TextBox.RenderTransform>
+									<RotateTransform Angle="60"/>
+								</TextBox.RenderTransform>
+							</TextBox>
+							<Border
+								Width="50"
+								Height="50"
+								BorderBrush="Blue"
+								BorderThickness="1"
+								VerticalAlignment="Center"
+								HorizontalAlignment="Center"/>
+						</Grid>
+					</StackPanel>
+				</ScrollViewer>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/TextBox_With_RotateTransform.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/TextBox_With_RotateTransform.xaml.cs
@@ -1,0 +1,14 @@
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform
+{
+	[SampleControlInfo("Transform", "TextBox_With_RotateTransform")]
+	public sealed partial class TextBox_With_RotateTransform : UserControl
+	{
+		public TextBox_With_RotateTransform()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/TransformToVisual_Simple.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/TransformToVisual_Simple.xaml
@@ -1,0 +1,48 @@
+<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform.TransformToVisual_Simple" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<Grid x:Name="EnclosingView"
+				Width="280"
+				Height="400">
+		<Border Margin="0,0,80,0">
+			<ScrollViewer ViewChanged="ScrollViewer_ViewChanged">
+				<Border Height="700">
+					<Border.Background>
+						<LinearGradientBrush StartPoint="0,0"
+																 EndPoint="1,1">
+							<GradientStop Color="Beige"
+														Offset="0" />
+							<GradientStop Color="Blue"
+														Offset="1" />
+						</LinearGradientBrush>
+					</Border.Background>
+					<!--Wrap TextBlock in Border as workaround because it doesn't inherit from UIElement on iOS-->
+					<Border x:Name="TargetView"
+									VerticalAlignment="Center">
+						<TextBlock Text="Target text" />
+					</Border>
+				</Border>
+			</ScrollViewer>
+		</Border>
+		<Canvas>
+			<Ellipse x:Name="TrackerView"
+							 Width="80"
+							 Height="20"
+							 Fill="PaleVioletRed"
+							 Canvas.Left="200"
+							 Canvas.Top="340" />
+		</Canvas>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/TransformToVisual_Simple.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/TransformToVisual_Simple.xaml.cs
@@ -1,0 +1,23 @@
+using Windows.Foundation;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform
+{
+	[SampleControlInfo("Transform", "TransformToVisual_Simple", description: "The ellipse should track the y-position of the text inside the scroll viewer, using TransformToVisual")]
+	public sealed partial class TransformToVisual_Simple : UserControl
+	{
+		public TransformToVisual_Simple()
+		{
+			this.InitializeComponent();
+		}
+
+		private void ScrollViewer_ViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
+		{
+			var transform = TargetView.TransformToVisual(EnclosingView);
+			var targetY = transform.TransformPoint(new Point(0, 0)).Y;
+			var tracker = TrackerView;
+			Windows.UI.Xaml.Controls.Canvas.SetTop(tracker, targetY);
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/TransformToVisual_Translate2d.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/TransformToVisual_Translate2d.xaml
@@ -1,0 +1,63 @@
+<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform.TransformToVisual_Translate2d"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock x:Name="OffsetTextBlock" />
+		<Grid x:Name="EnclosingView"
+					Width="340"
+					Height="340">
+			<Border Margin="0,0,40,40">
+				<ScrollViewer ViewChanged="ScrollViewer_ViewChanged"
+											HorizontalScrollBarVisibility="Auto"
+											HorizontalScrollMode="Enabled">
+					<Border Height="500"
+									Width="500">
+						<Border.Background>
+							<LinearGradientBrush StartPoint="0,0"
+																	 EndPoint="1,1">
+								<GradientStop Color="Beige"
+															Offset="0" />
+								<GradientStop Color="Blue"
+															Offset="1" />
+							</LinearGradientBrush>
+						</Border.Background>
+						<Border x:Name="TargetView"
+										HorizontalAlignment="Center"
+										VerticalAlignment="Center"
+										BorderBrush="Black"
+										BorderThickness="2">
+							<Image Width="40"
+										 Source="https://upload.wikimedia.org/wikipedia/commons/thumb/a/a5/Elder_Duck_1_%28PSF%29.png/269px-Elder_Duck_1_%28PSF%29.png" />
+						</Border>
+					</Border>
+				</ScrollViewer>
+			</Border>
+			<Canvas>
+				<Ellipse x:Name="TrackerViewX"
+								 Width="20"
+								 Height="40"
+								 Fill="PaleVioletRed"
+								 Canvas.Left="230"
+								 Canvas.Top="300" />
+				<Ellipse x:Name="TrackerViewY"
+								 Width="40"
+								 Height="20"
+								 Fill="PaleVioletRed"
+								 Canvas.Left="300"
+								 Canvas.Top="230" />
+			</Canvas>
+		</Grid>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/TransformToVisual_Translate2d.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media/Transform/TransformToVisual_Translate2d.xaml.cs
@@ -1,0 +1,25 @@
+using Windows.Foundation;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Media.Transform
+{
+	[SampleControlInfo("Transform", "TransformToVisual_Translate2d", description: "The ellipses should track the x- and y-positions of the duck inside the scroll viewer, using TransformToVisual")]
+	public sealed partial class TransformToVisual_Translate2d : UserControl
+	{
+		public TransformToVisual_Translate2d()
+		{
+			this.InitializeComponent();
+		}
+
+		private void ScrollViewer_ViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
+		{
+			var transform = TargetView.TransformToVisual(EnclosingView);
+			var target = transform.TransformPoint(new Point(0, 0));
+			Windows.UI.Xaml.Controls.Canvas.SetLeft(TrackerViewX, target.X);
+			Windows.UI.Xaml.Controls.Canvas.SetTop(TrackerViewY, target.Y);
+
+			OffsetTextBlock.Text = target.ToString();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/RotateTransform.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RotateTransform.Android.cs
@@ -36,16 +36,16 @@ namespace Windows.UI.Xaml.Media
 		{
 			base.Update();
 
-			if(View != null)
+			if (View != null)
 			{
-				View.PivotX = (float)(Origin.X * View.Width) + ViewHelper.LogicalToPhysicalPixels(CenterX);
-				View.PivotY = (float)(Origin.Y * View.Height) + ViewHelper.LogicalToPhysicalPixels(CenterY);
-				View.Rotation = (float)Angle;
+				View.PivotX = (float) (Origin.X * View.Width) + ViewHelper.LogicalToPhysicalPixels(CenterX);
+				View.PivotY = (float) (Origin.Y * View.Height) + ViewHelper.LogicalToPhysicalPixels(CenterY);
+				View.Rotation = (float) Angle;
 			}
 		}
 
 		/// <summary>
-		/// Apply Transform whem attached
+		/// Apply Transform when attached
 		/// </summary>
 		protected override void OnAttachedToView()
 		{
@@ -56,23 +56,19 @@ namespace Windows.UI.Xaml.Media
 			SetAngle(this.CreateInitialChangedEventArgs(AngleProperty));
 		}
 
-        internal override Android.Graphics.Matrix ToNativeTransform(Android.Graphics.Matrix targetMatrix = null, Size size = default(Size), bool isBrush = false)
-        {
-            if (targetMatrix == null)
-            {
-                targetMatrix = new Android.Graphics.Matrix();
-            }
+		internal override Android.Graphics.Matrix ToNativeTransform(Android.Graphics.Matrix targetMatrix = null,
+			Size size = default(Size), bool isBrush = false)
+		{
+			if (targetMatrix == null)
+			{
+				targetMatrix = new Android.Graphics.Matrix();
+			}
 
 			var pivot = this.GetPivot(size, isBrush);
 
-            targetMatrix.PostRotate((float)Angle, (float)pivot.X, (float)pivot.Y);
+			targetMatrix.PostRotate((float) Angle, (float) pivot.X, (float) pivot.Y);
 
-            return targetMatrix;
-        }
-
-    }
-
-
+			return targetMatrix;
+		}
+	}
 }
-
-

--- a/src/Uno.UI/UI/Xaml/Media/RotateTransform.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RotateTransform.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using Windows.Foundation;
-using global::System.Numerics;
+using System.Numerics;
 using Uno.Extensions;
 
 namespace Windows.UI.Xaml.Media
@@ -11,11 +11,11 @@ namespace Windows.UI.Xaml.Media
 	/// RotateTransform :  Based on the WinRT Rotate transform
 	/// https://msdn.microsoft.com/en-us/library/system.windows.media.rotatetransform(v=vs.110).aspx
 	/// </summary>
-	public partial class RotateTransform : Transform
+	public sealed partial class RotateTransform : Transform
 	{
 		internal override Point Origin
 		{
-			get { return base.Origin; }
+			get => base.Origin;
 			set
 			{
 				if(Origin != value)
@@ -30,8 +30,8 @@ namespace Windows.UI.Xaml.Media
 
 		public double CenterY
 		{
-			get { return (double)this.GetValue(CenterYProperty); }
-			set { this.SetValue(CenterYProperty, value); }
+			get => (double)GetValue(CenterYProperty);
+			set => SetValue(CenterYProperty, value);
 		}
 
 		// Using a DependencyProperty as the backing store for CenterY.  This enables animation, styling, binding, etc...
@@ -40,9 +40,7 @@ namespace Windows.UI.Xaml.Media
 
 		private static void OnCenterYChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
 		{
-			var self = dependencyObject as RotateTransform;
-
-			if (self != null)
+			if (dependencyObject is RotateTransform self)
 			{
 				self.SetCenterY(args);
 			}
@@ -52,8 +50,8 @@ namespace Windows.UI.Xaml.Media
 
 		public double CenterX
 		{
-			get { return (double)this.GetValue(CenterXProperty); }
-			set { this.SetValue(CenterXProperty, value); }
+			get => (double)GetValue(CenterXProperty);
+			set => SetValue(CenterXProperty, value);
 		}
 
 		// Using a DependencyProperty as the backing store for CenterX.  This enables animation, styling, binding, etc...
@@ -61,9 +59,7 @@ namespace Windows.UI.Xaml.Media
 			DependencyProperty.Register("CenterX", typeof(double), typeof(RotateTransform), new PropertyMetadata(0.0, OnCenterXChanged));
 		private static void OnCenterXChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
 		{
-			var self = dependencyObject as RotateTransform;
-
-			if (self != null)
+			if (dependencyObject is RotateTransform self)
 			{
 				self.SetCenterX(args);
 			}
@@ -73,8 +69,8 @@ namespace Windows.UI.Xaml.Media
 
 		public double Angle
 		{
-			get { return (double)this.GetValue(AngleProperty); }
-			set { this.SetValue(AngleProperty, value); }
+			get => (double)GetValue(AngleProperty);
+			set => SetValue(AngleProperty, value);
 		}
 
 		// Using a DependencyProperty as the backing store for Angle.  This enables animation, styling, binding, etc...
@@ -83,9 +79,7 @@ namespace Windows.UI.Xaml.Media
 
 		private static void OnAngleChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
 		{
-			var self = dependencyObject as RotateTransform;
-
-			if (self != null)
+			if (dependencyObject is RotateTransform self)
 			{
 				self.SetAngle(args);
 			}

--- a/src/Uno.UI/UI/Xaml/Media/RotateTransform.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/RotateTransform.wasm.cs
@@ -41,7 +41,10 @@ namespace Windows.UI.Xaml.Media
 
 		internal override Matrix3x2 ToNativeTransform(Size size)
 		{
-			var centerPoint = new Vector2((float) CenterX, (float) CenterY);
+			var centerPoint = new Vector2(
+				(float)(Origin.X * size.Width + CenterX),
+				(float)(Origin.Y * size.Height + CenterY));
+
 			return Matrix3x2.CreateRotation((float) ToRadians(Angle), centerPoint);
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Media/ScaleTransform.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ScaleTransform.Android.cs
@@ -13,28 +13,31 @@ namespace Windows.UI.Xaml.Media
 	/// </summary>
 	public partial class ScaleTransform
 	{
-
-
 		partial void SetScaleX(DependencyPropertyChangedEventArgs args)
 		{
+			Update();
+		}
+
+		partial void SetScaleY(DependencyPropertyChangedEventArgs args)
+		{
+			Update();
+		}
+
+		protected override void Update()
+		{
+			base.Update();
+
 			if (View != null)
 			{
 				View.PivotX = (float)(Origin.X * View.Width) + ViewHelper.LogicalToPhysicalPixels(CenterX);
 				View.PivotY = (float)(Origin.Y * View.Height) + ViewHelper.LogicalToPhysicalPixels(CenterY);
 				View.ScaleX = (float)ScaleX;
-			}
-		}
-
-		partial void SetScaleY(DependencyPropertyChangedEventArgs args)
-		{
-			if (View != null)
-			{
 				View.ScaleY = (float)ScaleY;
 			}
 		}
 
 		/// <summary>
-		/// Apply Transform whem attached
+		/// Apply Transform when attached
 		/// </summary>
 		protected override void OnAttachedToView()
 		{
@@ -62,8 +65,6 @@ namespace Windows.UI.Xaml.Media
 		}
 
 	}
-
-
 }
 
 

--- a/src/Uno.UI/UI/Xaml/Media/ScaleTransform.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ScaleTransform.cs
@@ -4,100 +4,96 @@ using System.Text;
 
 namespace Windows.UI.Xaml.Media
 {
-    /// <summary>
-    /// ScaleTransform :  Based on the WinRT ScaleTransform
-    /// https://msdn.microsoft.com/en-us/library/system.windows.media.scaletransform%28v=vs.110%29.aspx
-    /// </summary>
-    public partial class ScaleTransform : Transform
-    {
-        public double CenterY
-        {
-            get { return (double)this.GetValue(CenterYProperty); }
-            set { this.SetValue(CenterYProperty, value); }
-        }
+	/// <summary>
+	/// ScaleTransform :  Based on the WinRT ScaleTransform
+	/// https://msdn.microsoft.com/en-us/library/system.windows.media.scaletransform%28v=vs.110%29.aspx
+	/// </summary>
+	public partial class ScaleTransform : Transform
+	{
+		public double CenterY
+		{
+			get => (double) GetValue(CenterYProperty);
+			set => SetValue(CenterYProperty, value);
+		}
 
-        // Using a DependencyProperty as the backing store for CenterY.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty CenterYProperty =
-            DependencyProperty.Register("CenterY", typeof(double), typeof(ScaleTransform), new PropertyMetadata(0.0, OnCenterYChanged));
-        private static void OnCenterYChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
-        {
-            var self = dependencyObject as ScaleTransform;
+		// Using a DependencyProperty as the backing store for CenterY.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty CenterYProperty =
+			DependencyProperty.Register("CenterY", typeof(double), typeof(ScaleTransform),
+				new PropertyMetadata(0.0, OnCenterYChanged));
 
-            if (self != null)
-            {
-                self.SetCenterY(args);
-            }
-        }
+		private static void OnCenterYChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+			if (dependencyObject is ScaleTransform self)
+			{
+				self.SetCenterY(args);
+			}
+		}
 
-        partial void SetCenterY(DependencyPropertyChangedEventArgs args);
+		partial void SetCenterY(DependencyPropertyChangedEventArgs args);
 
-        public double CenterX
-        {
-            get { return (double)this.GetValue(CenterXProperty); }
-            set { this.SetValue(CenterXProperty, value); }
-        }
+		public double CenterX
+		{
+			get => (double) GetValue(CenterXProperty);
+			set => SetValue(CenterXProperty, value);
+		}
 
-        // Using a DependencyProperty as the backing store for CenterX.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty CenterXProperty =
-            DependencyProperty.Register("CenterX", typeof(double), typeof(ScaleTransform), new PropertyMetadata(0.0, OnCenterXChanged));
-        private static void OnCenterXChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
-        {
-            var self = dependencyObject as ScaleTransform;
+		// Using a DependencyProperty as the backing store for CenterX.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty CenterXProperty =
+			DependencyProperty.Register("CenterX", typeof(double), typeof(ScaleTransform),
+				new PropertyMetadata(0.0, OnCenterXChanged));
 
-            if (self != null)
-            {
-                self.SetCenterX(args);
-            }
-        }
+		private static void OnCenterXChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+			if (dependencyObject is ScaleTransform self)
+			{
+				self.SetCenterX(args);
+			}
+		}
 
-        partial void SetCenterX(DependencyPropertyChangedEventArgs args);
-
-
-        public double ScaleX
-        {
-            get { return (double)this.GetValue(ScaleXProperty); }
-            set { this.SetValue(ScaleXProperty, value); }
-        }
-
-        // Using a DependencyProperty as the backing store for ScaleX.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty ScaleXProperty =
-            DependencyProperty.Register("ScaleX", typeof(double), typeof(ScaleTransform), new PropertyMetadata(1.0, OnScaleXChanged));
-        private static void OnScaleXChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
-        {
-            var self = dependencyObject as ScaleTransform;
-
-            if (self != null)
-            {
-                self.SetScaleX(args);
-            }
-        }
-        partial void SetScaleX(DependencyPropertyChangedEventArgs args);
-
-        public double ScaleY
-        {
-            get { return (double)this.GetValue(ScaleYProperty); }
-            set { this.SetValue(ScaleYProperty, value); }
-        }
-
-        // Using a DependencyProperty as the backing store for ScaleY.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty ScaleYProperty =
-            DependencyProperty.Register("ScaleY", typeof(double), typeof(ScaleTransform), new PropertyMetadata(1.0, OnScaleYChanged));
-        private static void OnScaleYChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
-        {
-            var self = dependencyObject as ScaleTransform;
-
-            if (self != null)
-            {
-                self.SetScaleY(args);
-            }
-        }
-
-        partial void SetScaleY(DependencyPropertyChangedEventArgs args);
+		partial void SetCenterX(DependencyPropertyChangedEventArgs args);
 
 
+		public double ScaleX
+		{
+			get => (double) GetValue(ScaleXProperty);
+			set => SetValue(ScaleXProperty, value);
+		}
 
-    }
+		// Using a DependencyProperty as the backing store for ScaleX.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty ScaleXProperty =
+			DependencyProperty.Register("ScaleX", typeof(double), typeof(ScaleTransform),
+				new PropertyMetadata(1.0, OnScaleXChanged));
 
+		private static void OnScaleXChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+			if (dependencyObject is ScaleTransform self)
+			{
+				self.SetScaleX(args);
+			}
+		}
 
+		partial void SetScaleX(DependencyPropertyChangedEventArgs args);
+
+		public double ScaleY
+		{
+			get => (double) GetValue(ScaleYProperty);
+			set => SetValue(ScaleYProperty, value);
+		}
+
+		// Using a DependencyProperty as the backing store for ScaleY.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty ScaleYProperty =
+			DependencyProperty.Register("ScaleY", typeof(double), typeof(ScaleTransform),
+				new PropertyMetadata(1.0, OnScaleYChanged));
+
+		private static void OnScaleYChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
+		{
+			if (dependencyObject is ScaleTransform self)
+			{
+				self.SetScaleY(args);
+			}
+		}
+
+		partial void SetScaleY(DependencyPropertyChangedEventArgs args);
+	}
 }
 

--- a/src/Uno.UI/UI/Xaml/Media/ScaleTransform.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ScaleTransform.wasm.cs
@@ -51,7 +51,9 @@ namespace Windows.UI.Xaml.Media
 		internal override Matrix3x2 ToNativeTransform(Size size)
 		{
 			var scales = new Vector2((float)ScaleX, (float)ScaleY);
-			var centerPoint = new Vector2((float)CenterX, (float)CenterY);
+			var centerPoint = new Vector2(
+				(float)(Origin.X * size.Width + CenterX),
+				(float)(Origin.Y * size.Height + CenterY));
 			return Matrix3x2.CreateScale(scales, centerPoint);
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Media/SkewTransform.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/SkewTransform.Android.cs
@@ -14,24 +14,29 @@ namespace Windows.UI.Xaml.Media
 	{
 		partial void SetAngleX(DependencyPropertyChangedEventArgs args)
 		{
-			if (View != null)
-            {
-                View.PivotX = (float)(Origin.X * View.Width) + ViewHelper.LogicalToPhysicalPixels(CenterX);
-                View.PivotY = (float)(Origin.Y * View.Height) + ViewHelper.LogicalToPhysicalPixels(CenterY);
-                View.RotationX = (float)AngleX;
-			}
+			Update();
 		}
 
 		partial void SetAngleY(DependencyPropertyChangedEventArgs args)
 		{
+			Update();
+		}
+
+		protected override void Update()
+		{
+			base.Update();
+
 			if (View != null)
 			{
+				View.PivotX = (float)(Origin.X * View.Width) + ViewHelper.LogicalToPhysicalPixels(CenterX);
+				View.PivotY = (float)(Origin.Y * View.Height) + ViewHelper.LogicalToPhysicalPixels(CenterY);
 				View.RotationY = (float)AngleY;
+				View.RotationX = (float)AngleX;
 			}
 		}
 
 		/// <summary>
-		/// Apply Transform whem attached
+		/// Apply Transform when attached
 		/// </summary>
 		protected override void OnAttachedToView()
 		{
@@ -44,20 +49,20 @@ namespace Windows.UI.Xaml.Media
 			SetAngleY(this.CreateInitialChangedEventArgs(AngleYProperty));
 		}
 
-        internal override Android.Graphics.Matrix ToNativeTransform(Android.Graphics.Matrix targetMatrix = null, Size size = default(Size), bool isBrush = false)
-        {
-            if (targetMatrix == null)
-            {
-                targetMatrix = new Android.Graphics.Matrix();
-            }
+		internal override Android.Graphics.Matrix ToNativeTransform(Android.Graphics.Matrix targetMatrix = null, Size size = default(Size), bool isBrush = false)
+		{
+			if (targetMatrix == null)
+			{
+				targetMatrix = new Android.Graphics.Matrix();
+			}
 
 			var pivot = this.GetPivot(size, isBrush);
 
-            targetMatrix.PostSkew((float)AngleX, (float)AngleY, (float)pivot.X, (float)pivot.Y);
+			targetMatrix.PostSkew((float)AngleX, (float)AngleY, (float)pivot.X, (float)pivot.Y);
 
-            return targetMatrix;
-        }
-    }
+			return targetMatrix;
+		}
+	}
 }
 
 

--- a/src/Uno.UI/UI/Xaml/Media/SkewTransform.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/SkewTransform.wasm.cs
@@ -54,7 +54,9 @@ namespace Windows.UI.Xaml.Media
 
 		internal override Matrix3x2 ToNativeTransform(Size size)
 		{
-			var centerPoint = new Vector2((float) CenterX, (float) CenterY);
+			var centerPoint = new Vector2(
+				(float)(Origin.X * size.Width + CenterX),
+				(float)(Origin.Y * size.Height + CenterY));
 			return Matrix3x2.CreateSkew((float)MathEx.ToRadians(AngleX), (float)MathEx.ToRadians(AngleY), centerPoint);
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Media/Transform.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Transform.cs
@@ -44,10 +44,7 @@ namespace Windows.UI.Xaml.Media
 		/// </summary>
 		internal View View
 		{
-			get
-			{
-				return _view;
-			}
+			get => _view;
 			set
 			{
 				var view = _view;
@@ -74,7 +71,7 @@ namespace Windows.UI.Xaml.Media
 		partial void OnDetachedFromViewPartial(View view);
 
 		/// <summary>
-		/// The <see cref="FrameworkElement.RenderTransformOrigin"/> of the targetted view.
+		/// The <see cref="FrameworkElement.RenderTransformOrigin"/> of the targeted view.
 		/// </summary>
 		internal virtual Foundation.Point Origin { get; set; }
 	}


### PR DESCRIPTION
## Bugfix
RotateTransform in Wasm were not considering the `TransformOrigin`.

## What is the current behavior?
Using a `RotateTransform` in Wasm were not 100% accurate with other platforms,
except when the `TransformOrigin` was at `[0, 0]` (default is `[0.5, 0.5]`).

## What is the new behavior?
`TransformOrigin` is correctly calculated now.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

## Internal Issue
* <https://nventive.visualstudio.com/Umbrella/_workitems/edit/143598> Wasm Animation rotation center is incorrect