### PR TITLE
Handle the load events from managed code to reduce interop

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -52,6 +52,7 @@
 * Improved Xaml generation speed, and incremental build performance
 * [Wasm] Fix `CoreDispatcher` `StackOverflowException` when running on low stack space environments (e.g. iOS)
 * Add support for `ResourceLoader.GetForViewIndependentUse(string)` and named resource files
+* [Wasm] Load events are now raised directly from managed code. You can restore the previous behavior (raised from native) by setting `FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded = false`.
 
 ### Breaking changes
 * Refactored ToggleSwitch Default Native XAML Styles. (cf. 'NativeDefaultToggleSwitch' styles in Generic.Native.xaml)

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -13,6 +13,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\LoadEvents.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\AutoBorderStretchwithbottommargin.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -554,6 +558,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ViewModelBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_ApplicationModel_Resources_ResourceLoader\ResourceLoader_Simple.xaml.cs">
       <DependentUpon>ResourceLoader_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\LoadEvents.xaml.cs">
+      <DependentUpon>LoadEvents.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\AutoBorderStretchwithbottommargin.xaml.cs">
       <DependentUpon>AutoBorderStretchwithbottommargin.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/LoadEvents.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/LoadEvents.xaml
@@ -1,0 +1,37 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml.FrameworkElementTests.LoadEvents"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml.FrameworkElementTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:controls="using:Uno.UI.Samples.Controls"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Tests the Loaded/Unloaded events">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel>
+					<TextBlock
+						Text="This sample tests that Loaded and Unloaded events are raised properly. You should see ** 2 ** lines prefixed by [OK]."
+						Margin="0,0,0,5" />
+
+					<TextBlock Text="Loaded:" FontWeight="Black" />
+					<TextBlock
+						Text="[ERROR] loaded not received"
+						Loaded="OnLoadTextLoaded"
+						Margin="0,5" />
+
+					<TextBlock Text="Unloaded:" FontWeight="Black" />
+					<TextBlock
+						Text="[ERROR] loaded not received"
+						Loaded="OnUnloadTextLoaded"
+						Unloaded="OnUnloadTextUnloaded"
+						Margin="0,5" />
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/LoadEvents.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/LoadEvents.xaml.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Linq;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml.FrameworkElementTests
+{
+	[SampleControlInfo("FrameworkElement", "LoadEvents")]
+	public sealed partial class LoadEvents : UserControl
+	{
+		public LoadEvents()
+		{
+			this.InitializeComponent();
+		}
+
+		private void OnLoadTextLoaded(object sender, RoutedEventArgs e)
+		{
+			if (sender is TextBlock block)
+			{
+				block.Text = "[OK] Loaded event received";
+			}
+		}
+
+		private Panel _unloadTextParent;
+
+		private async void OnUnloadTextLoaded(object sender, RoutedEventArgs e)
+		{
+			if (_unloadTextParent != null)
+			{
+				return;
+			}
+
+			var block = (TextBlock) sender;
+			block.Text = "[PENDING] Loaded event received, try to unload it...";
+			block.Loaded -= OnUnloadTextLoaded;
+
+			_unloadTextParent = (Panel) block.Parent;
+
+			await block.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => _unloadTextParent.Children.Remove(block));
+		}
+
+		private async void OnUnloadTextUnloaded(object sender, RoutedEventArgs e)
+		{
+			var block = (TextBlock)sender;
+			block.Text = "[OK] Unloaded event received";
+			block.Unloaded -= OnUnloadTextUnloaded;
+
+			await block.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () => _unloadTextParent.Children.Add(block));
+		}
+	}
+}

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -97,12 +97,18 @@ declare namespace Uno.UI {
         private loadingElementId;
         static current: WindowManager;
         private static _isHosted;
+        private static _isLoadEventsEnabled;
         /**
          * Defines if the WindowManager is running in hosted mode, and should skip the
-         * initialization of WebAssembly, use this mode in conjuction with the Uno.UI.WpfHost
+         * initialization of WebAssembly, use this mode in conjunction with the Uno.UI.WpfHost
          * to improve debuggability.
          */
         static readonly isHosted: boolean;
+        /**
+         * Defines if the WindowManager is responsible to raise the loading, loaded and unloaded events,
+         * or if they are raised directly by the managed code to reduce interop.
+         */
+        static readonly isLoadEventsEnabled: boolean;
         private static readonly unoRootClassName;
         private static readonly unoUnarrangedClassName;
         private static _cctor;
@@ -111,7 +117,7 @@ declare namespace Uno.UI {
             * @param containerElementId The ID of the container element for the Xaml UI
             * @param loadingElementId The ID of the loading element to remove once ready
             */
-        static init(localStoragePath: string, isHosted: boolean, containerElementId?: string, loadingElementId?: string): string;
+        static init(localStoragePath: string, isHosted: boolean, isLoadEventsEnabled: boolean, containerElementId?: string, loadingElementId?: string): string;
         /**
             * Initialize the WindowManager
             * @param containerElementId The ID of the container element for the Xaml UI
@@ -305,7 +311,7 @@ declare namespace Uno.UI {
         /**
             * Set a view as a child of another one.
             *
-            * "Loading" & "Loaded" events will be raised if nescessary.
+            * "Loading" & "Loaded" events will be raised if necessary.
             *
             * @param index Position in children list. Appended at end if not specified.
             */
@@ -313,7 +319,7 @@ declare namespace Uno.UI {
         /**
             * Set a view as a child of another one.
             *
-            * "Loading" & "Loaded" events will be raised if nescessary.
+            * "Loading" & "Loaded" events will be raised if necessary.
             *
             * @param pParams Pointer to a WindowManagerAddViewParams native structure.
             */
@@ -322,13 +328,13 @@ declare namespace Uno.UI {
         /**
             * Remove a child from a parent element.
             *
-            * "Unloading" & "Unloaded" events will be raised if nescessary.
+            * "Unloading" & "Unloaded" events will be raised if necessary.
             */
         removeView(parentId: number, childId: number): string;
         /**
             * Remove a child from a parent element.
             *
-            * "Unloading" & "Unloaded" events will be raised if nescessary.
+            * "Unloading" & "Unloaded" events will be raised if necessary.
             */
         removeViewNative(pParams: number): boolean;
         private removeViewInternal(parentId, childId);
@@ -443,6 +449,7 @@ declare class WindowManagerGetBBoxReturn {
 declare class WindowManagerInitParams {
     LocalFolderPath: string;
     IsHostedMode: boolean;
+    IsLoadEventsEnabled: boolean;
     static unmarshal(pData: number): WindowManagerInitParams;
 }
 declare class WindowManagerMeasureViewParams {

--- a/src/Uno.UI.Wasm/tsBindings/WindowManagerInitParams.ts
+++ b/src/Uno.UI.Wasm/tsBindings/WindowManagerInitParams.ts
@@ -4,6 +4,7 @@ class WindowManagerInitParams
 	/* Pack=4 */
 	LocalFolderPath : string;
 	IsHostedMode : boolean;
+	IsLoadEventsEnabled : boolean;
 	public static unmarshal(pData:number) : WindowManagerInitParams
 	{
 		let ret = new WindowManagerInitParams();
@@ -23,6 +24,10 @@ class WindowManagerInitParams
 		
 		{
 			ret.IsHostedMode = Boolean(Module.getValue(pData + 4, "i32"));
+		}
+		
+		{
+			ret.IsLoadEventsEnabled = Boolean(Module.getValue(pData + 8, "i32"));
 		}
 		return ret;
 	}

--- a/src/Uno.UI/Configuration.cs
+++ b/src/Uno.UI/Configuration.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
@@ -41,15 +42,28 @@ namespace Uno.UI
 
 #if __ANDROID__
 			/// <summary>
-			/// Controls the propagation of <see cref="FrameworkElement.Loaded"/> and
-			/// <see cref="FrameworkElement.AndroidUseManagedLoadedUnloaded"/> events through managed
+			/// Controls the propagation of <see cref="Windows.UI.Xaml.FrameworkElement.Loaded"/> and
+			/// <see cref="Windows.UI.Xaml.FrameworkElement.Unloaded"/> events through managed
 			/// or native visual tree traversal. 
 			/// </summary>
 			/// <remarks>
-			/// This setting impacts significatly the loading performance of controls on Android.
+			/// This setting impacts significantly the loading performance of controls on Android.
 			/// Setting it to <see cref="true"/> avoids the use of costly Java->C# interop.
 			/// </remarks>
 			public static bool AndroidUseManagedLoadedUnloaded { get; set; } = true;
+#endif
+
+#if __WASM__
+			/// <summary>
+			/// Controls the propagation of <see cref="Windows.UI.Xaml.FrameworkElement.Loaded"/> and
+			/// <see cref="Windows.UI.Xaml.FrameworkElement.Unloaded"/> events through managed
+			/// or native visual tree traversal. 
+			/// </summary>
+			/// <remarks>
+			/// This setting impacts significantly the loading performance of controls on Web Assembly.
+			/// Setting it to <see cref="true"/> avoids the use of costly JavaScript->C# interop.
+			/// </remarks>
+			public static bool WasmUseManagedLoadedUnloaded { get; set; } = true;
 #endif
 		}
 

--- a/src/Uno.UI/UI/Xaml/Application.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Application.wasm.cs
@@ -11,6 +11,7 @@ using Uno.Foundation;
 using Uno.Extensions;
 using Uno.Logging;
 using System.Threading;
+using Uno.UI;
 using Uno.UI.Xaml;
 
 namespace Windows.UI.Xaml
@@ -33,8 +34,10 @@ namespace Windows.UI.Xaml
 		{
 			_startInvoked = true;
 
-			bool isHostedMode = !WebAssemblyRuntime.IsWebAssembly;
-			WindowManagerInterop.Init(Windows.Storage.ApplicationData.Current.LocalFolder.Path, isHostedMode);
+			var localFolderPath = Windows.Storage.ApplicationData.Current.LocalFolder.Path;
+			var isHostedMode = !WebAssemblyRuntime.IsWebAssembly;
+			var isLoadEventsEnabled = !FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded;
+			WindowManagerInterop.Init(localFolderPath, isHostedMode, isLoadEventsEnabled);
 
 			SynchronizationContext.SetSynchronizationContext(
 				new CoreDispatcherSynchronizationContext(CoreDispatcher.Main, CoreDispatcherPriority.Normal)

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.wasm.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Microsoft.Extensions.Logging;
 using Uno.Extensions;
+using Uno.UI;
 
 namespace Windows.UI.Xaml
 {
@@ -35,9 +36,12 @@ namespace Windows.UI.Xaml
 		{
 			Initialize();
 
-			Loading += OnLoading;
-			Loaded += OnLoaded;
-			Unloaded += OnUnloaded;
+			if (!FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded)
+			{
+				Loading += NativeOnLoading;
+				Loaded += NativeOnLoaded;
+				Unloaded += NativeOnUnloaded;
+			}
 
 			_log = this.Log();
 		}

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.wasm.cs
@@ -11,7 +11,9 @@ using Windows.UI.Xaml.Controls;
 using Windows.Foundation;
 using View = Windows.UI.Xaml.UIElement;
 using System.Collections;
+using System.Runtime.CompilerServices;
 using Windows.UI.Xaml.Media;
+using Uno.UI;
 
 namespace Windows.UI.Xaml
 {
@@ -19,10 +21,41 @@ namespace Windows.UI.Xaml
 	{
 		partial void OnLoadingPartial();
 
-		private void OnLoading(object sender, RoutedEventArgs args)
+		/*
+			About NativeOn** vs ManagedOn** methods:
+				The flag FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded will configure which set of methods will be used
+				but they are mutually exclusive: Only one of each is going to be invoked.
+
+			For the managed methods: for perf consideration (avoid lots of casting) the loaded state is managed by the UI Element,
+				the FrameworkElement only makes it publicly available by overriding methods from UIElement and raising events.
+				The propagation of this loaded state is also made by the UIElement.
+		 */
+
+		internal sealed override void ManagedOnLoading()
 		{
 			OnLoadingPartial();
+			ApplyCompiledBindings();
 
+			try
+			{
+				// Raise event before invoking base in order to raise them top to bottom
+				_loading?.Invoke(this, RoutedEventArgs.Empty);
+			}
+			catch (Exception error)
+			{
+				this.Log().Error("ManagedOnLoading failed in FrameworkElement", error);
+				Application.Current.RaiseRecoverableUnhandledException(error);
+			}
+
+			// Explicit propagation of the loading even must be performed
+			// after the compiled bindings are applied (cf. OnLoading), as there may be altered
+			// properties that affect the visual tree.
+			base.ManagedOnLoading();
+		}
+
+		private void NativeOnLoading(object sender, RoutedEventArgs args)
+		{
+			OnLoadingPartial();
 			ApplyCompiledBindings();
 
 			// Explicit propagation of the loading even must be performed
@@ -34,28 +67,81 @@ namespace Windows.UI.Xaml
 			}
 		}
 
-		private void OnLoaded(object sender, RoutedEventArgs args)
+		internal sealed override void ManagedOnLoaded()
 		{
-			IsLoaded = true;
+			// Make sure to set the flag before raising the loaded event (duplicated with the base.ManagedOnLoaded)
+			base.IsLoaded = true;
+
+			try
+			{
+				// Raise event before invoking base in order to raise them top to bottom
+				OnLoaded();
+				_loaded?.Invoke(this, RoutedEventArgs.Empty);
+			}
+			catch (Exception error)
+			{
+				this.Log().Error("ManagedOnLoaded failed in FrameworkElement", error);
+				Application.Current.RaiseRecoverableUnhandledException(error);
+			}
+
+			base.ManagedOnLoaded();
+		}
+
+		private void NativeOnLoaded(object sender, RoutedEventArgs args)
+		{
+			base.IsLoaded = true;
 
 			foreach (var child in _children)
 			{
 				(child as FrameworkElement)?.InternalDispatchEvent("loaded", args);
 			}
 
-			OnLoaded();
+			try
+			{
+				OnLoaded();
+			}
+			catch (Exception error)
+			{
+				this.Log().Error("NativeOnLoaded failed in FrameworkElement", error);
+				Application.Current.RaiseRecoverableUnhandledException(error);
+			}
 		}
 
-		private void OnUnloaded(object sender, RoutedEventArgs args)
+		internal sealed override void ManagedOnUnloaded()
 		{
-			IsLoaded = false;
+			base.ManagedOnUnloaded(); // Will set flag IsLoaded to false
+
+			try
+			{
+				// Raise event after invoking base in order to raise them bottom to top
+				OnUnloaded();
+				_unloaded?.Invoke(this, RoutedEventArgs.Empty);
+			}
+			catch (Exception error)
+			{
+				this.Log().Error("ManagedOnUnloaded failed in FrameworkElement", error);
+				Application.Current.RaiseRecoverableUnhandledException(error);
+			}
+		}
+
+		private void NativeOnUnloaded(object sender, RoutedEventArgs args)
+		{
+			base.IsLoaded = false;
 
 			foreach (var child in _children)
 			{
 				(child as FrameworkElement)?.InternalDispatchEvent("unloaded", args);
 			}
 
-			OnUnloaded();
+			try
+			{
+				OnUnloaded();
+			}
+			catch (Exception error)
+			{
+				this.Log().Error("NativeOnUnloaded failed in FrameworkElement", error);
+				Application.Current.RaiseRecoverableUnhandledException(error);
+			}
 		}
 
 		public bool HasParent()
@@ -75,25 +161,88 @@ namespace Windows.UI.Xaml
 
 		static partial void OnGenericPropertyUpdatedPartial(object dependencyObject, DependencyPropertyChangedEventArgs args);
 
+		private event RoutedEventHandler _loading;
 		public event RoutedEventHandler Loading
 		{
-			add => RegisterEventHandler("loading", value);
-			remove => UnregisterEventHandler("loading", value);
+			add
+			{
+				if (FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded)
+				{
+					_loading += value;
+				}
+				else
+				{
+					RegisterEventHandler("loading", value);
+				}
+			}
+			remove
+			{
+				if (FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded)
+				{
+					_loading -= value;
+				}
+				else
+				{
+					UnregisterEventHandler("loading", value);
+				}
+			}
 		}
 
+		private event RoutedEventHandler _loaded;
 		public event RoutedEventHandler Loaded
 		{
-			add => RegisterEventHandler("loaded", value);
-			remove => UnregisterEventHandler("loaded", value);
+			add
+			{
+				if (FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded)
+				{
+					_loaded += value;
+				}
+				else
+				{
+					RegisterEventHandler("loaded", value);
+				}
+			}
+			remove
+			{
+				if (FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded)
+				{
+					_loaded -= value;
+				}
+				else
+				{
+					UnregisterEventHandler("loaded", value);
+				}
+			}
 		}
 
+		private event RoutedEventHandler _unloaded;
 		public event RoutedEventHandler Unloaded
 		{
-			add => RegisterEventHandler("unloaded", value);
-			remove => UnregisterEventHandler("unloaded", value);
+			add
+			{
+				if (FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded)
+				{
+					_unloaded += value;
+				}
+				else
+				{
+					RegisterEventHandler("unloaded", value);
+				}
+			}
+			remove
+			{
+				if (FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded)
+				{
+					_unloaded -= value;
+				}
+				else
+				{
+					UnregisterEventHandler("unloaded", value);
+				}
+			}
 		}
 
-		public bool IsLoaded { get; private set; } = false;
+		public new bool IsLoaded => base.IsLoaded; // The IsLoaded state is managed by the UIElement, FrameworkElement only makes it publicly visible
 
 		private bool IsTopLevelXamlView() => throw new NotSupportedException();
 
@@ -171,7 +320,7 @@ namespace Windows.UI.Xaml
 				typeof(HorizontalAlignment),
 				typeof(FrameworkElement),
 				new FrameworkPropertyMetadata(
-					defaultValue: HorizontalAlignment.Stretch,
+					defaultValue: Xaml.HorizontalAlignment.Stretch,
 					options: FrameworkPropertyMetadataOptions.AutoConvert | FrameworkPropertyMetadataOptions.AffectsMeasure
 				)
 			);
@@ -191,7 +340,7 @@ namespace Windows.UI.Xaml
 				typeof(VerticalAlignment),
 				typeof(FrameworkElement),
 				new FrameworkPropertyMetadata(
-					defaultValue: VerticalAlignment.Stretch,
+					defaultValue: Xaml.VerticalAlignment.Stretch,
 					options: FrameworkPropertyMetadataOptions.AutoConvert | FrameworkPropertyMetadataOptions.AffectsMeasure
 				)
 			);

--- a/src/Uno.UI/UI/Xaml/UIElementCollection.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElementCollection.wasm.cs
@@ -53,7 +53,7 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override void MoveCore(uint oldIndex, uint newIndex)
 		{
-			_view.MoveViewTo((int)oldIndex, (int)newIndex);
+			_view.MoveChildTo((int)oldIndex, (int)newIndex);
 		}
 
 		protected override View RemoveAtCore(int index)

--- a/src/Uno.UI/UI/Xaml/Window.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Window.wasm.cs
@@ -148,11 +148,26 @@ namespace Windows.UI.Xaml
 			_rootBorder.Child = _content = content;
 			if (content != null)
 			{
+				if (FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded && !_window.IsLoaded)
+				{
+					_window.ManagedOnLoading();
+				}
+
 				WebAssemblyRuntime.InvokeJS($"Uno.UI.WindowManager.current.setRootContent(\"{_window.HtmlId}\");");
+
+				if (FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded && !_window.IsLoaded)
+				{
+					_window.ManagedOnLoaded();
+				}
 			}
 			else
 			{
 				WebAssemblyRuntime.InvokeJS($"Uno.UI.WindowManager.current.setRootContent();");
+
+				if (FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded && _window.IsLoaded)
+				{
+					_window.ManagedOnUnloaded();
+				}
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.Wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.Wasm.cs
@@ -22,11 +22,11 @@ namespace Uno.UI.Xaml
 			!WebAssemblyRuntime.IsWebAssembly || FeatureConfiguration.Interop.ForceJavascriptInterop;
 
 		#region Init
-		internal static void Init(string localFolderPath, bool isHostedMode)
+		internal static void Init(string localFolderPath, bool isHostedMode, bool isLoadEventsEnabled)
 		{
 			if (UseJavascriptEval)
 			{
-				WebAssemblyRuntime.InvokeJS($"Uno.UI.WindowManager.init(\"{localFolderPath}\", {isHostedMode.ToString().ToLowerInvariant()});");
+				WebAssemblyRuntime.InvokeJS($"Uno.UI.WindowManager.init(\"{localFolderPath}\", {isHostedMode.ToString().ToLowerInvariant()}, {isLoadEventsEnabled.ToString().ToLowerInvariant()});");
 			}
 			else
 			{
@@ -34,6 +34,7 @@ namespace Uno.UI.Xaml
 				{
 					LocalFolderPath = localFolderPath,
 					IsHostedMode = isHostedMode,
+					IsLoadEventsEnabled = isLoadEventsEnabled
 				};
 
 				TSInteropMarshaller.InvokeJS<WindowManagerInitParams, bool>("UnoStatic:initNative", parms);
@@ -48,6 +49,8 @@ namespace Uno.UI.Xaml
 			public string LocalFolderPath;
 
 			public bool IsHostedMode;
+
+			public bool IsLoadEventsEnabled;
 		}
 
 		#endregion


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
 - Other: Performance improvement on WASM, reduces interop

## What is the current behavior?
On WASM `Loading`, `Loaded` and `Unloaded` events are raised by the Javascript then marshaled to the managed code.

## What is the new behavior?
They are now raised directly by the managed code

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
Old behavior can be restored by setting to `false` the feature flag `FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded`

Internal Issue (If applicable):
https://nventive.visualstudio.com/DefaultCollection/Umbrella/_workitems/edit/144039