### PR TITLE
Fix VisibleBoundsPadding memory leak, improve profiling documentation

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -53,6 +53,8 @@
 * [Wasm] Fix `CoreDispatcher` `StackOverflowException` when running on low stack space environments (e.g. iOS)
 * Add support for `ResourceLoader.GetForViewIndependentUse(string)` and named resource files
 * [Wasm] Load events are now raised directly from managed code. You can restore the previous behavior (raised from native) by setting `FeatureConfiguration.FrameworkElement.WasmUseManagedLoadedUnloaded = false`.
+* Updated memory profiling documentation
+* Updated default app template iOS GC settings
 
 ### Breaking changes
 * Refactored ToggleSwitch Default Native XAML Styles. (cf. 'NativeDefaultToggleSwitch' styles in Generic.Native.xaml)
@@ -94,6 +96,7 @@
  * Fixes invalid parsing of custom types containing `{}` in their value (#455)
  * Add workaround for iOS stackoverflow during initialization.
  * Improve the file locking issues of Uno.UI.Tasks MSBuild task
+ * Fix `VisibleBoundsPadding` memory leak
 
 ## Release 1.42
 

--- a/doc/articles/debugging-uno-ui.md
+++ b/doc/articles/debugging-uno-ui.md
@@ -69,3 +69,84 @@ The Source Generation tooling diagnostics can be enabled as follows:
 - The best way to provide those file for troubleshooting is to make a zip archive of the whole solution folder without cleaning it, so it contains the proper diagnostics `.binlog` files.
 
 **Make sure to remove the `UnoSourceGeneratorUnsecureBinLogEnabled` property once done.**
+
+## Troubleshooting Memory Issues 
+
+Uno provides a set of classes aimed at diagnosing memory issues related to leaking controls, wether it be from
+an Uno.UI issue or from an invalid pattern in user code.
+
+### Enable Memory intances counter
+In your application, as early as possible in the initialization (generally in the App.xaml.cs
+constructor), add and call the following method:
+
+```
+using Uno.UI.DataBinding;
+
+// ....
+private void EnableViewsMemoryStatistics()
+{
+	//
+	// Call this method to enable Views memory tracking.
+	// Make sure that you've added the following :
+	//
+	//  { "Uno.UI.DataBinding", LogLevel.Information }
+	//
+	// in the logger settings, so that the statistics are showing up.
+	//
+
+
+	var unused = Windows.UI.Xaml.Window.Current.Dispatcher.RunAsync(
+		CoreDispatcherPriority.Normal,
+		async () =>
+		{
+			BinderReferenceHolder.IsEnabled = true;
+
+			while (true)
+			{
+				await Task.Delay(1500);
+
+				try
+				{
+					BinderReferenceHolder.LogReport();
+
+					var inactiveInstances = BinderReferenceHolder.GetInactiveViewBinders();
+
+					// Force the variable to be kept by the linker so we can see it with the debugger.
+					// Put a breakpoint on this line to dig into the inactive views.
+					inactiveInstances.ToString();
+				}
+				catch (Exception ex)
+				{
+					this.Log().Error("Report generation failed", ex);
+				}
+			}
+		}
+	);
+}
+```
+You'll also need to add the following logger filter:
+```
+	{ "Uno.UI.DataBinding.BinderReferenceHolder", LogLevel.Information },
+```
+
+### Interpeting the statistics output
+
+The output provides two sets of DependencyObject in memory:
+- Active, for which the instances have a parent dependency object (e.g. an item in a Grid)
+- Inactive, for which the instances do not have a parent dependency object
+
+When doing back and forth navigation between pages, instances of the controls in the dismissed pages should
+generally be collected after a few seconds, once those have been cleared from the `Frame` control's forward
+stack (done after every new page navigation).
+
+Searching for inactive objects first is generally best, as those instances are most likely kept alive by
+cross references.
+
+This can happen when a Grid item has a strong field reference to its parent:
+
+```
+var myItem = new Grid(){ Tag = grid };
+grid.Children.Add(myItem);
+```
+
+For Xamarin.iOS specifically, see [this article about performance tuning](https://docs.microsoft.com/en-us/xamarin/ios/deploy-test/performance).

--- a/src/SolutionTemplate/UnoSolutionTemplate/iOS/UnoQuickStart.iOS.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/iOS/UnoQuickStart.iOS.csproj
@@ -25,6 +25,7 @@
 		<MtouchArch>x86_64</MtouchArch>
 		<MtouchLink>None</MtouchLink>
 		<MtouchDebug>true</MtouchDebug>
+		<MtouchExtraArgs>--setenv=MONO_LOG_LEVEL=debug --setenv=MONO_LOG_MASK=gc --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
 		<DebugType>portable</DebugType>
@@ -35,6 +36,7 @@
 		<MtouchLink>None</MtouchLink>
 		<MtouchArch>x86_64</MtouchArch>
 		<ConsolePause>false</ConsolePause>
+		<MtouchExtraArgs>--setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
 		<DebugSymbols>true</DebugSymbols>
@@ -49,6 +51,7 @@
 		<CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
 		<CodesignKey>iPhone Developer</CodesignKey>
 		<MtouchDebug>true</MtouchDebug>
+		<MtouchExtraArgs>--setenv=MONO_LOG_LEVEL=debug --setenv=MONO_LOG_MASK=gc --setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
 		<DebugType>none</DebugType>
@@ -63,6 +66,7 @@
 		<MtouchUseLlvm>true</MtouchUseLlvm>
 		<MtouchEnableSGenConc>true</MtouchEnableSGenConc>
 		<BuildIpa>true</BuildIpa>
+		<MtouchExtraArgs>--setenv=MONO_GC_PARAMS=soft-heap-limit=512m,nursery-size=64m,evacuation-threshold=66,major=marksweep,concurrent-sweep</MtouchExtraArgs>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Ad-Hoc|iPhone' ">
 		<DebugType>none</DebugType>

--- a/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
+++ b/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
@@ -115,7 +115,7 @@ namespace Uno.UI.Toolkit
 		public class VisibleBoundsDetails
 		{
 			private static ConditionalWeakTable<FrameworkElement, VisibleBoundsDetails> _instances = new ConditionalWeakTable<FrameworkElement, VisibleBoundsDetails>();
-			private FrameworkElement _owner;
+			private WeakReference _owner;
 			private TypedEventHandler<global::Windows.UI.ViewManagement.ApplicationView, object> _visibleBoundsChanged;
 			private PaddingMask _paddingMask;
 			private Thickness _originalPadding;
@@ -123,16 +123,18 @@ namespace Uno.UI.Toolkit
 
 			internal VisibleBoundsDetails(FrameworkElement owner)
 			{
-				_owner = owner;
+				_owner = new WeakReference(owner);
 
-				_originalPadding = (Thickness)(_owner.GetValue(GetPaddingProperty()) ?? new Thickness(0));
+				_originalPadding = (Thickness)(Owner.GetValue(GetPaddingProperty()) ?? new Thickness(0));
 
 				_visibleBoundsChanged = (s2, e2) => UpdatePadding();
 
-				_owner.LayoutUpdated += (s, e) => UpdatePadding();
-				_owner.Loaded += (s, e) => ApplicationView.GetForCurrentView().VisibleBoundsChanged += _visibleBoundsChanged;
-				_owner.Unloaded += (s, e) => ApplicationView.GetForCurrentView().VisibleBoundsChanged -= _visibleBoundsChanged;
+				Owner.LayoutUpdated += (s, e) => UpdatePadding();
+				Owner.Loaded += (s, e) => ApplicationView.GetForCurrentView().VisibleBoundsChanged += _visibleBoundsChanged;
+				Owner.Unloaded += (s, e) => ApplicationView.GetForCurrentView().VisibleBoundsChanged -= _visibleBoundsChanged;
 			}
+
+			private FrameworkElement Owner => _owner.Target as FrameworkElement;
 
 			private void UpdatePadding()
 			{
@@ -153,7 +155,7 @@ namespace Uno.UI.Toolkit
 					var scrollAncestor = GetScrollAncestor();
 
 					// If the owner view is scrollable, the visibility of interest is that of the scroll viewport.
-					var fixedControl = scrollAncestor ?? _owner;
+					var fixedControl = scrollAncestor ?? Owner;
 
 					var controlBounds = GetRelativeBounds(fixedControl, Window.Current.Content);
 
@@ -208,7 +210,7 @@ namespace Uno.UI.Toolkit
 				if (scrollableRoot != null)
 				{
 					// Get the spacing already provided by the alignment of the child relative to it ancestor at the root of the scrollable hierarchy.
-					var controlBounds = GetRelativeBounds(_owner, scrollableRoot);
+					var controlBounds = GetRelativeBounds(Owner, scrollableRoot);
 					var rootBounds = new Rect(0, 0, scrollableRoot.ActualWidth, scrollableRoot.ActualHeight);
 
 					// Adjust for existing spacing
@@ -255,13 +257,13 @@ namespace Uno.UI.Toolkit
 
 				if (property != null)
 				{
-					_owner.SetValue(property, padding);
+					Owner.SetValue(property, padding);
 				}
 			}
 
 			private DependencyProperty GetPaddingProperty()
 			{
-				switch (_owner)
+				switch (Owner)
 				{
 					case Grid g:
 						return Grid.PaddingProperty;
@@ -289,7 +291,7 @@ namespace Uno.UI.Toolkit
 
 			private DependencyProperty GetDefaultPaddingProperty()
 			{
-				var ownerType = _owner.GetType();
+				var ownerType = Owner.GetType();
 
 				if (!_paddingPropertyCache.TryGetValue(ownerType, out var property))
 				{
@@ -329,7 +331,7 @@ namespace Uno.UI.Toolkit
 
 			private ScrollViewer GetScrollAncestor()
 			{
-				return _owner.FindFirstParent<ScrollViewer>();
+				return Owner.FindFirstParent<ScrollViewer>();
 			}
 
 			private static Rect GetRelativeBounds(FrameworkElement boundsOf, UIElement relativeTo)


### PR DESCRIPTION
## PR Type
- Bugfix
- Documentation

## What is the current behavior?
Adding the VisibleBoundsPadding behavior makes the instance and the underlying tree leak.

## What is the new behavior?
`VisibleBoundsPadding` does not leak anymore.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
