### PR TITLE
Use AppDomain isolation for Uno.UI.Tasks, copy file to override folder.

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -93,6 +93,7 @@
  * 143598 [Wasm] Wasm Animation rotation center is incorrect
  * Fixes invalid parsing of custom types containing `{}` in their value (#455)
  * Add workaround for iOS stackoverflow during initialization.
+ * Improve the file locking issues of Uno.UI.Tasks MSBuild task
 
 ## Release 1.42
 

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -9,9 +9,6 @@
 	<UnoSourceGeneratorBeforeTarget Condition="'$(XamarinProjectType)'=='android'" Include="UpdateAndroidAssets" />
   </ItemGroup>
 
-  <UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.ResourcesGenerationTask_v0" />
-  <UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.Assets.RetargetAssets_v0" />
-
   <Target Name="ResourcesGeneration"
 				  BeforeTargets="PrepareForBuild;_CheckForContent"
 				  DependsOnTargets="AssignLinkMetadata"
@@ -24,14 +21,15 @@
 	  <DefaultLanguage Condition="'$(DefaultLanguage)'==''">en</DefaultLanguage>
 	  <XamarinProjectType Condition="'$(UnoForceProcessPRIResource)'!=''"></XamarinProjectType>
 	</PropertyGroup>
-	<ResourcesGenerationTask_v0 Resources="@(PRIResource)"
-							   TargetProjectDirectory="$(ProjectDir)"
-							   TargetPlatform="$(XamarinProjectType)"
-							   IntermediateOutputPath="$(IntermediateOutputPath)"
-							   DefaultLanguage="$(DefaultLanguage)">
+    <ResourcesGenerationTask AssemblyPath="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll"
+                             Resources="@(PRIResource)"
+							 TargetProjectDirectory="$(ProjectDir)"
+							 TargetPlatform="$(XamarinProjectType)"
+							 IntermediateOutputPath="$(IntermediateOutputPath)"
+							 DefaultLanguage="$(DefaultLanguage)">
 	  <Output TaskParameter="GeneratedFiles"
 					  ItemName="GeneratedFiles" />
-	</ResourcesGenerationTask_v0>
+	</ResourcesGenerationTask>
 	<ItemGroup>
 	  <BundleResource Condition="'%(GeneratedFiles.UnoResourceTarget)' =='iOS'" Include="@(GeneratedFiles)" />
 	  <AndroidResource Condition="'%(GeneratedFiles.UnoResourceTarget)' =='Android'" Include="@(GeneratedFiles)" />
@@ -41,20 +39,188 @@
 	<PropertyGroup>
 	  <UseHighDPIResources Condition="'$(UseHighDPIResources)'==''">True</UseHighDPIResources>
 	</PropertyGroup>
-	<RetargetAssets_v0 UseHighDPIResources="$(UseHighDPIResources)"
-						TargetPlatform="$(XamarinProjectType)"
-						DefaultLanguage="$(DefaultLanguage)"
-						ContentItems="@(Content)"
-						Condition="'$(XamarinProjectType)'!=''">
+	<RetargetAssets AssemblyPath="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll"
+                       UseHighDPIResources="$(UseHighDPIResources)"
+					   TargetPlatform="$(XamarinProjectType)"
+					   DefaultLanguage="$(DefaultLanguage)"
+					   ContentItems="@(Content)"
+					   Condition="'$(XamarinProjectType)'!=''">
 	  <Output TaskParameter="Assets"
 					  ItemName="Assets" />
 	  <Output TaskParameter="RetargetedAssets"
 					  ItemName="RetargetedAssets" />
-	</RetargetAssets_v0>
+	</RetargetAssets>
 	<ItemGroup>
 	  <Content Remove="@(Assets)" />
 	  <BundleResource Condition="'$(XamarinProjectType)'=='ios'" Include="@(RetargetedAssets)" />
 	  <AndroidResource Condition="'$(XamarinProjectType)'=='android'" Include="@(RetargetedAssets)" />
 	</ItemGroup>
   </Target>
+
+  <!--
+    Use inline tasks to create an in-memory assembly that will be able to execute
+    the target task without locking it. This issue generally only happens when being inside visual studio.
+
+  -->
+  <UsingTask
+      TaskName="ResourcesGenerationTask"
+      TaskFactory="CodeTaskFactory"
+      AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <AssemblyPath ParameterType="System.String" Required="true" />
+      <TargetProjectDirectory ParameterType="System.String" Required="true" />
+      <TargetPlatform ParameterType="System.String" Required="false" />
+      <IntermediateOutputPath ParameterType="System.String" Required="true" />
+      <DefaultLanguage ParameterType="System.String" Required="true" />
+      <Resources ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+      <GeneratedFiles ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true"/>
+    </ParameterGroup>
+    <Task>
+      <Reference Include="System.Core" />
+      <Reference Include="Microsoft.CSharp" />
+      <Using Namespace="MyTasks" />
+      <Code Type="Class" Language="cs">
+        <![CDATA[ 
+        using System;  
+        using System.Reflection;
+        using Microsoft.Build.Framework;  
+        using Microsoft.Build.Utilities;
+
+        namespace MyTasks
+        {      
+            public class IsolatedResourcesGenerationTask : AppDomainIsolatedTask
+            {
+		        [Required]
+		        public string AssemblyPath { get; set; }
+
+		        [Required]
+		        public ITaskItem[] Resources { get; set; }
+
+		        public string TargetPlatform { get; set; }
+
+		        [Required]
+		        public string TargetProjectDirectory { get; set; }
+
+		        [Required]
+		        public string IntermediateOutputPath { get; set; }
+
+		        [Required]
+		        public string DefaultLanguage { get; set; }
+
+		        [Output]
+		        public ITaskItem[] GeneratedFiles { get; set; }
+
+                public override bool Execute()
+                { 
+                    var asm = Assembly.LoadFrom(AssemblyPath);
+                    var type = asm.GetType("Uno.UI.Tasks.ResourcesGenerator.ResourcesGenerationTask_v0");
+                    var instance = Activator.CreateInstance(type);
+
+                    SetPropertyValue(type, instance, "TargetProjectDirectory", TargetProjectDirectory);
+                    SetPropertyValue(type, instance, "TargetPlatform", TargetPlatform);
+                    SetPropertyValue(type, instance, "IntermediateOutputPath", IntermediateOutputPath);
+                    SetPropertyValue(type, instance, "DefaultLanguage", DefaultLanguage);
+                    SetPropertyValue(type, instance, "Resources", Resources);
+
+                    SetPropertyValue(type, instance, "BuildEngine", BuildEngine);
+                    type.GetMethod("Execute").Invoke(instance, null);
+
+                    GeneratedFiles = (ITaskItem[])type.GetProperty("GeneratedFiles").GetValue(instance);
+
+                    return true;  
+                }
+
+                private void SetPropertyValue(Type taskType, object instance, string name, object value)
+                {
+                    taskType.GetProperty(name).SetValue(instance, value);
+                }
+            }
+        } 
+         ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+  <UsingTask
+      TaskName="RetargetAssets"
+      TaskFactory="CodeTaskFactory"
+      AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+    <ParameterGroup>
+      <AssemblyPath ParameterType="System.String" Required="true" />
+      <UseHighDPIResources ParameterType="System.Boolean" Required="true" />
+      <TargetPlatform ParameterType="System.String" Required="true" />
+      <DefaultLanguage ParameterType="System.String" Required="true" />
+      <ContentItems ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+
+      <Assets ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true"/>
+      <RetargetedAssets ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true"/>
+    </ParameterGroup>
+    <Task>
+      <Reference Include="System.Core" />
+      <Reference Include="Microsoft.CSharp" />
+      <Using Namespace="MyTasks" />
+      <Code Type="Class" Language="cs">
+        <![CDATA[ 
+        using System;  
+        using System.Reflection;
+        using Microsoft.Build.Framework;  
+        using Microsoft.Build.Utilities;  
+
+        namespace MyTasks
+        {
+            public class IsolatedRetargetAssets : AppDomainIsolatedTask
+            {
+		        [Required]
+		        public string AssemblyPath { get; set; }
+
+                [Required]
+		        public bool UseHighDPIResources { get; set; }
+
+		        [Required]
+		        public string TargetPlatform { get; set; }
+
+		        [Required]
+		        public string DefaultLanguage { get; set; }
+
+		        [Required]
+		        public ITaskItem[] ContentItems { get; set; }
+
+		        [Output]
+		        public ITaskItem[] Assets { get; set; }
+
+		        [Output]
+		        public ITaskItem[] RetargetedAssets { get; set; }
+
+                public override bool Execute()
+                { 
+                    var asm = Assembly.LoadFrom(AssemblyPath);
+                    var type = asm.GetType("Uno.UI.Tasks.Assets.RetargetAssets_v0");
+                    var task = Activator.CreateInstance(type);
+
+                    SetPropertyValue(type, task, "UseHighDPIResources", UseHighDPIResources);
+                    SetPropertyValue(type, task, "TargetPlatform", TargetPlatform);
+                    SetPropertyValue(type, task, "DefaultLanguage", DefaultLanguage);
+                    SetPropertyValue(type, task, "ContentItems", ContentItems);
+
+                    SetPropertyValue(type, task, "BuildEngine", BuildEngine);
+                    type.GetMethod("Execute").Invoke(task, null);
+
+                    Assets = (ITaskItem[])type.GetProperty("Assets").GetValue(task);
+                    RetargetedAssets = (ITaskItem[])type.GetProperty("RetargetedAssets").GetValue(task);
+
+                    return true;  
+                }
+
+                private void SetPropertyValue(Type taskType, object instance, string name, object value)
+                {
+                    taskType.GetProperty(name).SetValue(instance, value);
+                }
+            }
+          } 
+         ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+
 </Project>

--- a/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
+++ b/src/SourceGenerators/Uno.UI.Tasks/Uno.UI.Tasks.csproj
@@ -108,4 +108,18 @@
 		<Copy SkipUnchangedFiles="true" SourceFiles="@(_unoTasksFiles)" DestinationFolder="$(OutputPath)\..\$(Configuration)_Shadow" Retries="1" RetryDelayMilliseconds="500" ContinueOnError="true" />
 	</Target>
   <Import Project="..\..\Common.targets" />
+	
+	<Target Name="_UnoToolkitOverrideNuget" AfterTargets="AfterBuild" DependsOnTargets="BuiltProjectOutputGroup" Condition="'$(UnoNugetOverrideVersion)'!=''">
+		<PropertyGroup>
+			<_OverrideTargetFramework>$(TargetFramework)</_OverrideTargetFramework>
+			<_TargetNugetFolder>$(USERPROFILE)\.nuget\packages\Uno.UI\$(UnoNugetOverrideVersion)\build\Uno.UI.Tasks</_TargetNugetFolder>
+		</PropertyGroup>
+		<ItemGroup>
+			<_OutputFiles Include="$(TargetDir)*.*" />
+		</ItemGroup>
+		<MakeDir Directories="$(_TargetNugetFolder)" />
+		<Message Importance="high" Text="OVERRIDING NUGET PACKAGE CACHE: $(_TargetNugetFolder)" />
+		<Copy SourceFiles="@(_OutputFiles)" DestinationFiles="@(_OutputFiles->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename)%(Extension)')" />
+		<Copy SourceFiles="@(_OutputFilesPDB)" DestinationFiles="@(_OutputFilesPDB->'$(_TargetNugetFolder)\%(RecursiveDir)%(Filename).pdb')" />
+	</Target>
 </Project>


### PR DESCRIPTION
## PR Type
- Bugfix

## What is the current behavior?
The Uno.UI.Task file gets locked very often by msbuild or devenv.

## What is the new behavior?
This PR attemps to limit the file locking by isolating the task inside of a inline task, and making sure the task is not referenced explicitly.

The Uno.UI.Tasks assembly is now copied properly in case of a nuget override, during development.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
