### PR TITLE
Fix iOS support, improve CoreDispatcher performance

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -50,6 +50,7 @@
 * Add support for `DynamicObject` data binding, to enable support for `Elmish.Uno`.
 * Add support for VS2019 VSIX installation
 * Improved Xaml generation speed, and incremental build performance
+* [Wasm] Fix `CoreDispatcher` `StackOverflowException` when running on low stack space environments (e.g. iOS)
 
 ### Breaking changes
 * Refactored ToggleSwitch Default Native XAML Styles. (cf. 'NativeDefaultToggleSwitch' styles in Generic.Native.xaml)
@@ -89,6 +90,7 @@
  * 143527 [Android] Fixed broken TimePicker Flyout on android devices.
  * 143598 [Wasm] Wasm Animation rotation center is incorrect
  * Fixes invalid parsing of custom types containing `{}` in their value (#455)
+ * Add workaround for iOS stackoverflow during initialization.
 
 ## Release 1.42
 

--- a/src/Uno.UI.Wasm/Uno.UI.Wasm.csproj
+++ b/src/Uno.UI.Wasm/Uno.UI.Wasm.csproj
@@ -27,13 +27,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <UpToDateCheckInput Remove="ts\AppManifest.ts" />
-	  <UpToDateCheckInput Remove="ts\Interop\IAppManifest.ts" />
-	  <UpToDateCheckInput Remove="ts\Interop\IUnoDispatch.ts" />
-	  <UpToDateCheckInput Remove="ts\MonoSupport.ts" />
-	</ItemGroup>
-
-	<ItemGroup>
     <PackageReference Include="Uno.Core">
       <Version>1.26.0-dev.58</Version>
       <ExcludeAssets>Runtime</ExcludeAssets>

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -3,6 +3,23 @@ declare namespace Uno.Utils {
         static setText(text: string): string;
     }
 }
+declare namespace Windows.UI.Core {
+    /**
+     * Support file for the Windows.UI.Core
+     * */
+    class CoreDispatcher {
+        static _coreDispatcherCallback: any;
+        static _isIOS: boolean;
+        static _isFirstCall: boolean;
+        static init(): void;
+        /**
+         * Enqueues a core dispatcher callback on the javascript's event loop
+         *
+         * */
+        static WakeUp(): boolean;
+        private static initMethods();
+    }
+}
 declare namespace Uno.UI {
     class HtmlDom {
         /**
@@ -51,7 +68,9 @@ declare namespace MonoSupport {
      * unmarshaled invocation of javascript from .NET code.
      * */
     class jsCallDispatcher {
-        static registrations: Map<string, object>;
+        static registrations: Map<string, any>;
+        static methodMap: Map<string, any>;
+        static _isUnoRegistered: boolean;
         /**
          * Registers a instance for a specified identier
          * @param identifier the scope name
@@ -59,6 +78,17 @@ declare namespace MonoSupport {
          */
         static registerScope(identifier: string, instance: any): void;
         static findJSFunction(identifier: string): any;
+        /**
+         * Parses the method identifier
+         * @param identifier
+         */
+        private static parseIdentifier(identifier);
+        /**
+         * Adds the a resolved method for a given identifier
+         * @param identifier the findJSFunction identifier
+         * @param boundMethod the method to call
+         */
+        private static cacheMethod(identifier, boundMethod);
     }
 }
 declare namespace Uno.UI {
@@ -75,16 +105,22 @@ declare namespace Uno.UI {
         static readonly isHosted: boolean;
         private static readonly unoRootClassName;
         private static readonly unoUnarrangedClassName;
+        private static _cctor;
         /**
             * Initialize the WindowManager
             * @param containerElementId The ID of the container element for the Xaml UI
             * @param loadingElementId The ID of the loading element to remove once ready
             */
         static init(localStoragePath: string, isHosted: boolean, containerElementId?: string, loadingElementId?: string): string;
+        /**
+            * Initialize the WindowManager
+            * @param containerElementId The ID of the container element for the Xaml UI
+            * @param loadingElementId The ID of the loading element to remove once ready
+            */
+        static initNative(pParams: number): boolean;
         private containerElement;
         private rootContent;
         private allActiveElementsById;
-        static assembly: UI.Interop.IMonoAssemblyHandle;
         private static resizeMethod;
         private static dispatchEventMethod;
         private constructor();
@@ -368,8 +404,6 @@ declare namespace Uno.UI {
         private removeLoading();
         private resize();
         private dispatchEvent(element, eventName, eventPayload?);
-        private getMonoString(str);
-        private fromMonoString(strHandle);
         private getIsConnectedToRootElement(element);
     }
 }
@@ -405,6 +439,11 @@ declare class WindowManagerGetBBoxReturn {
     Width: number;
     Height: number;
     marshal(pData: number): void;
+}
+declare class WindowManagerInitParams {
+    LocalFolderPath: string;
+    IsHostedMode: boolean;
+    static unmarshal(pData: number): WindowManagerInitParams;
 }
 declare class WindowManagerMeasureViewParams {
     HtmlId: number;

--- a/src/Uno.UI.Wasm/WasmScripts/setImmediate.js
+++ b/src/Uno.UI.Wasm/WasmScripts/setImmediate.js
@@ -1,0 +1,192 @@
+﻿/**
+ * Polyfill for setImmediate
+ *
+ * https://github.com/YuzuJS/setImmediate/commit/f1ccbfdf09cb93aadf77c4aa749ea554503b9234
+ */
+
+(function (global, undefined) {
+    "use strict";
+
+    if (global.setImmediate) {
+        return;
+    }
+
+    var nextHandle = 1; // Spec says greater than zero
+    var tasksByHandle = {};
+    var currentlyRunningATask = false;
+    var doc = global.document;
+    var registerImmediate;
+
+    function setImmediate(callback) {
+        // Callback can either be a function or a string
+        if (typeof callback !== "function") {
+            callback = new Function("" + callback);
+        }
+        // Copy function arguments
+        var args = new Array(arguments.length - 1);
+        for (var i = 0; i < args.length; i++) {
+            args[i] = arguments[i + 1];
+        }
+        // Store and register the task
+        var task = { callback: callback, args: args };
+        tasksByHandle[nextHandle] = task;
+        registerImmediate(nextHandle);
+        return nextHandle++;
+    }
+
+    function clearImmediate(handle) {
+        delete tasksByHandle[handle];
+    }
+
+    function run(task) {
+        var callback = task.callback;
+        var args = task.args;
+        switch (args.length) {
+            case 0:
+                callback();
+                break;
+            case 1:
+                callback(args[0]);
+                break;
+            case 2:
+                callback(args[0], args[1]);
+                break;
+            case 3:
+                callback(args[0], args[1], args[2]);
+                break;
+            default:
+                callback.apply(undefined, args);
+                break;
+        }
+    }
+
+    function runIfPresent(handle) {
+        // From the spec: "Wait until any invocations of this algorithm started before this one have completed."
+        // So if we're currently running a task, we'll need to delay this invocation.
+        if (currentlyRunningATask) {
+            // Delay by doing a setTimeout. setImmediate was tried instead, but in Firefox 7 it generated a
+            // "too much recursion" error.
+            setTimeout(runIfPresent, 0, handle);
+        } else {
+            var task = tasksByHandle[handle];
+            if (task) {
+                currentlyRunningATask = true;
+                try {
+                    run(task);
+                } finally {
+                    clearImmediate(handle);
+                    currentlyRunningATask = false;
+                }
+            }
+        }
+    }
+
+    function installNextTickImplementation() {
+        registerImmediate = function (handle) {
+            process.nextTick(function () { runIfPresent(handle); });
+        };
+    }
+
+    function canUsePostMessage() {
+        // The test against `importScripts` prevents this implementation from being installed inside a web worker,
+        // where `global.postMessage` means something completely different and can't be used for this purpose.
+        if (global.postMessage && !global.importScripts) {
+            var postMessageIsAsynchronous = true;
+            var oldOnMessage = global.onmessage;
+            global.onmessage = function () {
+                postMessageIsAsynchronous = false;
+            };
+            global.postMessage("", "*");
+            global.onmessage = oldOnMessage;
+            return postMessageIsAsynchronous;
+        }
+    }
+
+    function installPostMessageImplementation() {
+        // Installs an event handler on `global` for the `message` event: see
+        // * https://developer.mozilla.org/en/DOM/window.postMessage
+        // * http://www.whatwg.org/specs/web-apps/current-work/multipage/comms.html#crossDocumentMessages
+
+        var messagePrefix = "setImmediate$" + Math.random() + "$";
+        var onGlobalMessage = function (event) {
+            if (event.source === global &&
+                typeof event.data === "string" &&
+                event.data.indexOf(messagePrefix) === 0) {
+                runIfPresent(+event.data.slice(messagePrefix.length));
+            }
+        };
+
+        if (global.addEventListener) {
+            global.addEventListener("message", onGlobalMessage, false);
+        } else {
+            global.attachEvent("onmessage", onGlobalMessage);
+        }
+
+        registerImmediate = function (handle) {
+            global.postMessage(messagePrefix + handle, "*");
+        };
+    }
+
+    function installMessageChannelImplementation() {
+        var channel = new MessageChannel();
+        channel.port1.onmessage = function (event) {
+            var handle = event.data;
+            runIfPresent(handle);
+        };
+
+        registerImmediate = function (handle) {
+            channel.port2.postMessage(handle);
+        };
+    }
+
+    function installReadyStateChangeImplementation() {
+        var html = doc.documentElement;
+        registerImmediate = function (handle) {
+            // Create a <script> element; its readystatechange event will be fired asynchronously once it is inserted
+            // into the document. Do so, thus queuing up the task. Remember to clean up once it's been called.
+            var script = doc.createElement("script");
+            script.onreadystatechange = function () {
+                runIfPresent(handle);
+                script.onreadystatechange = null;
+                html.removeChild(script);
+                script = null;
+            };
+            html.appendChild(script);
+        };
+    }
+
+    function installSetTimeoutImplementation() {
+        registerImmediate = function (handle) {
+            setTimeout(runIfPresent, 0, handle);
+        };
+    }
+
+    // If supported, we should attach to the prototype of global, since that is where setTimeout et al. live.
+    var attachTo = Object.getPrototypeOf && Object.getPrototypeOf(global);
+    attachTo = attachTo && attachTo.setTimeout ? attachTo : global;
+
+    // Don't get fooled by e.g. browserify environments.
+    if ({}.toString.call(global.process) === "[object process]") {
+        // For Node.js before 0.9
+        installNextTickImplementation();
+
+    } else if (canUsePostMessage()) {
+        // For non-IE10 modern browsers
+        installPostMessageImplementation();
+
+    } else if (global.MessageChannel) {
+        // For web workers, where supported
+        installMessageChannelImplementation();
+
+    } else if (doc && "onreadystatechange" in doc.createElement("script")) {
+        // For IE 6–8
+        installReadyStateChangeImplementation();
+
+    } else {
+        // For older browsers
+        installSetTimeoutImplementation();
+    }
+
+    attachTo.setImmediate = setImmediate;
+    attachTo.clearImmediate = clearImmediate;
+}(typeof self === "undefined" ? typeof global === "undefined" ? this : global : self));

--- a/src/Uno.UI.Wasm/ts/CoreDispatcher.ts
+++ b/src/Uno.UI.Wasm/ts/CoreDispatcher.ts
@@ -1,0 +1,53 @@
+﻿namespace Windows.UI.Core {
+
+	/**
+	 * Support file for the Windows.UI.Core 
+	 * */
+	export class CoreDispatcher {
+		static _coreDispatcherCallback: any;
+		static _isIOS: boolean;
+		static _isFirstCall: boolean = true;
+
+		public static init() {
+			MonoSupport.jsCallDispatcher.registerScope("CoreDispatcher", Windows.UI.Core.CoreDispatcher);
+			CoreDispatcher.initMethods();
+
+			CoreDispatcher._isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !(<any>window).MSStream;
+		}
+
+		/**
+		 * Enqueues a core dispatcher callback on the javascript's event loop
+		 *
+		 * */
+		public static WakeUp(): boolean {
+
+			if (CoreDispatcher._isIOS && CoreDispatcher._isFirstCall) {
+				//
+				// This is a workaround for the available call stack during the first 5 (?) seconds
+				// of the startup of an application. See https://github.com/mono/mono/issues/12357 for
+				// more details.
+				//
+				CoreDispatcher._isFirstCall = false;
+				console.debug("Detected iOS, delaying first CoreDispatched dispatch for 5s (see https://github.com/mono/mono/issues/12357)");
+				window.setTimeout(() => this.WakeUp(), 5000);
+			} else {
+				(<any>window).setImmediate(() => CoreDispatcher._coreDispatcherCallback());
+			}
+
+
+			return true;
+		}
+
+
+		private static initMethods() {
+			if (Uno.UI.WindowManager.isHosted) {
+				console.debug("Hosted Mode: Skipping CoreDispatcher initialization ");
+			}
+			else {
+				if (!CoreDispatcher._coreDispatcherCallback) {
+					CoreDispatcher._coreDispatcherCallback = (<any>Module).mono_bind_static_method("[Uno] Windows.UI.Core.CoreDispatcher:DispatcherCallback");
+				}
+			}
+		}
+	}
+}

--- a/src/Uno.UI.Wasm/tsBindings/WindowManagerInitParams.ts
+++ b/src/Uno.UI.Wasm/tsBindings/WindowManagerInitParams.ts
@@ -1,0 +1,29 @@
+/* TSBindingsGenerator Generated code -- this code is regenerated on each build */
+class WindowManagerInitParams
+{
+	/* Pack=4 */
+	LocalFolderPath : string;
+	IsHostedMode : boolean;
+	public static unmarshal(pData:number) : WindowManagerInitParams
+	{
+		let ret = new WindowManagerInitParams();
+		
+		{
+			var ptr = Module.getValue(pData + 0, "*");
+			if(ptr !== 0)
+			{
+				ret.LocalFolderPath = String(Module.UTF8ToString(ptr));
+			}
+			else
+			
+			{
+				ret.LocalFolderPath = null;
+			}
+		}
+		
+		{
+			ret.IsHostedMode = Boolean(Module.getValue(pData + 4, "i32"));
+		}
+		return ret;
+	}
+}

--- a/src/Uno.UI.WpfHost/UnoHostView.cs
+++ b/src/Uno.UI.WpfHost/UnoHostView.cs
@@ -214,14 +214,16 @@ namespace Uno.UI.WpfHost
 		{
 		}
 
-		public void Resize(string size)
+		public void Resize(string newSize)
 		{
 			var d = Windows.UI.Core.CoreDispatcher.Main.RunAsync(
 				Windows.UI.Core.CoreDispatcherPriority.Normal,
 				() =>
 				{
+					var sizeParts = newSize.Split(';');
+
 					// Console.WriteLine($"Resize {size}");
-					Windows.UI.Xaml.Window.Resize(size);
+					Windows.UI.Xaml.Window.Resize(double.Parse(sizeParts[0]), double.Parse(sizeParts[1]));
 				});
 		}
 
@@ -231,9 +233,18 @@ namespace Uno.UI.WpfHost
 				Windows.UI.Core.CoreDispatcherPriority.Normal,
 				() =>
 				{
-					// Console.WriteLine($"Dispatch {htmlIdStr} {eventNameStr} {eventPayloadStr}");
-					Windows.UI.Xaml.UIElement.DispatchEvent(htmlIdStr, eventNameStr, eventPayloadStr);
+                    // parse htmlId to IntPtr
+                    if (int.TryParse(htmlIdStr, out var handle))
+                    {
+                        // Console.WriteLine($"Dispatch {htmlIdStr} {eventNameStr} {eventPayloadStr}");
+                        Windows.UI.Xaml.UIElement.DispatchEvent(handle, eventNameStr, eventPayloadStr);
+                    }
+                    else
+                    {
+                        Console.WriteLine("Failed to parse htmlIdStr");
+                    }
 				});
 		}
+
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Application.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Application.wasm.cs
@@ -11,18 +11,31 @@ using Uno.Foundation;
 using Uno.Extensions;
 using Uno.Logging;
 using System.Threading;
+using Uno.UI.Xaml;
 
 namespace Windows.UI.Xaml
 {
 	public partial class Application
 	{
+		private static bool _startInvoked = false;
+
 		public Application()
 		{
+			if (!_startInvoked)
+			{
+				throw new InvalidOperationException("The application must be started using Application.Start first, e.g. Windows.UI.Xaml.Application.Start(_ => new App());");
+			}
+
 			CoreDispatcher.Main.RunAsync(CoreDispatcherPriority.Normal, Initialize);
 		}
 
 		static partial void StartPartial(ApplicationInitializationCallback callback)
 		{
+			_startInvoked = true;
+
+			bool isHostedMode = !WebAssemblyRuntime.IsWebAssembly;
+			WindowManagerInterop.Init(Windows.Storage.ApplicationData.Current.LocalFolder.Path, isHostedMode);
+
 			SynchronizationContext.SetSynchronizationContext(
 				new CoreDispatcherSynchronizationContext(CoreDispatcher.Main, CoreDispatcherPriority.Normal)
 			);

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -532,29 +532,21 @@ namespace Windows.UI.Xaml
 			return false;
 		}
 
-		private static readonly Func<string, IntPtr> _strToIntPtr =
-			Marshal.SizeOf<IntPtr>() == 4
-				? (s => (IntPtr)int.Parse(s))
-				: (Func<string, IntPtr>)(s => (IntPtr)long.Parse(s));
-
 		[Preserve]
-		public static string DispatchEvent(string htmlId, string eventName, string eventArgs)
+		public static bool DispatchEvent(int handle, string eventName, string eventArgs)
 		{
-			// parse htmlId to IntPtr
-			var handle = _strToIntPtr(htmlId);
-
-			// Dispatch to right object... if we can find it
-			var gcHandle = GCHandle.FromIntPtr(handle);
+			// Dispatch to right object, if we can find it
+			var gcHandle = GCHandle.FromIntPtr((IntPtr)handle);
 			if (gcHandle.IsAllocated && gcHandle.Target is UIElement element)
 			{
-				return element.InternalDispatchEvent(eventName, nativeEventPayload: eventArgs).ToString();
+				return element.InternalDispatchEvent(eventName, nativeEventPayload: eventArgs);
 			}
 			else
 			{
-				Console.Error.WriteLine($"No UIElement found for htmlId \"{htmlId}\" {gcHandle.IsAllocated}.");
+				Console.Error.WriteLine($"No UIElement found for htmlId \"{handle}\" {gcHandle.IsAllocated}.");
 			}
 
-			return false.ToString();
+			return false;
 		}
 
 		private Rect _arranged;

--- a/src/Uno.UI/UI/Xaml/Window.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Window.wasm.cs
@@ -38,10 +38,6 @@ namespace Windows.UI.Xaml
 		public void Init()
 		{
 			Dispatcher = CoreDispatcher.Main;
-
-			bool isHostedMode = !WebAssemblyRuntime.IsWebAssembly;
-
-			WebAssemblyRuntime.InvokeJS($"Uno.UI.WindowManager.init(\"{Windows.Storage.ApplicationData.Current.LocalFolder.Path}\", {isHostedMode.ToString().ToLowerInvariant()});");
 			CoreWindow = new CoreWindow();
 		}
 
@@ -90,7 +86,7 @@ namespace Windows.UI.Xaml
 		}
 
 		[Preserve]
-		public static void Resize(string newSize)
+		public static void Resize(double width, double height)
 		{
 			var window = Current?._window;
 			if (window == null)
@@ -99,10 +95,7 @@ namespace Windows.UI.Xaml
 				return; // nothing to measure
 			}
 
-			var sizeParts = newSize.Split(';');
-			var size = new Size(double.Parse(sizeParts[0]), double.Parse(sizeParts[1]));
-
-			Current.OnNativeSizeChanged(size);
+			Current.OnNativeSizeChanged(new Size(width, height));
 		}
 
 		private void OnNativeSizeChanged(Size size)

--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.Wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.Wasm.cs
@@ -21,6 +21,37 @@ namespace Uno.UI.Xaml
 		private static bool UseJavascriptEval =>
 			!WebAssemblyRuntime.IsWebAssembly || FeatureConfiguration.Interop.ForceJavascriptInterop;
 
+		#region Init
+		internal static void Init(string localFolderPath, bool isHostedMode)
+		{
+			if (UseJavascriptEval)
+			{
+				WebAssemblyRuntime.InvokeJS($"Uno.UI.WindowManager.init(\"{localFolderPath}\", {isHostedMode.ToString().ToLowerInvariant()});");
+			}
+			else
+			{
+				var parms = new WindowManagerInitParams
+				{
+					LocalFolderPath = localFolderPath,
+					IsHostedMode = isHostedMode,
+				};
+
+				TSInteropMarshaller.InvokeJS<WindowManagerInitParams, bool>("UnoStatic:initNative", parms);
+			}
+		}
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct WindowManagerInitParams
+		{
+			[MarshalAs(TSInteropMarshaller.LPUTF8Str)]
+			public string LocalFolderPath;
+
+			public bool IsHostedMode;
+		}
+
+		#endregion
+
 		#region CreateContent
 		internal static void CreateContent(IntPtr htmlId, string htmlTag, IntPtr handle, string fullName, bool htmlTagIsSvg, bool isFrameworkElement, bool isFocusable, string[] classes)
 		{

--- a/src/Uno.UWP/UI/Core/CoreDispatcher.wasm.cs
+++ b/src/Uno.UWP/UI/Core/CoreDispatcher.wasm.cs
@@ -4,12 +4,18 @@ using System.ComponentModel;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Uno.Foundation;
+using Uno.Foundation.Interop;
 
 namespace Windows.UI.Core
 {
-    public sealed partial class CoreDispatcher
-    {
-		private Timer _timer;
+	public sealed partial class CoreDispatcher
+	{
+		/// <summary>
+		/// Method invoked from 
+		/// </summary>
+		private static void DispatcherCallback()
+			=> Main.DispatchItems();
 
 		/// <summary>
 		/// Provide a action that will delegate the dispach of CoreDispatcher work
@@ -19,10 +25,6 @@ namespace Windows.UI.Core
 
 		partial void Initialize()
 		{
-			if (DispatchOverride == null)
-			{
-				_timer = new Timer(_ => DispatchItems());
-			}
 		}
 
 		// Always reschedule, otherwise we may end up in live-lock.
@@ -36,7 +38,7 @@ namespace Windows.UI.Core
 		{
 			if (DispatchOverride == null)
 			{
-				_timer.Change(0, -1);
+				WebAssemblyRuntime.InvokeJSUnmarshalled("CoreDispatcher:WakeUp", IntPtr.Zero);
 			}
 			else
 			{


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
iOS Applications do not start, caused by a stackoverflow.

## What is the new behavior?
iOS applications start, with a 5 second arbitrary delay, see https://github.com/mono/mono/issues/12357 for more details.

The CoreDispatcher implementation is now relying on a specialized typescript class that uses `setImmediate` polyfill, to avoid spending time in the `System.Threading.Timer` scheduler. This will make the UI Thread scheduling faster.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

https://nventive.visualstudio.com/DefaultCollection/Umbrella/_workitems/edit/144038
