### PR TITLE
Fix broken ComboBox on Wasm

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -97,6 +97,8 @@
  * Add workaround for iOS stackoverflow during initialization.
  * Improve the file locking issues of Uno.UI.Tasks MSBuild task
  * Fix `VisibleBoundsPadding` memory leak
+ * #87 / 124046 ComboBox incorrect behavior when using Items property
+ * [Wasm] ComboBox wasn't working anymore since few versions
 
 ## Release 1.42
 

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -695,6 +695,14 @@ namespace SampleControl.Presentation
 			//Activator is used here in order to generate the view and bind it directly with the proper view model 
 			var control = Activator.CreateInstance(newContent.ControlType);
 
+			if (newContent.ViewModelType != null && control is FrameworkElement fe)
+			{
+				var vm = Activator.CreateInstance(newContent.ViewModelType, fe.Dispatcher);
+				fe.DataContext = vm;
+
+			}
+
+
 			var controlContainsSampleControl = (control as UserControl)?.Content is Uno.UI.Samples.Controls.SampleControl;
 			if (!controlContainsSampleControl)
 			{

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserContent.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleChooserContent.cs
@@ -8,6 +8,7 @@ using Windows.UI.Xaml;
 
 namespace SampleControl.Entities
 {
+	[Windows.UI.Xaml.Data.Bindable]
 	public class SampleChooserContent : INotifyPropertyChanged
 	{
 		public string ControlName { get; set; }

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleControlInfoAttribute.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/SampleControlInfoAttribute.cs
@@ -23,28 +23,14 @@ namespace Uno.UI.Samples.Controls
 			this._description = description;
         }
 		
-		public string ControlName
-		{
-			get { return _controlName; }
-		}
-		public string Category
-		{
-			get { return _category; }
-		}
+		public string ControlName => _controlName;
 
-		public Type ViewModelType
-		{
-			get { return _viewModelType; }
-		}
+		public string Category => _category;
 
-		public bool IgnoreInAutomatedTests
-		{
-			get { return _ignoreInAutomatedTests; }
-		}
+		public Type ViewModelType => _viewModelType;
 
-		public string Description
-		{
-			get { return _description; }
-		}
+		public bool IgnoreInAutomatedTests => _ignoreInAutomatedTests;
+
+		public string Description => _description;
 	}
 }

--- a/src/SamplesApp/SamplesApp.Wasm/Properties/launchSettings.json
+++ b/src/SamplesApp/SamplesApp.Wasm/Properties/launchSettings.json
@@ -1,0 +1,19 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:55838/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
+++ b/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
@@ -1,53 +1,54 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <WasmHead>true</WasmHead>
-    <DefineConstants>$(DefineConstants);__WASM__;HAS_UNO</DefineConstants>
-    <NoWarn>NU1701,CS1998</NoWarn>
-    <LangVersion>7.3</LangVersion>
+<Project Sdk="Microsoft.NET.Sdk.Web">
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<WasmHead>true</WasmHead>
+		<DefineConstants>$(DefineConstants);__WASM__;HAS_UNO</DefineConstants>
+		<NoWarn>NU1701,CS1998</NoWarn>
+		<LangVersion>7.3</LangVersion>
 	</PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsAsErrors />
-  </PropertyGroup>
-  <ItemGroup>
-    <Content Include="..\SamplesApp.UWP\Assets\*.png" Link="Assets\%(FileName)%(Extension)" />
-    <Content Include="Fonts\winjs-symbols.woff2" />
-    <Content Include="web.config" />
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="WasmCSS\Fonts.css" />
-    <EmbeddedResource Include="WasmScripts\*.js" />
-  </ItemGroup>
-  <ItemGroup>
-    <LinkerDescriptor Include="LinkerConfig.xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <!-- 
-    This item group is required by the project templace because of the
-    new SDK-Style project, otherwise some files are not aded automatically.
-    
-    You can safely this ItemGroup completely.
-    -->
-    <Compile Remove="Program.cs" />
-    <Compile Include="Program.cs" />
-    <Content Include="LinkerConfig.xml" />
-  </ItemGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<WarningsAsErrors />
+	</PropertyGroup>
+	<ItemGroup>
+		<Content Update="..\SamplesApp.UWP\Assets\*.png" Link="Assets\%(FileName)%(Extension)" />
+		<Content Update="Fonts\winjs-symbols.woff2" />
+		<Content Update="web.config" />
+	</ItemGroup>
+	<ItemGroup>
+		<EmbeddedResource Include="WasmCSS\Fonts.css" />
+		<EmbeddedResource Include="WasmScripts\*.js" />
+	</ItemGroup>
+	<ItemGroup>
+		<LinkerDescriptor Include="LinkerConfig.xml" />
+	</ItemGroup>
+	<ItemGroup>
+		<!-- 
+		This item group is required by the project templace because of the
+		new SDK-Style project, otherwise some files are not aded automatically.
+		
+		You can safely this ItemGroup completely.
+		-->
+		<Compile Remove="Program.cs" />
+		<Compile Include="Program.cs" />
+		<Content Update="LinkerConfig.xml" />
+	</ItemGroup>
 	
-  <ItemGroup>
+	<ItemGroup>
 		<PackageReference Include="Microsoft.TypeScript.Compiler" Version="2.8.3" />
 		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="2.8.3" />
 		<PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
 		<PackageReference Include="Uno.SourceGenerationTasks">
-			<Version>1.29.0-dev.226</Version>
+			<Version>1.29.0-dev.232</Version>
 			<NoWarn>NU1701</NoWarn>
 		</PackageReference>
-		<PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.0-dev.131" />
+		<PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.0-dev.137" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
 		<PackageReference Include="Uno.Wasm.MonoRuntime" Version="1.0.0-dev0000" />
+		<DotNetCliToolReference Include="Uno.Wasm.Bootstrap.Cli" Version="1.0.0-dev.137" />
 	</ItemGroup>
 	
 	<ItemGroup>
@@ -64,7 +65,7 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-	  <None Remove="web.config" />
+		<None Remove="web.config" />
 	</ItemGroup>
 
 	<Import Project="..\..\SourceGenerators\sourcegenerators.local.props" />

--- a/src/SamplesApp/UITests.Shared/Helpers/ViewModelBase.cs
+++ b/src/SamplesApp/UITests.Shared/Helpers/ViewModelBase.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Windows.Input;
 using Windows.UI.Core;
 
 namespace Uno.UI.Samples.UITests.Helpers
@@ -20,10 +22,94 @@ namespace Uno.UI.Samples.UITests.Helpers
 
 		protected void RaisePropertyChanged([CallerMemberName] string propertyName = "")
 		{
-			var unused = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+			if (Dispatcher.HasThreadAccess)
+			{
+				RaiseEvent();
+			}
+			else
+			{
+				var _ = Dispatcher.RunAsync(CoreDispatcherPriority.Normal, RaiseEvent);
+			}
+
+			void RaiseEvent()
 			{
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-			});
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs($"Item[{propertyName}]"));
+			}
+		}
+
+		protected static Command CreateCommand(Action<object> action)
+		{
+			return new Command(action);
+		}
+
+		protected static Command CreateCommand(Action action)
+		{
+			return new Command(_ => action());
+		}
+
+		public object this[string propertyName]
+		{
+			// This is a hack to adapt samples to an old way to build viewmodels.
+			// You don't need to use this for new samples.
+			get
+			{
+				var type = GetType();
+				var pi = type.GetProperty(propertyName,
+					BindingFlags.Instance | BindingFlags.GetProperty | BindingFlags.Public);
+				var value = pi?.GetValue(this);
+				return value;
+			}
+		}
+
+		public class Command : ICommand
+		{
+			private readonly Action<object> _action;
+			private bool _manualCanExecute = true;
+
+			public bool ManualCanExecute
+			{
+				get => _manualCanExecute;
+				set
+				{
+					_manualCanExecute = value;
+					CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+				}
+			}
+
+			private bool _isExecuting = false;
+
+			public Command(Action<object> action)
+			{
+				_action = action;
+			}
+
+			public bool CanExecute(object parameter)
+			{
+				return !_isExecuting && _manualCanExecute;
+			}
+
+			public void Execute(object parameter)
+			{
+				if (_isExecuting)
+				{
+					return;
+				}
+
+				try
+				{
+					_isExecuting = true;
+					CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+					_action(parameter);
+				}
+				finally
+				{
+					_isExecuting = false;
+					CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+				}
+			}
+
+			public event EventHandler CanExecuteChanged;
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Helpers/ViewModelBase.cs
+++ b/src/SamplesApp/UITests.Shared/Helpers/ViewModelBase.cs
@@ -9,6 +9,7 @@ using Windows.UI.Core;
 
 namespace Uno.UI.Samples.UITests.Helpers
 {
+	[Windows.UI.Xaml.Data.Bindable]
 	public class ViewModelBase : INotifyPropertyChanged
 	{
 		public CoreDispatcher Dispatcher { get; }
@@ -62,6 +63,7 @@ namespace Uno.UI.Samples.UITests.Helpers
 			}
 		}
 
+		[Windows.UI.Xaml.Data.Bindable]
 		public class Command : ICommand
 		{
 			private readonly Action<object> _action;

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -145,7 +145,55 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Corners.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_DisplayMemberPath.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_DropDownWidth.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Empty.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Header.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ItemsSource.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Legacy.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_NativePopup.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Picker.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_PlaceholderText.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Popover.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ScrollViewer.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_SelectedItem.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -154,6 +202,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_With_ItemTemplate.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\Picker_Resizable.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -674,14 +726,55 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ComboBoxItem_Selection.xaml.cs">
       <DependentUpon>ComboBox_ComboBoxItem_Selection.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Corners.xaml.cs">
+      <DependentUpon>ComboBox_Corners.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_DisplayMemberPath.xaml.cs">
       <DependentUpon>ComboBox_DisplayMemberPath.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_DropDownWidth.xaml.cs">
+      <DependentUpon>ComboBox_DropDownWidth.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Empty.xaml.cs">
+      <DependentUpon>ComboBox_Empty.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Header.xaml.cs">
+      <DependentUpon>ComboBox_Header.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ItemsSource.xaml.cs">
+      <DependentUpon>ComboBox_ItemsSource.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Legacy.xaml.cs">
+      <DependentUpon>ComboBox_Legacy.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_NativePopup.xaml.cs">
+      <DependentUpon>ComboBox_NativePopup.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Picker.xaml.cs">
+      <DependentUpon>ComboBox_Picker.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_PlaceholderText.xaml.cs">
+      <DependentUpon>ComboBox_PlaceholderText.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Popover.xaml.cs">
+      <DependentUpon>ComboBox_Popover.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ScrollViewer.xaml.cs">
+      <DependentUpon>ComboBox_ScrollViewer.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_SelectedItem.xaml.cs">
+      <DependentUpon>ComboBox_SelectedItem.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_With_ItemContainerStyle.xaml.cs">
       <DependentUpon>ComboBox_With_ItemContainerStyle.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_With_ItemTemplate.xaml.cs">
       <DependentUpon>ComboBox_With_ItemTemplate.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\Models\ComboBoxViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\Models\ListViewViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\Picker_Resizable.xaml.cs">
+      <DependentUpon>Picker_Resizable.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Models\ImageWithLateSourceViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\BorderImageBrush.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -141,6 +141,22 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ComboBoxItem_Selection.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_DisplayMemberPath.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_With_ItemContainerStyle.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_With_ItemTemplate.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\BorderImageBrush.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -654,6 +670,18 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\ZeroThicknessWithRadius.xaml.cs">
       <DependentUpon>ZeroThicknessWithRadius.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ComboBoxItem_Selection.xaml.cs">
+      <DependentUpon>ComboBox_ComboBoxItem_Selection.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_DisplayMemberPath.xaml.cs">
+      <DependentUpon>ComboBox_DisplayMemberPath.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_With_ItemContainerStyle.xaml.cs">
+      <DependentUpon>ComboBox_With_ItemContainerStyle.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_With_ItemTemplate.xaml.cs">
+      <DependentUpon>ComboBox_With_ItemTemplate.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Models\ImageWithLateSourceViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media\ImageBrushTests\BorderImageBrush.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml
@@ -1,0 +1,39 @@
+﻿<UserControl
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ComboBox.ComboBox_ComboBoxItem_Selection"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<ComboBox x:Name="_combo">
+			<ComboBoxItem>
+				<StackPanel Orientation="Horizontal">
+					<Ellipse Fill="Aquamarine" Width="20" Height="30" />
+					<TextBlock>Item 1</TextBlock>
+				</StackPanel>
+ 			</ComboBoxItem>
+			<ComboBoxItem>Item 2</ComboBoxItem>
+			<ComboBoxItem>Item 3</ComboBoxItem>
+			<ComboBoxItem>Item 4</ComboBoxItem>
+		</ComboBox>
+		<TextBlock>
+			Previous Combo VisualTree (first item):<LineBreak />
+			<Run x:Name="_combo1Txt"></Run>
+		</TextBlock>
+		<ComboBox x:Name="_combo2">
+			<TextBlock>Item 1</TextBlock>
+			<TextBlock>Item 2</TextBlock>
+			<TextBlock>Item 3</TextBlock>
+			<TextBlock>Item 4</TextBlock>
+			<TextBlock>Item 5</TextBlock>
+		</ComboBox>
+		<TextBlock>
+			Previous Combo VisualTree (first item):<LineBreak />
+			<Run x:Name="_combo2Txt"></Run>
+		</TextBlock>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Sample.Views.Helper;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_ComboBoxItem_Selection")]
+	public sealed partial class ComboBox_ComboBoxItem_Selection : UserControl
+	{
+		public ComboBox_ComboBoxItem_Selection()
+		{
+			this.InitializeComponent();
+
+			_combo.SelectionChanged += SelectionChanged;
+
+			Loaded += OnLoaded;
+		}
+
+		private void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			var items = _combo.Items;
+			var item = items.First() as FrameworkElement;
+			item.Loaded += (snd, evt) => { _combo1Txt.Text = GetVisualTree(item); };
+
+			var items2 = _combo2.Items;
+			var item2 = items2.First() as FrameworkElement;
+			item2.Loaded += (snd, evt) => { _combo2Txt.Text = GetVisualTree(item2); };
+		}
+
+		private void SelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			var items = _combo.Items;
+			var item = _combo.SelectedItem;
+			var item2 = e.AddedItems.ToArray();
+		}
+
+		private string GetVisualTree(FrameworkElement element)
+		{
+			IEnumerable<string> GetElements()
+			{
+				foreach (var o in element.GetParentHierarchy())
+				{
+					var e = o as FrameworkElement;
+					yield return $"{o.GetType().Name}{e?.Name}";
+					if( e is Windows.UI.Xaml.Controls.ComboBox)
+					{
+						yield break;
+					}
+				}
+			}
+
+			return string.Join("\n->", GetElements());
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ComboBoxItem_Selection.xaml.cs
@@ -45,7 +45,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
 				foreach (var o in element.GetParentHierarchy())
 				{
 					var e = o as FrameworkElement;
-					yield return $"{o.GetType().Name}{e?.Name}";
+					yield return $"{o.GetType().Name}[{e?.Name}]-{o}";
 					if( e is Windows.UI.Xaml.Controls.ComboBox)
 					{
 						yield break;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Corners.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Corners.xaml
@@ -1,0 +1,40 @@
+﻿<UserControl x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Corners"
+			 xmlns:controls="using:Uno.UI.Samples.Controls"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:Uno.UI.Samples.Content.UITests.ComboBox"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:xamarin="http:///umbrella/ui/xamarin"
+			 mc:Ignorable="d xamarin"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+  <controls:SampleControl SampleDescription="ComboBoxes located at the corners of the screen. The drop down should remain inside the window.">
+	<controls:SampleControl.SampleContent>
+	  <DataTemplate>
+
+		<Grid HorizontalAlignment="Stretch"
+			  VerticalAlignment="Stretch">
+
+		  <ComboBox ItemsSource="{Binding VariableLengthItems}"
+					VerticalAlignment="Top"
+					HorizontalAlignment="Left" />
+
+		  <ComboBox ItemsSource="{Binding VariableLengthItems}"
+					VerticalAlignment="Top"
+					HorizontalAlignment="Right" />
+
+		  <ComboBox ItemsSource="{Binding VariableLengthItems}"
+					VerticalAlignment="Bottom"
+					HorizontalAlignment="Left" />
+
+		  <ComboBox ItemsSource="{Binding VariableLengthItems}"
+					VerticalAlignment="Bottom"
+					HorizontalAlignment="Right"  />
+
+		</Grid>
+
+	  </DataTemplate>
+	</controls:SampleControl.SampleContent>
+  </controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Corners.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Corners.xaml
@@ -1,40 +1,45 @@
-﻿<UserControl x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Corners"
-			 xmlns:controls="using:Uno.UI.Samples.Controls"
-			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-			 xmlns:local="using:Uno.UI.Samples.Content.UITests.ComboBox"
-			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-			 xmlns:xamarin="http:///umbrella/ui/xamarin"
-			 mc:Ignorable="d xamarin"
-			 d:DesignHeight="300"
-			 d:DesignWidth="400">
-  <controls:SampleControl SampleDescription="ComboBoxes located at the corners of the screen. The drop down should remain inside the window.">
-	<controls:SampleControl.SampleContent>
-	  <DataTemplate>
+﻿<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Corners"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="http:///umbrella/ui/xamarin"
+	mc:Ignorable="d xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
 
-		<Grid HorizontalAlignment="Stretch"
-			  VerticalAlignment="Stretch">
+	<controls:SampleControl SampleDescription="ComboBoxes located at the corners of the screen. The drop down should remain inside the window.">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
 
-		  <ComboBox ItemsSource="{Binding VariableLengthItems}"
-					VerticalAlignment="Top"
-					HorizontalAlignment="Left" />
+				<Grid HorizontalAlignment="Stretch"
+					VerticalAlignment="Stretch">
 
-		  <ComboBox ItemsSource="{Binding VariableLengthItems}"
-					VerticalAlignment="Top"
-					HorizontalAlignment="Right" />
+					<TextBlock Text="{Binding}"
+						HorizontalAlignment="Center"
+						VerticalAlignment="Center" />
 
-		  <ComboBox ItemsSource="{Binding VariableLengthItems}"
-					VerticalAlignment="Bottom"
-					HorizontalAlignment="Left" />
+					<ComboBox ItemsSource="{Binding VariableLengthItems}"
+						VerticalAlignment="Top"
+						HorizontalAlignment="Left" />
 
-		  <ComboBox ItemsSource="{Binding VariableLengthItems}"
-					VerticalAlignment="Bottom"
-					HorizontalAlignment="Right"  />
+					<ComboBox ItemsSource="{Binding VariableLengthItems}"
+						VerticalAlignment="Top"
+						HorizontalAlignment="Right" />
 
-		</Grid>
+					<ComboBox ItemsSource="{Binding VariableLengthItems}"
+						VerticalAlignment="Bottom"
+						HorizontalAlignment="Left" />
 
-	  </DataTemplate>
-	</controls:SampleControl.SampleContent>
-  </controls:SampleControl>
+					<ComboBox ItemsSource="{Binding VariableLengthItems}"
+						VerticalAlignment="Bottom"
+						HorizontalAlignment="Right"  />
+
+				</Grid>
+
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Corners.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Corners.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_Corners", typeof(ListViewViewModel))]
+	public sealed partial class ComboBox_Corners : UserControl
+    {
+		public ComboBox_Corners()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Corners.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Corners.xaml.cs
@@ -1,16 +1,15 @@
 ﻿using Windows.UI.Xaml.Controls;
+using SamplesApp.Windows_UI_Xaml_Controls.ComboBox.Models;
 using Uno.UI.Samples.Controls;
-
-// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
 {
 	[SampleControlInfo("ComboBox", "ComboBox_Corners", typeof(ListViewViewModel))]
 	public sealed partial class ComboBox_Corners : UserControl
-    {
+	{
 		public ComboBox_Corners()
-        {
-            this.InitializeComponent();
-        }
-    }
+		{
+			this.InitializeComponent();
+		}
+	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DisplayMemberPath.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DisplayMemberPath.xaml
@@ -1,0 +1,19 @@
+﻿<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_DisplayMemberPath"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+  <StackPanel>
+
+	<TextBlock Text="You should see First, Second, Third, ..." />
+	<ComboBox ItemsSource="{Binding}"
+			  DisplayMemberPath="Name" />
+
+  </StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DisplayMemberPath.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DisplayMemberPath.xaml.cs
@@ -1,0 +1,33 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_DisplayMemberPath")]
+	public sealed partial class ComboBox_DisplayMemberPath : UserControl
+	{
+		public ComboBox_DisplayMemberPath()
+		{
+			this.InitializeComponent();
+
+			DataContext = new MyEntity[]
+			{
+				new MyEntity { Name = "First" },
+				new MyEntity { Name = "Second" },
+				new MyEntity { Name = "Third" },
+				new MyEntity { Name = "Fourth" },
+				new MyEntity { Name = "Fifth" },
+				new MyEntity { Name = "Sixth" },
+				new MyEntity { Name = "Seventh" },
+			};
+		}
+
+		public class MyEntity
+		{
+			public string Name { get; set; }
+
+			// We're using DisplayMemberPath="Name", therefore we shouldn't see MyEntity.ToString().
+			public override string ToString() => "If you see this text, there's a bug.";
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DropDownWidth.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DropDownWidth.xaml
@@ -1,0 +1,204 @@
+<UserControl x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_DropDownWidth"
+			 xmlns:controls="using:Uno.UI.Samples.Controls"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:Uno.UI.Samples.Content.UITests"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:android="http:///umbrella/ui/android"
+			 mc:Ignorable="d android"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+	<UserControl.Resources>
+		<Style x:Key="ComboBoxItemContainerStyle"
+			   TargetType="SelectorItem">
+			<Setter Property="Background"
+					Value="Red" />
+			<Setter Property="TabNavigation"
+					Value="Local" />
+			<Setter Property="Padding"
+					Value="12,14,12,13" />
+			<Setter Property="HorizontalContentAlignment"
+					Value="Center" />
+			<Setter Property="Foreground"
+					Value="Blue" />
+			<Setter Property="UseSystemFocusVisuals"
+					Value="True" />
+			<Setter Property="FontSize"
+					Value="16" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="SelectorItem">
+						<Border x:Name="LayoutRoot"
+								Background="{TemplateBinding Background}"
+								Control.IsTemplateFocusTarget="True">
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal">
+										<Storyboard>
+											<win:PointerUpThemeAnimation Storyboard.TargetName="LayoutRoot" />
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="PointerOver">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Red" />
+											</ObjectAnimationUsingKeyFrames>
+											<win:PointerUpThemeAnimation Storyboard.TargetName="LayoutRoot" />
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Disabled">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Grey" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Pressed">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Black" />
+											</ObjectAnimationUsingKeyFrames>
+											<win:PointerDownThemeAnimation Storyboard.TargetName="LayoutRoot" />
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Selected">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot"
+																		   Storyboard.TargetProperty="Background">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Purple" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Black" />
+											</ObjectAnimationUsingKeyFrames>
+											<win:PointerUpThemeAnimation Storyboard.TargetName="LayoutRoot" />
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="SelectedUnfocused">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot"
+																		   Storyboard.TargetProperty="Background">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Transparent" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Blue" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="SelectedDisabled">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot"
+																		   Storyboard.TargetProperty="Background">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Grey" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Grey" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="SelectedPointerOver">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot"
+																		   Storyboard.TargetProperty="Background">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Blue" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Red" />
+											</ObjectAnimationUsingKeyFrames>
+											<win:PointerUpThemeAnimation Storyboard.TargetName="LayoutRoot" />
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="SelectedPressed">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot"
+																		   Storyboard.TargetProperty="Background">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Blue" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+																		   Storyboard.TargetProperty="Foreground">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Red" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+							<ContentPresenter x:Name="ContentPresenter"
+											  Content="{TemplateBinding Content}"
+											  ContentTransitions="{TemplateBinding ContentTransitions}"
+											  ContentTemplate="{TemplateBinding ContentTemplate}"
+											  Foreground="{TemplateBinding Foreground}"
+											  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+											  Margin="{TemplateBinding Padding}" />
+						</Border>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+
+		<Style BasedOn="{StaticResource ComboBoxItemContainerStyle}"
+			   x:Key="BlueCombo"
+			   TargetType="SelectorItem">
+			<Setter Property="Background"
+					Value="Blue" />
+		</Style>
+	</UserControl.Resources>
+
+	<controls:SampleControl SampleDescription="Description for sample of ComboBox_DropDownWidth">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel>
+					<ComboBox Name="Box"
+							  Width="100"
+							  ItemsSource="{Binding [SampleItems]}"
+							  SelectedItem="{Binding [SelectedItem]}"
+							  ItemContainerStyle="{StaticResource ComboBoxItemContainerStyle}" >
+						<ComboBox.ItemTemplate>
+							<DataTemplate>
+								<TextBlock VerticalAlignment="Center"
+										   Foreground="Green"
+										   Text="{Binding }" />
+							</DataTemplate>
+						</ComboBox.ItemTemplate>
+					</ComboBox>
+					<ComboBox Name="Box2"
+							  Width="300"
+							  ItemsSource="{Binding [SampleItems]}"
+							  SelectedItem="{Binding [SelectedItem]}"
+							  ItemContainerStyle="{StaticResource BlueCombo}" >
+						<ComboBox.ItemTemplate>
+							<DataTemplate>
+								<TextBlock VerticalAlignment="Center"
+										   Foreground="Green"
+										   Text="{Binding }" />
+							</DataTemplate>
+						</ComboBox.ItemTemplate>
+					</ComboBox>
+					<ComboBox ItemsSource="{Binding [SampleItems]}"
+							  HorizontalAlignment="Stretch" />
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DropDownWidth.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DropDownWidth.xaml.cs
@@ -1,0 +1,28 @@
+using Uno.UI.Samples.Controls;
+
+#if NETFX_CORE
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+#elif XAMARIN
+using Windows.UI.Xaml.Controls;
+using System.Globalization;
+#endif
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_DropDownWidth", typeof(ListViewViewModel))]
+	public sealed partial class ComboBox_DropDownWidth : UserControl
+	{
+		public ComboBox_DropDownWidth()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DropDownWidth.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_DropDownWidth.xaml.cs
@@ -1,19 +1,6 @@
+using SamplesApp.Windows_UI_Xaml_Controls.ComboBox.Models;
 using Uno.UI.Samples.Controls;
-
-#if NETFX_CORE
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
-#elif XAMARIN
-using Windows.UI.Xaml.Controls;
-using System.Globalization;
-#endif
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
 {

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Empty.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Empty.xaml
@@ -1,0 +1,22 @@
+﻿<UserControl x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Empty"
+			 xmlns:controls="using:Uno.UI.Samples.Controls"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:Uno.UI.Samples.Content.UITests.ComboBox"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:xamarin="http:///umbrella/ui/xamarin"
+			 mc:Ignorable="d xamarin"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="ComboBox without ItemsSource">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+
+				<ComboBox />
+
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Empty.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Empty.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_Empty", typeof(ListViewViewModel))]
+	public sealed partial class ComboBox_Empty : UserControl
+	{
+		public ComboBox_Empty()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Empty.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Empty.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using Windows.UI.Xaml.Controls;
+using SamplesApp.Windows_UI_Xaml_Controls.ComboBox.Models;
 using Uno.UI.Samples.Controls;
-
-// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
 {

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Header.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Header.xaml
@@ -1,0 +1,26 @@
+﻿<UserControl x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Header"
+			 xmlns:controls="using:Uno.UI.Samples.Controls"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:Uno.UI.Samples.Content.UITests.ComboBox"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:xamarin="http:///umbrella/ui/xamarin"
+			 mc:Ignorable="d xamarin"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="ComboBox with Header">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+
+				<StackPanel>
+					<ComboBox Header="{Binding [Header]}" />
+					<Button Content="Toggle header"
+							Command="{Binding [ToggleHeader]}" />
+				</StackPanel>
+
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Header.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Header.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_Header", typeof(ComboBoxViewModel))]
+	public sealed partial class ComboBox_Header : UserControl
+    {
+        public ComboBox_Header()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Header.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Header.xaml.cs
@@ -1,16 +1,15 @@
 ﻿using Windows.UI.Xaml.Controls;
+using SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.Models;
 using Uno.UI.Samples.Controls;
-
-// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
 {
 	[SampleControlInfo("ComboBox", "ComboBox_Header", typeof(ComboBoxViewModel))]
 	public sealed partial class ComboBox_Header : UserControl
-    {
-        public ComboBox_Header()
-        {
-            this.InitializeComponent();
-        }
-    }
+	{
+		public ComboBox_Header()
+		{
+			this.InitializeComponent();
+		}
+	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ItemsSource.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ItemsSource.xaml
@@ -1,0 +1,22 @@
+﻿<UserControl x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_ItemsSource"
+			 xmlns:controls="using:Uno.UI.Samples.Controls"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:Uno.UI.Samples.Content.UITests.ComboBox"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:xamarin="http:///umbrella/ui/xamarin"
+			 mc:Ignorable="d xamarin"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="ComboBox with ItemsSource">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+
+				<ComboBox ItemsSource="{Binding [SampleItems]}" />
+
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ItemsSource.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ItemsSource.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_ItemsSource", typeof(ListViewViewModel))]
+	public sealed partial class ComboBox_ItemsSource : UserControl
+    {
+        public ComboBox_ItemsSource()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ItemsSource.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ItemsSource.xaml.cs
@@ -1,16 +1,15 @@
 ﻿using Windows.UI.Xaml.Controls;
+using SamplesApp.Windows_UI_Xaml_Controls.ComboBox.Models;
 using Uno.UI.Samples.Controls;
-
-// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
 {
 	[SampleControlInfo("ComboBox", "ComboBox_ItemsSource", typeof(ListViewViewModel))]
 	public sealed partial class ComboBox_ItemsSource : UserControl
-    {
-        public ComboBox_ItemsSource()
-        {
-            this.InitializeComponent();
-        }
-    }
+	{
+		public ComboBox_ItemsSource()
+		{
+			this.InitializeComponent();
+		}
+	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Legacy.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Legacy.xaml
@@ -1,0 +1,275 @@
+﻿<UserControl
+    x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Legacy"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Samples.Content.UITests.ComboBox"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+  <UserControl.Resources>
+	<Style x:Key="LegacyComboBoxStyle"
+		   TargetType="ComboBox">
+	  <Setter Property="Padding"
+			  Value="12,5,0,7" />
+	  <Setter Property="MinWidth"
+			  Value="{ThemeResource ComboBoxThemeMinWidth}" />
+	  <Setter Property="Foreground"
+			  Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
+	  <Setter Property="Background"
+			  Value="{ThemeResource SystemControlBackgroundAltMediumLowBrush}" />
+	  <Setter Property="BorderBrush"
+			  Value="{ThemeResource SystemControlForegroundBaseMediumLowBrush}" />
+	  <Setter Property="BorderThickness"
+			  Value="{ThemeResource ComboBoxBorderThemeThickness}" />
+	  <Setter Property="TabNavigation"
+			  Value="Once" />
+	  <Setter Property="ScrollViewer.HorizontalScrollBarVisibility"
+			  Value="Disabled" />
+	  <Setter Property="ScrollViewer.VerticalScrollBarVisibility"
+			  Value="Auto" />
+	  <Setter Property="ScrollViewer.HorizontalScrollMode"
+			  Value="Disabled" />
+	  <Setter Property="ScrollViewer.VerticalScrollMode"
+			  Value="Auto" />
+	  <Setter Property="ScrollViewer.IsVerticalRailEnabled"
+			  Value="True" />
+	  <Setter Property="ScrollViewer.IsDeferredScrollingEnabled"
+			  Value="False" />
+	  <Setter Property="ScrollViewer.BringIntoViewOnFocusChange"
+			  Value="True" />
+	  <Setter Property="HorizontalContentAlignment"
+			  Value="Stretch" />
+	  <Setter Property="HorizontalAlignment"
+			  Value="Left" />
+	  <Setter Property="VerticalAlignment"
+			  Value="Top" />
+	  <Setter Property="FontFamily"
+			  Value="{ThemeResource ContentControlThemeFontFamily}" />
+	  <Setter Property="FontSize"
+			  Value="{ThemeResource ControlContentThemeFontSize}" />
+	  <Setter Property="Template">
+		<Setter.Value>
+		  <ControlTemplate TargetType="ComboBox">
+			<Grid>
+			  <Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
+			  </Grid.RowDefinitions>
+			  <Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="32" />
+			  </Grid.ColumnDefinitions>
+			  <VisualStateManager.VisualStateGroups>
+				<VisualStateGroup x:Name="CommonStates">
+				  <VisualState x:Name="Normal" />
+				  <VisualState x:Name="PointerOver">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlPageBackgroundAltMediumBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightBaseMediumBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Pressed">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlBackgroundListMediumBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Disabled">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				</VisualStateGroup>
+				<VisualStateGroup x:Name="FocusStates">
+				  <VisualState x:Name="Focused">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HighlightBackground"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightTransparentBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <DoubleAnimation Storyboard.TargetName="HighlightBackground"
+									   Storyboard.TargetProperty="Opacity"
+									   To="1"
+									   Duration="0" />
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="FocusedPressed">
+					<Storyboard>
+					  <DoubleAnimation Storyboard.TargetName="HighlightBackground"
+									   Storyboard.TargetProperty="Opacity"
+									   To="1"
+									   Duration="0" />
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Unfocused" />
+				  <VisualState x:Name="PointerFocused" />
+				  <VisualState x:Name="FocusedDropDown">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PopupBorder"
+													 Storyboard.TargetProperty="Visibility"
+													 Duration="0">
+						<DiscreteObjectKeyFrame KeyTime="0">
+						  <DiscreteObjectKeyFrame.Value>
+							<Visibility>Visible</Visibility>
+						  </DiscreteObjectKeyFrame.Value>
+						</DiscreteObjectKeyFrame>
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				</VisualStateGroup>
+				<VisualStateGroup x:Name="DropDownStates">
+				  <VisualState x:Name="Opened" />
+				  <VisualState x:Name="Closed" />
+				</VisualStateGroup>
+			  </VisualStateManager.VisualStateGroups>
+			  <ContentPresenter x:Name="HeaderContentPresenter"
+								x:DeferLoadStrategy="Lazy"
+								Margin="{ThemeResource ComboBoxHeaderThemeMargin}"
+								FlowDirection="{TemplateBinding FlowDirection}"
+								FontWeight="{ThemeResource ComboBoxHeaderThemeFontWeight}"
+								Visibility="Collapsed"
+								Content="{TemplateBinding Header}"
+								ContentTemplate="{TemplateBinding HeaderTemplate}" />
+			  <Border x:Name="Background"
+					  Grid.Row="1"
+					  Grid.ColumnSpan="2"
+					  Background="{TemplateBinding Background}"
+					  BorderBrush="{TemplateBinding BorderBrush}"
+					  BorderThickness="{TemplateBinding BorderThickness}" />
+			  <Border x:Name="HighlightBackground"
+					  Grid.Row="1"
+					  Grid.ColumnSpan="2"
+					  Background="{ThemeResource SystemControlHighlightListAccentLowBrush}"
+					  BorderBrush="{ThemeResource SystemControlHighlightBaseMediumLowBrush}"
+					  BorderThickness="{TemplateBinding BorderThickness}"
+					  Opacity="0" />
+			  <ContentPresenter x:Name="ContentPresenter"
+								Grid.Row="1"
+								ContentTemplate="{TemplateBinding ItemTemplate}"
+								ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+								Margin="{TemplateBinding Padding}"
+								HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+								VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+				<TextBlock x:Name="PlaceholderTextBlock"
+						   Text="{TemplateBinding PlaceholderText}"
+						   Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}" />
+			  </ContentPresenter>
+			  <FontIcon x:Name="DropDownGlyph"
+						Grid.Row="1"
+						Grid.Column="1"
+						IsHitTestVisible="False"
+						Margin="0,10,10,10"
+						Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+						FontFamily="{ThemeResource SymbolThemeFontFamily}"
+						FontSize="12"
+						Glyph="&#xE0E5;"
+						HorizontalAlignment="Right"
+						VerticalAlignment="Center"
+						AutomationProperties.AccessibilityView="Raw" />
+			  <Popup x:Name="Popup">
+				<Border x:Name="PopupBorder"
+						Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"
+						BorderBrush="{ThemeResource SystemControlForegroundChromeHighBrush}"
+						BorderThickness="{ThemeResource ComboBoxDropdownBorderThickness}"
+						Margin="0,-1,0,-1"
+						HorizontalAlignment="Stretch">
+				  <ListView MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownContentMinWidth}"
+									ItemsSource="{TemplateBinding ItemsSource}"
+									ItemTemplate="{TemplateBinding ItemTemplate}"
+									ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+									ItemContainerStyle="{TemplateBinding ItemContainerStyle}"
+									SelectedItem="{Binding SelectedItem, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}" />
+				</Border>
+			  </Popup>
+			</Grid>
+		  </ControlTemplate>
+		</Setter.Value>
+	  </Setter>
+	</Style>
+  </UserControl.Resources>
+
+  <Grid>
+	<ComboBox Style="{StaticResource LegacyComboBoxStyle}"
+			  ItemsSource="{Binding [SampleItems]}" />
+  </Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Legacy.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Legacy.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_Legacy", typeof(ListViewViewModel))]
+    public sealed partial class ComboBox_Legacy : UserControl
+    {
+        public ComboBox_Legacy()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Legacy.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Legacy.xaml.cs
@@ -1,16 +1,15 @@
 ﻿using Windows.UI.Xaml.Controls;
+using SamplesApp.Windows_UI_Xaml_Controls.ComboBox.Models;
 using Uno.UI.Samples.Controls;
-
-// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
 {
 	[SampleControlInfo("ComboBox", "ComboBox_Legacy", typeof(ListViewViewModel))]
-    public sealed partial class ComboBox_Legacy : UserControl
-    {
-        public ComboBox_Legacy()
-        {
-            this.InitializeComponent();
-        }
-    }
+	public sealed partial class ComboBox_Legacy : UserControl
+	{
+		public ComboBox_Legacy()
+		{
+			this.InitializeComponent();
+		}
+	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_NativePopup.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_NativePopup.xaml
@@ -1,0 +1,328 @@
+﻿<UserControl
+    x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_NativePopup"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:not_ios="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Uno.UI.Samples.Content.UITests.ComboBox"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android xamarin">
+
+  <UserControl.Resources>
+
+	<!-- Default style for Windows.UI.Xaml.Controls.ComboBox -->
+	<android:Style x:Key="NativePopupComboBoxStyle"
+				   TargetType="ComboBox">
+	  <Setter Property="Padding"
+			  Value="12,5,0,7" />
+	  <Setter Property="MinWidth"
+			  Value="{ThemeResource ComboBoxThemeMinWidth}" />
+	  <Setter Property="Foreground"
+			  Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
+	  <Setter Property="Background"
+			  Value="{ThemeResource SystemControlBackgroundAltMediumLowBrush}" />
+	  <Setter Property="BorderBrush"
+			  Value="{ThemeResource SystemControlForegroundBaseMediumLowBrush}" />
+	  <Setter Property="BorderThickness"
+			  Value="{ThemeResource ComboBoxBorderThemeThickness}" />
+	  <Setter Property="TabNavigation"
+			  Value="Once" />
+	  <Setter Property="ScrollViewer.HorizontalScrollBarVisibility"
+			  Value="Disabled" />
+	  <Setter Property="ScrollViewer.VerticalScrollBarVisibility"
+			  Value="Auto" />
+	  <Setter Property="ScrollViewer.HorizontalScrollMode"
+			  Value="Disabled" />
+	  <Setter Property="ScrollViewer.VerticalScrollMode"
+			  Value="Auto" />
+	  <Setter Property="ScrollViewer.IsVerticalRailEnabled"
+			  Value="True" />
+	  <Setter Property="ScrollViewer.IsDeferredScrollingEnabled"
+			  Value="False" />
+	  <Setter Property="ScrollViewer.BringIntoViewOnFocusChange"
+			  Value="True" />
+	  <Setter Property="HorizontalContentAlignment"
+			  Value="Stretch" />
+	  <Setter Property="HorizontalAlignment"
+			  Value="Left" />
+	  <Setter Property="VerticalAlignment"
+			  Value="Top" />
+	  <Setter Property="FontFamily"
+			  Value="{ThemeResource ContentControlThemeFontFamily}" />
+	  <Setter Property="FontSize"
+			  Value="{ThemeResource ControlContentThemeFontSize}" />
+	  <Setter Property="ItemsPanel">
+		<Setter.Value>
+		  <ItemsPanelTemplate>
+			<CarouselPanel />
+		  </ItemsPanelTemplate>
+		</Setter.Value>
+	  </Setter>
+	  <Setter Property="Template">
+		<Setter.Value>
+		  <ControlTemplate TargetType="ComboBox">
+			<Grid>
+			  <Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
+			  </Grid.RowDefinitions>
+			  <Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="32" />
+			  </Grid.ColumnDefinitions>
+			  <VisualStateManager.VisualStateGroups>
+				<VisualStateGroup x:Name="CommonStates">
+				  <VisualState x:Name="Normal" />
+				  <VisualState x:Name="PointerOver">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlPageBackgroundAltMediumBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightBaseMediumBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Pressed">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlBackgroundListMediumBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Disabled">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				</VisualStateGroup>
+				<VisualStateGroup x:Name="FocusStates">
+				  <VisualState x:Name="Focused">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HighlightBackground"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightTransparentBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <DoubleAnimation Storyboard.TargetName="HighlightBackground"
+									   Storyboard.TargetProperty="Opacity"
+									   To="1"
+									   Duration="0" />
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="FocusedPressed">
+					<Storyboard>
+					  <DoubleAnimation Storyboard.TargetName="HighlightBackground"
+									   Storyboard.TargetProperty="Opacity"
+									   To="1"
+									   Duration="0" />
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Unfocused" />
+				  <VisualState x:Name="PointerFocused" />
+				  <VisualState x:Name="FocusedDropDown">
+					<Storyboard>
+					  <not_ios:ObjectAnimationUsingKeyFrames Storyboard.TargetName="PopupBorder"
+															 Storyboard.TargetProperty="Visibility"
+															 Duration="0">
+						<DiscreteObjectKeyFrame KeyTime="0">
+						  <DiscreteObjectKeyFrame.Value>
+							<Visibility>Visible</Visibility>
+						  </DiscreteObjectKeyFrame.Value>
+						</DiscreteObjectKeyFrame>
+					  </not_ios:ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				</VisualStateGroup>
+				<VisualStateGroup x:Name="DropDownStates">
+				  <VisualState x:Name="Opened">
+					<Storyboard>
+					  <win:SplitOpenThemeAnimation OpenedTargetName="PopupBorder"
+												   ClosedTargetName="ContentPresenter"
+												   OffsetFromCenter="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOffset}"
+												   OpenedLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOpenedHeight}" />
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Closed">
+					<Storyboard>
+					  <win:SplitCloseThemeAnimation OpenedTargetName="PopupBorder"
+													ClosedTargetName="ContentPresenter"
+													OffsetFromCenter="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOffset}"
+													OpenedLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOpenedHeight}" />
+					</Storyboard>
+				  </VisualState>
+				</VisualStateGroup>
+			  </VisualStateManager.VisualStateGroups>
+			  <ContentPresenter x:Name="HeaderContentPresenter"
+								x:DeferLoadStrategy="Lazy"
+								Margin="{ThemeResource ComboBoxHeaderThemeMargin}"
+								FlowDirection="{TemplateBinding FlowDirection}"
+								FontWeight="{ThemeResource ComboBoxHeaderThemeFontWeight}"
+								Visibility="Collapsed"
+								Content="{TemplateBinding Header}"
+								ContentTemplate="{TemplateBinding HeaderTemplate}" />
+			  <Border x:Name="Background"
+					  Grid.Row="1"
+					  Grid.ColumnSpan="2"
+					  Background="{TemplateBinding Background}"
+					  BorderBrush="{TemplateBinding BorderBrush}"
+					  BorderThickness="{TemplateBinding BorderThickness}" />
+			  <Border x:Name="HighlightBackground"
+					  Grid.Row="1"
+					  Grid.ColumnSpan="2"
+					  Background="{ThemeResource SystemControlHighlightListAccentLowBrush}"
+					  BorderBrush="{ThemeResource SystemControlHighlightBaseMediumLowBrush}"
+					  BorderThickness="{TemplateBinding BorderThickness}"
+					  Opacity="0" />
+			  <ContentPresenter x:Name="ContentPresenter"
+								Grid.Row="1"
+								Margin="{TemplateBinding Padding}"
+								HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+								VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+				<TextBlock x:Name="PlaceholderTextBlock"
+						   Text="{TemplateBinding PlaceholderText}"
+						   Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}" />
+			  </ContentPresenter>
+			  <not_android:FontIcon x:Name="DropDownGlyph"
+									Grid.Row="1"
+									Grid.Column="1"
+									IsHitTestVisible="False"
+									Margin="0,10,10,10"
+									Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+									FontFamily="{ThemeResource SymbolThemeFontFamily}"
+									FontSize="12"
+									Glyph="&#xE0E5;"
+									HorizontalAlignment="Right"
+									VerticalAlignment="Center"
+									AutomationProperties.AccessibilityView="Raw" />
+			  <android:TextBlock x:Name="DropDownGlyph"
+								 Grid.Row="1"
+								 Grid.Column="1"
+								 IsHitTestVisible="False"
+								 Margin="0,10,10,10"
+								 Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+								 FontFamily="{ThemeResource SymbolThemeFontFamily}"
+								 FontSize="12"
+								 Text="&#xE0E5;"
+								 HorizontalAlignment="Right"
+								 VerticalAlignment="Center"
+								 AutomationProperties.AccessibilityView="Raw" />
+			  <android:NativePopup x:Name="Popup"
+								   Anchor="{Binding ElementName=Background}">
+				<Border x:Name="PopupBorder"
+						Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"
+						BorderBrush="{ThemeResource SystemControlForegroundChromeHighBrush}"
+						BorderThickness="{ThemeResource ComboBoxDropdownBorderThickness}"
+						Margin="0,-1,0,-1"
+						HorizontalAlignment="Stretch">
+				  <ScrollViewer x:Name="ScrollViewer"
+								Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+								MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownContentMinWidth}"
+								VerticalSnapPointsType="OptionalSingle"
+								VerticalSnapPointsAlignment="Near"
+								HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+								HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+								VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+								VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+								IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+								IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+								IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+								BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
+								ZoomMode="Disabled"
+								AutomationProperties.AccessibilityView="Raw">
+					<ItemsPresenter />
+				  </ScrollViewer>
+				</Border>
+			  </android:NativePopup>
+			</Grid>
+		  </ControlTemplate>
+		</Setter.Value>
+	  </Setter>
+	</android:Style>
+
+  </UserControl.Resources>
+
+  <StackPanel>
+	<not_android:TextBlock Text="NativePopup is only supported on Android." />
+	<android:ComboBox Style="{StaticResource NativePopupComboBoxStyle}"
+					  ItemsSource="{Binding [SampleItems]}" />
+	<android:ComboBox Style="{StaticResource NativePopupComboBoxStyle}"
+					  ItemsSource="{Binding VariableLengthItems}" />
+  </StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_NativePopup.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_NativePopup.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_NativePopup", typeof(ListViewViewModel))]
+	public sealed partial class ComboBox_NativePopup : UserControl
+	{
+		public ComboBox_NativePopup()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_NativePopup.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_NativePopup.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Windows.UI.Xaml.Controls;
+using SamplesApp.Windows_UI_Xaml_Controls.ComboBox.Models;
 using Uno.UI.Samples.Controls;
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Picker.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Picker.xaml
@@ -1,0 +1,367 @@
+﻿<UserControl
+    x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Picker"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Samples.Content.UITests.ComboBox"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://nventive.com/ios"
+	xmlns:xamarin="http://nventive.com/xamarin"
+	xmlns:android="http://nventive.com/android"
+	xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    mc:Ignorable="d ios xamarin android"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+  <UserControl.Resources>
+
+	<Style x:Key="PickerComboBoxStyle"
+	   TargetType="ComboBox">
+	  <!-- Default Windows Value + changed 12 to 10 to match TextBox padding -->
+	  <Setter Property="Padding"
+				  Value="10,10,0,7" />
+	  <ios:Setter Property="IsPopupFullscreen"
+				  Value="True" />
+	  <Setter Property="HorizontalContentAlignment"
+			  Value="Stretch" />
+	  <Setter Property="Template">
+		<Setter.Value>
+		  <ControlTemplate TargetType="ComboBox">
+			<Grid>
+			  <Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
+			  </Grid.RowDefinitions>
+			  <Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="32" />
+			  </Grid.ColumnDefinitions>
+			  <VisualStateManager.VisualStateGroups>
+				<VisualStateGroup x:Name="CommonStates">
+				  <VisualState x:Name="Normal" />
+				  <VisualState x:Name="PointerOver">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlPageBackgroundAltMediumBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightBaseMediumBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Pressed">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlBackgroundListMediumBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Disabled">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				</VisualStateGroup>
+				<VisualStateGroup x:Name="FocusStates">
+				  <VisualState x:Name="Focused">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HighlightBackground"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightTransparentBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <DoubleAnimation Storyboard.TargetName="HighlightBackground"
+									   Storyboard.TargetProperty="Opacity"
+									   To="1"
+									   Duration="0" />
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="FocusedPressed">
+					<Storyboard>
+					  <DoubleAnimation Storyboard.TargetName="HighlightBackground"
+									   Storyboard.TargetProperty="Opacity"
+									   To="1"
+									   Duration="0" />
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Unfocused" />
+				  <VisualState x:Name="PointerFocused" />
+				  <VisualState x:Name="FocusedDropDown">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PopupBorder"
+													 Storyboard.TargetProperty="Visibility"
+													 Duration="0">
+						<DiscreteObjectKeyFrame KeyTime="0">
+						  <DiscreteObjectKeyFrame.Value>
+							<Visibility>Visible</Visibility>
+						  </DiscreteObjectKeyFrame.Value>
+						</DiscreteObjectKeyFrame>
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				</VisualStateGroup>
+				<VisualStateGroup x:Name="DropDownStates">
+				  <VisualState x:Name="Opened">
+					<Storyboard>
+					  <win:SplitOpenThemeAnimation OpenedTargetName="PopupBorder"
+												   ClosedTargetName="ContentPresenter"
+												   OffsetFromCenter="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOffset}"
+												   OpenedLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOpenedHeight}" />
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="IsOpen"
+													 Storyboard.TargetName="Popup">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="True" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <DoubleAnimation Storyboard.TargetProperty="Y"
+									   Storyboard.TargetName="PopupContentTransform"
+									   Duration="0:0:0.3"
+									   To="0"/>
+					  <DoubleAnimation Storyboard.TargetProperty="Opacity"
+									   Storyboard.TargetName="PopupBackground"
+									   Duration="0:0:0.3"
+									   To="1"/>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Closed">
+					<Storyboard>
+					  <win:SplitCloseThemeAnimation OpenedTargetName="PopupBorder"
+													ClosedTargetName="ContentPresenter"
+													OffsetFromCenter="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOffset}"
+													OpenedLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOpenedHeight}" />
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="IsOpen"
+													 Storyboard.TargetName="Popup">
+						<DiscreteObjectKeyFrame KeyTime="0:0:0.3"
+												Value="False" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <DoubleAnimation Storyboard.TargetProperty="Y"
+									   Storyboard.TargetName="PopupContentTransform"
+									   Duration="0:0:0.3"
+									   To="260"/>
+					  <DoubleAnimation Storyboard.TargetProperty="Opacity"
+									   Storyboard.TargetName="PopupBackground"
+									   Duration="0:0:0.3"
+									   To="0"/>
+					</Storyboard>
+				  </VisualState>
+				</VisualStateGroup>
+			  </VisualStateManager.VisualStateGroups>
+			  <ContentPresenter x:Name="HeaderContentPresenter"
+								x:DeferLoadStrategy="Lazy"
+								Margin="{ThemeResource ComboBoxHeaderThemeMargin}"
+								FlowDirection="{TemplateBinding FlowDirection}"
+								FontWeight="{ThemeResource ComboBoxHeaderThemeFontWeight}"
+								Visibility="Collapsed"
+								Content="{TemplateBinding Header}"
+								ContentTemplate="{TemplateBinding HeaderTemplate}" />
+			  <Border x:Name="Background"
+					  Grid.Row="1"
+					  Grid.ColumnSpan="2"
+					  Background="{TemplateBinding Background}"
+					  BorderBrush="{TemplateBinding BorderBrush}"
+					  BorderThickness="{TemplateBinding BorderThickness}" />
+			  <Border x:Name="HighlightBackground"
+					  Grid.Row="1"
+					  Grid.ColumnSpan="2"
+					  Background="{ThemeResource SystemControlHighlightListAccentLowBrush}"
+					  BorderBrush="{ThemeResource SystemControlHighlightBaseMediumLowBrush}"
+					  BorderThickness="{TemplateBinding BorderThickness}"
+					  Opacity="0" />
+			  <ContentPresenter x:Name="ContentPresenter"
+								Grid.Row="1"
+								ContentTemplate="{TemplateBinding ItemTemplate}"
+								ContentTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+								Margin="{TemplateBinding Padding}"
+								HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+								VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+				<TextBlock x:Name="PlaceholderTextBlock"
+						   Text="{TemplateBinding PlaceholderText}"
+						   Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}" />
+			  </ContentPresenter>
+			  <not_android:FontIcon x:Name="DropDownGlyph"
+									Grid.Row="1"
+									Grid.Column="1"
+									IsHitTestVisible="False"
+									Margin="0,10,10,10"
+									Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+									FontFamily="{ThemeResource SymbolThemeFontFamily}"
+									FontSize="12"
+									Glyph="&#xE0E5;"
+									HorizontalAlignment="Right"
+									VerticalAlignment="Center"
+									AutomationProperties.AccessibilityView="Raw" />
+			  <android:TextBlock x:Name="DropDownGlyph"
+								 Grid.Row="1"
+								 Grid.Column="1"
+								 IsHitTestVisible="False"
+								 Margin="0,10,10,10"
+								 Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+								 FontFamily="{ThemeResource SymbolThemeFontFamily}"
+								 FontSize="12"
+								 Text="&#xE0E5;"
+								 HorizontalAlignment="Right"
+								 VerticalAlignment="Center"
+								 AutomationProperties.AccessibilityView="Raw" />
+			  <Popup x:Name="Popup"
+					 IsLightDismissEnabled="False">
+				<Popup.Child>
+				  <Grid>
+					<Border x:Name="PopupBackground"
+							Background="#8000"
+							Opacity="0" />
+					<Border x:Name="PopupBorder"
+							Background="White"
+							VerticalAlignment="Bottom">
+					  <Border.RenderTransform>
+						<TranslateTransform x:Name="PopupContentTransform"
+											Y="260" />
+					  </Border.RenderTransform>
+					  <StackPanel>
+						<Border Height="44"
+								Background="RoyalBlue">
+						  <ToggleButton Content="OK"
+										x:Uid="ComboBox_Done"
+										IsChecked="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
+										Padding="0,0,15,0"
+										HorizontalAlignment="Right"
+										VerticalContentAlignment="Center"
+										HorizontalContentAlignment="Center"
+										VerticalAlignment="Stretch">
+							<ToggleButton.Template>
+							  <ControlTemplate>
+								<!-- Non-null background ensures the button can be hit (workaround that's not necessary on Windows) -->
+								<Border Background="Transparent">
+								  <TextBlock FontSize="16"
+											 Foreground="White"
+											 Margin="0,0,15,0"
+											 VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+											 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+											 Text="{TemplateBinding Content}" />
+								</Border>
+							  </ControlTemplate>
+							</ToggleButton.Template>
+						  </ToggleButton>
+						</Border>
+						<ios:Picker	Height="180"
+									Placeholder="{TemplateBinding PlaceholderText}"
+									ItemTemplateSelector="{TemplateBinding ItemTemplateSelector}"
+									DisplayMemberPath="{TemplateBinding DisplayMemberPath}"
+									ItemTemplate="{TemplateBinding ItemTemplate}"
+									ItemsSource="{TemplateBinding ItemsSource}"
+									ItemContainerStyle="{StaticResource PickerItemStyle}"
+									SelectedItem="{Binding SelectedItem, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}" />
+					  </StackPanel>
+					</Border>
+				  </Grid>
+				</Popup.Child>
+			  </Popup>
+			</Grid>
+		  </ControlTemplate>
+		</Setter.Value>
+	  </Setter>
+	</Style>
+
+	<ios:Style x:Key="PickerItemStyle"
+			   TargetType="SelectorItem">
+	  <Setter Property="FontSize"
+			  Value="22" />
+	  <Setter Property="FontWeight"
+			   Value="Medium" />
+	  <Setter Property="VerticalContentAlignment"
+			  Value="Center" />
+	  <Setter Property="HorizontalContentAlignment"
+			  Value="Center" />
+	  <Setter Property="Template">
+		<Setter.Value>
+		  <ControlTemplate TargetType="SelectorItem">
+			<ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+							  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+							  Content="{TemplateBinding Content}"
+							  ContentTemplate="{TemplateBinding ContentTemplate}"
+							  ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}" />
+		  </ControlTemplate>
+		</Setter.Value>
+	  </Setter>
+	</ios:Style>
+
+  </UserControl.Resources>
+
+  <StackPanel>
+
+	<TextBlock Text="This sample only works on iOS" />
+	<ios:ComboBox ItemsSource="{Binding VariableLengthItems}"
+				  Style="{StaticResource PickerComboBoxStyle}" />
+
+  </StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Picker.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Picker.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_Picker", typeof(ListViewViewModel))]
+    public sealed partial class ComboBox_Picker : UserControl
+    {
+        public ComboBox_Picker()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Picker.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Picker.xaml.cs
@@ -1,16 +1,15 @@
 ﻿using Windows.UI.Xaml.Controls;
+using SamplesApp.Windows_UI_Xaml_Controls.ComboBox.Models;
 using Uno.UI.Samples.Controls;
-
-// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
 {
 	[SampleControlInfo("ComboBox", "ComboBox_Picker", typeof(ListViewViewModel))]
-    public sealed partial class ComboBox_Picker : UserControl
-    {
-        public ComboBox_Picker()
-        {
-            this.InitializeComponent();
-        }
-    }
+	public sealed partial class ComboBox_Picker : UserControl
+	{
+		public ComboBox_Picker()
+		{
+			this.InitializeComponent();
+		}
+	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_PlaceholderText.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_PlaceholderText.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_PlaceholderText"
+			 xmlns:controls="using:Uno.UI.Samples.Controls"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:Uno.UI.Samples.Content.UITests.ComboBox"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:xamarin="http:///umbrella/ui/xamarin"
+			 mc:Ignorable="d xamarin"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="ComboBox with PlaceholderText">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+
+				<ComboBox PlaceholderText="PlaceholderText"
+						  ItemsSource="{Binding [SampleItems]}" />
+
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_PlaceholderText.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_PlaceholderText.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_PlaceholderText", typeof(ListViewViewModel))]
+	public sealed partial class ComboBox_PlaceholderText : UserControl
+    {
+        public ComboBox_PlaceholderText()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_PlaceholderText.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_PlaceholderText.xaml.cs
@@ -1,16 +1,15 @@
 ﻿using Windows.UI.Xaml.Controls;
+using SamplesApp.Windows_UI_Xaml_Controls.ComboBox.Models;
 using Uno.UI.Samples.Controls;
-
-// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
 {
 	[SampleControlInfo("ComboBox", "ComboBox_PlaceholderText", typeof(ListViewViewModel))]
 	public sealed partial class ComboBox_PlaceholderText : UserControl
-    {
-        public ComboBox_PlaceholderText()
-        {
-            this.InitializeComponent();
-        }
-    }
+	{
+		public ComboBox_PlaceholderText()
+		{
+			this.InitializeComponent();
+		}
+	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Popover.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Popover.xaml
@@ -1,0 +1,359 @@
+﻿<UserControl x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_Popover"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:not_android="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:not_ios="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:Uno.UI.Samples.Content.UITests.ComboBox"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:xamarin="http://uno.ui/xamarin"
+			 xmlns:ios="http://uno.ui/ios"
+			 xmlns:android="http://uno.ui/android"
+			 mc:Ignorable="d ios android xamarin"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+  <UserControl.Resources>
+
+	<!-- Default style for Windows.UI.Xaml.Controls.ComboBox -->
+	<xamarin:Style x:Key="iPadComboBoxStyle"
+				   TargetType="ComboBox">
+	  <xamarin:Setter Property="ItemContainerStyle"
+					  Value="{StaticResource DefaultComboBoxItemStyle}">
+	  </xamarin:Setter>
+	  <Setter Property="Padding"
+			  Value="12,5,0,7" />
+	  <Setter Property="MinWidth"
+			  Value="{ThemeResource ComboBoxThemeMinWidth}" />
+	  <Setter Property="Foreground"
+			  Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
+	  <Setter Property="Background"
+			  Value="{ThemeResource SystemControlBackgroundAltMediumLowBrush}" />
+	  <Setter Property="BorderBrush"
+			  Value="{ThemeResource SystemControlForegroundBaseMediumLowBrush}" />
+	  <Setter Property="BorderThickness"
+			  Value="{ThemeResource ComboBoxBorderThemeThickness}" />
+	  <Setter Property="TabNavigation"
+			  Value="Once" />
+	  <Setter Property="ScrollViewer.HorizontalScrollBarVisibility"
+			  Value="Disabled" />
+	  <Setter Property="ScrollViewer.VerticalScrollBarVisibility"
+			  Value="Auto" />
+	  <Setter Property="ScrollViewer.HorizontalScrollMode"
+			  Value="Disabled" />
+	  <Setter Property="ScrollViewer.VerticalScrollMode"
+			  Value="Auto" />
+	  <Setter Property="ScrollViewer.IsVerticalRailEnabled"
+			  Value="True" />
+	  <Setter Property="ScrollViewer.IsDeferredScrollingEnabled"
+			  Value="False" />
+	  <Setter Property="ScrollViewer.BringIntoViewOnFocusChange"
+			  Value="True" />
+	  <Setter Property="HorizontalContentAlignment"
+			  Value="Stretch" />
+	  <Setter Property="HorizontalAlignment"
+			  Value="Left" />
+	  <Setter Property="VerticalAlignment"
+			  Value="Top" />
+	  <Setter Property="FontFamily"
+			  Value="{ThemeResource ContentControlThemeFontFamily}" />
+	  <Setter Property="FontSize"
+			  Value="{ThemeResource ControlContentThemeFontSize}" />
+	  <Setter Property="ItemsPanel">
+		<Setter.Value>
+		  <ItemsPanelTemplate>
+			<CarouselPanel />
+		  </ItemsPanelTemplate>
+		</Setter.Value>
+	  </Setter>
+	  <Setter Property="Template">
+		<Setter.Value>
+		  <ControlTemplate TargetType="ComboBox">
+			<Grid>
+			  <Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
+			  </Grid.RowDefinitions>
+			  <Grid.ColumnDefinitions>
+				<ColumnDefinition Width="*" />
+				<ColumnDefinition Width="32" />
+			  </Grid.ColumnDefinitions>
+			  <VisualStateManager.VisualStateGroups>
+				<VisualStateGroup x:Name="CommonStates">
+				  <VisualState x:Name="Normal" />
+				  <VisualState x:Name="PointerOver">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlPageBackgroundAltMediumBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightBaseMediumBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Pressed">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlBackgroundListMediumBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Disabled">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlBackgroundBaseLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlDisabledBaseMediumLowBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				</VisualStateGroup>
+				<VisualStateGroup x:Name="FocusStates">
+				  <VisualState x:Name="Focused">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HighlightBackground"
+													 Storyboard.TargetProperty="BorderBrush">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightTransparentBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <DoubleAnimation Storyboard.TargetName="HighlightBackground"
+									   Storyboard.TargetProperty="Opacity"
+									   To="1"
+									   Duration="0" />
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="FocusedPressed">
+					<Storyboard>
+					  <DoubleAnimation Storyboard.TargetName="HighlightBackground"
+									   Storyboard.TargetProperty="Opacity"
+									   To="1"
+									   Duration="0" />
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="DropDownGlyph"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="{ThemeResource SystemControlHighlightAltBaseMediumHighBrush}" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Unfocused" />
+				  <VisualState x:Name="PointerFocused" />
+				  <VisualState x:Name="FocusedDropDown">
+					<Storyboard>
+					  <not_ios:ObjectAnimationUsingKeyFrames Storyboard.TargetName="PopupBorder"
+															 Storyboard.TargetProperty="Visibility"
+															 Duration="0">
+						<DiscreteObjectKeyFrame KeyTime="0">
+						  <DiscreteObjectKeyFrame.Value>
+							<Visibility>Visible</Visibility>
+						  </DiscreteObjectKeyFrame.Value>
+						</DiscreteObjectKeyFrame>
+					  </not_ios:ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				</VisualStateGroup>
+				<VisualStateGroup x:Name="DropDownStates">
+				  <VisualState x:Name="Opened">
+					<Storyboard>
+					  <win:SplitOpenThemeAnimation OpenedTargetName="PopupBorder"
+												   ClosedTargetName="ContentPresenter"
+												   OffsetFromCenter="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOffset}"
+												   OpenedLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOpenedHeight}" />
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Closed">
+					<Storyboard>
+					  <win:SplitCloseThemeAnimation OpenedTargetName="PopupBorder"
+													ClosedTargetName="ContentPresenter"
+													OffsetFromCenter="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOffset}"
+													OpenedLength="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownOpenedHeight}" />
+					</Storyboard>
+				  </VisualState>
+				</VisualStateGroup>
+			  </VisualStateManager.VisualStateGroups>
+			  <ContentPresenter x:Name="HeaderContentPresenter"
+								x:DeferLoadStrategy="Lazy"
+								Margin="{ThemeResource ComboBoxHeaderThemeMargin}"
+								FlowDirection="{TemplateBinding FlowDirection}"
+								FontWeight="{ThemeResource ComboBoxHeaderThemeFontWeight}"
+								Visibility="Collapsed"
+								Content="{TemplateBinding Header}"
+								ContentTemplate="{TemplateBinding HeaderTemplate}" />
+			  <Border x:Name="Background"
+					  Grid.Row="1"
+					  Grid.ColumnSpan="2"
+					  Background="{TemplateBinding Background}"
+					  BorderBrush="{TemplateBinding BorderBrush}"
+					  BorderThickness="{TemplateBinding BorderThickness}" />
+			  <Border x:Name="HighlightBackground"
+					  Grid.Row="1"
+					  Grid.ColumnSpan="2"
+					  Background="{ThemeResource SystemControlHighlightListAccentLowBrush}"
+					  BorderBrush="{ThemeResource SystemControlHighlightBaseMediumLowBrush}"
+					  BorderThickness="{TemplateBinding BorderThickness}"
+					  Opacity="0" />
+			  <ContentPresenter x:Name="ContentPresenter"
+								Grid.Row="1"
+								Margin="{TemplateBinding Padding}"
+								HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+								VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+				<TextBlock x:Name="PlaceholderTextBlock"
+						   Text="{TemplateBinding PlaceholderText}"
+						   Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}" />
+			  </ContentPresenter>
+			  <not_android:FontIcon x:Name="DropDownGlyph"
+									Grid.Row="1"
+									Grid.Column="1"
+									IsHitTestVisible="False"
+									Margin="0,10,10,10"
+									Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+									FontFamily="{ThemeResource SymbolThemeFontFamily}"
+									FontSize="12"
+									Glyph="&#xE0E5;"
+									HorizontalAlignment="Right"
+									VerticalAlignment="Center"
+									AutomationProperties.AccessibilityView="Raw" />
+			  <android:TextBlock x:Name="DropDownGlyph"
+								 Grid.Row="1"
+								 Grid.Column="1"
+								 IsHitTestVisible="False"
+								 Margin="0,10,10,10"
+								 Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+								 FontFamily="{ThemeResource SymbolThemeFontFamily}"
+								 FontSize="12"
+								 Text="&#xE0E5;"
+								 HorizontalAlignment="Right"
+								 VerticalAlignment="Center"
+								 AutomationProperties.AccessibilityView="Raw" />
+			  <not_ios:Popup x:Name="Popup">
+				<Border x:Name="PopupBorder"
+						Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"
+						BorderBrush="{ThemeResource SystemControlForegroundChromeHighBrush}"
+						BorderThickness="{ThemeResource ComboBoxDropdownBorderThickness}"
+						Margin="0,-1,0,-1"
+						HorizontalAlignment="Stretch">
+				  <ScrollViewer x:Name="ScrollViewer"
+								Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+								MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownContentMinWidth}"
+								VerticalSnapPointsType="OptionalSingle"
+								VerticalSnapPointsAlignment="Near"
+								HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+								HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+								VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+								VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+								IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+								IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+								IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+								BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
+								ZoomMode="Disabled"
+								AutomationProperties.AccessibilityView="Raw">
+					<ItemsPresenter Margin="{ThemeResource ComboBoxDropdownContentMargin}" />
+				  </ScrollViewer>
+				</Border>
+			  </not_ios:Popup>
+			  <ios:Popover x:Name="Popup"
+						   Anchor="{Binding ElementName=Background}"
+						   IsOpen="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
+						   MaxHeight="{TemplateBinding MaxDropDownHeight}">
+				<Border x:Name="PopupBorder"
+						Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"
+						BorderBrush="{ThemeResource SystemControlForegroundChromeHighBrush}"
+						BorderThickness="{ThemeResource ComboBoxDropdownBorderThickness}"
+						Margin="0,-1,0,-1"
+						HorizontalAlignment="Stretch">
+				  <ScrollViewer x:Name="ScrollViewer"
+								Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
+								MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownContentMinWidth}"
+								VerticalSnapPointsType="OptionalSingle"
+								VerticalSnapPointsAlignment="Near"
+								HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
+								HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
+								VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
+								VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
+								IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
+								IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
+								IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
+								BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
+								ZoomMode="Disabled"
+								AutomationProperties.AccessibilityView="Raw">
+					<ItemsPresenter />
+				  </ScrollViewer>
+				</Border>
+			  </ios:Popover>
+			</Grid>
+		  </ControlTemplate>
+		</Setter.Value>
+	  </Setter>
+	</xamarin:Style>
+
+  </UserControl.Resources>
+
+  <StackPanel>
+	<TextBlock Text="This ComboBox should use a Popover (iPad only, will crash on iPhone)" />
+	<ComboBox Style="{StaticResource iPadComboBoxStyle}"
+			  ItemsSource="{Binding [SampleItems]}"
+			  HorizontalAlignment="Stretch" />
+  </StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Popover.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Popover.xaml
@@ -351,7 +351,7 @@
 
   <StackPanel>
 	<TextBlock Text="This ComboBox should use a Popover (iPad only, will crash on iPhone)" />
-	<ComboBox Style="{StaticResource iPadComboBoxStyle}"
+	<ComboBox xamarin:Style="{StaticResource iPadComboBoxStyle}"
 			  ItemsSource="{Binding [SampleItems]}"
 			  HorizontalAlignment="Stretch" />
   </StackPanel>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Popover.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Popover.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_Popover", typeof(ListViewViewModel))] 
+	public sealed partial class ComboBox_Popover : UserControl
+    {
+        public ComboBox_Popover()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Popover.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_Popover.xaml.cs
@@ -1,16 +1,15 @@
 ﻿using Windows.UI.Xaml.Controls;
+using SamplesApp.Windows_UI_Xaml_Controls.ComboBox.Models;
 using Uno.UI.Samples.Controls;
-
-// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
 {
 	[SampleControlInfo("ComboBox", "ComboBox_Popover", typeof(ListViewViewModel))] 
 	public sealed partial class ComboBox_Popover : UserControl
-    {
-        public ComboBox_Popover()
-        {
-            this.InitializeComponent();
-        }
-    }
+	{
+		public ComboBox_Popover()
+		{
+			this.InitializeComponent();
+		}
+	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ScrollViewer.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ScrollViewer.xaml
@@ -1,0 +1,24 @@
+﻿<UserControl
+    x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_ScrollViewer"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Samples.Content.UITests.ComboBox"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+  <Grid>
+	<ScrollViewer Height="300"
+				  Width="300"
+				  VerticalScrollBarVisibility="Visible"
+				  HorizontalScrollBarVisibility="Visible"
+				  Background="LightGray">
+	  <StackPanel Height="500"
+				  Width="500">
+		<ComboBox ItemsSource="{Binding [SampleItems]}"
+				  Margin="200,200,0,0" />
+	  </StackPanel>
+	</ScrollViewer>
+  </Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ScrollViewer.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ScrollViewer.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_ScrollViewer", typeof(ListViewViewModel))] 
+	public sealed partial class ComboBox_ScrollViewer : UserControl
+	{
+		public ComboBox_ScrollViewer()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ScrollViewer.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ScrollViewer.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Windows.UI.Xaml.Controls;
+using SamplesApp.Windows_UI_Xaml_Controls.ComboBox.Models;
 using Uno.UI.Samples.Controls;
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_SelectedItem.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_SelectedItem.xaml
@@ -1,0 +1,15 @@
+﻿<UserControl
+    x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_SelectedItem"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Samples.Content.UITests.ComboBox"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<ComboBox ItemsSource="{Binding [SampleItems]}"
+			  SelectedItem="{Binding [SelectedItem]}" />
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_SelectedItem.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_SelectedItem.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_SelectedItem", typeof(ListViewViewModel))]
+	public sealed partial class ComboBox_SelectedItem : UserControl
+    {
+        public ComboBox_SelectedItem()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_SelectedItem.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_SelectedItem.xaml.cs
@@ -1,16 +1,15 @@
 ﻿using Windows.UI.Xaml.Controls;
+using SamplesApp.Windows_UI_Xaml_Controls.ComboBox.Models;
 using Uno.UI.Samples.Controls;
-
-// The User Control item template is documented at http://go.microsoft.com/fwlink/?LinkId=234236
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
 {
 	[SampleControlInfo("ComboBox", "ComboBox_SelectedItem", typeof(ListViewViewModel))]
 	public sealed partial class ComboBox_SelectedItem : UserControl
-    {
-        public ComboBox_SelectedItem()
-        {
-            this.InitializeComponent();
-        }
-    }
+	{
+		public ComboBox_SelectedItem()
+		{
+			this.InitializeComponent();
+		}
+	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_With_ItemContainerStyle.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_With_ItemContainerStyle.xaml
@@ -1,0 +1,173 @@
+﻿<UserControl x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_With_ItemContainerStyle"
+			 xmlns:controls="using:Uno.UI.Samples.Controls"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:Uno.UI.Samples.Content.UITests"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:android="http:///umbrella/ui/android"
+			 mc:Ignorable="d android"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+  <UserControl.Resources>
+	<Style x:Key="ComboBoxItemContainerStyle"
+				 TargetType="ComboBoxItem">
+	  <Setter Property="Background"
+			  Value="Red" />
+	  <Setter Property="TabNavigation"
+			  Value="Local" />
+	  <Setter Property="Padding"
+			  Value="12,14,12,13" />
+	  <Setter Property="HorizontalContentAlignment"
+			  Value="Center" />
+	  <Setter Property="Foreground"
+			  Value="Blue" />
+	  <Setter Property="UseSystemFocusVisuals"
+			  Value="True" />
+	  <Setter Property="FontSize"
+			  Value="16" />
+	  <Setter Property="Template">
+		<Setter.Value>
+		  <ControlTemplate TargetType="ComboBoxItem">
+			<Border x:Name="LayoutRoot"
+					Background="{TemplateBinding Background}"
+					Control.IsTemplateFocusTarget="True">
+			  <VisualStateManager.VisualStateGroups>
+				<VisualStateGroup x:Name="CommonStates">
+				  <VisualState x:Name="Normal">
+					<Storyboard>
+					  <win:PointerUpThemeAnimation Storyboard.TargetName="LayoutRoot" />
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="PointerOver">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="Red" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <win:PointerUpThemeAnimation Storyboard.TargetName="LayoutRoot" />
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Disabled">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="Grey" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Pressed">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="Black" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <win:PointerDownThemeAnimation Storyboard.TargetName="LayoutRoot" />
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="Selected">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="Purple" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="Black" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <win:PointerUpThemeAnimation Storyboard.TargetName="LayoutRoot" />
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="SelectedUnfocused">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="Transparent" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="Blue" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="SelectedDisabled">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="Grey" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="Grey" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="SelectedPointerOver">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="Blue" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="Red" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <win:PointerUpThemeAnimation Storyboard.TargetName="LayoutRoot" />
+					</Storyboard>
+				  </VisualState>
+				  <VisualState x:Name="SelectedPressed">
+					<Storyboard>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="LayoutRoot"
+													 Storyboard.TargetProperty="Background">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="Blue" />
+					  </ObjectAnimationUsingKeyFrames>
+					  <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter"
+													 Storyboard.TargetProperty="Foreground">
+						<DiscreteObjectKeyFrame KeyTime="0"
+												Value="Red" />
+					  </ObjectAnimationUsingKeyFrames>
+					</Storyboard>
+				  </VisualState>
+				</VisualStateGroup>
+			  </VisualStateManager.VisualStateGroups>
+			  <ContentPresenter x:Name="ContentPresenter"
+								Content="{TemplateBinding Content}"
+								ContentTransitions="{TemplateBinding ContentTransitions}"
+								ContentTemplate="{TemplateBinding ContentTemplate}"
+								Foreground="{TemplateBinding Foreground}"
+								HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+								VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+								Margin="{TemplateBinding Padding}" />
+			</Border>
+		  </ControlTemplate>
+		</Setter.Value>
+	  </Setter>
+	</Style>
+  </UserControl.Resources>
+
+  <StackPanel>
+	<TextBlock Text="You should see a ComboBox with a Red Background and a blue foreground defined by ItemContainerStyle" />
+	<android:TextBlock Text="Limitation : - we have the same style applied for 'SelectedItem' and for 'ComboBoxItem'" />
+	<android:TextBlock Text="- can't style the arrow because it comes from the Spinner control" />
+
+	<ComboBox Name="Box"
+			  ItemContainerStyle="{StaticResource ComboBoxItemContainerStyle}" />
+
+	<TextBlock Name="Txt" />
+  </StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_With_ItemContainerStyle.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_With_ItemContainerStyle.xaml.cs
@@ -1,0 +1,54 @@
+﻿using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_With_ItemContainerStyle")]
+	public sealed partial class ComboBox_With_ItemContainerStyle : UserControl
+	{
+		public ComboBox_With_ItemContainerStyle()
+		{
+			this.InitializeComponent();
+			this.DataContext = this;
+
+			this.Loaded += OnLoaded;
+		}
+
+		private void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			this.Loaded -= OnLoaded;
+
+			InitList();
+		}
+
+		public List<string> Lst { get; set; }
+
+		private void InitList()
+		{
+			Lst = new List<string>();
+			Lst.Add("Item 1");
+			Lst.Add("Item 2");
+			Lst.Add("Item 3");
+			Lst.Add("Item 4");
+			Lst.Add("Item 5");
+			Lst.Add("Item 6");
+			Lst.Add("Item 7");
+			Lst.Add("Item 8");
+			Lst.Add("Item 9");
+			Lst.Add("Item 10");
+
+			Box.ItemsSource = Lst.ToArray();
+
+			void handleSelection(object sender, object args)
+			{
+				var item = (string)Box.SelectedItem;
+				Txt.Text = "Current selection : " + item;
+			}
+
+			Box.Loaded += (s, e) => Box.SelectionChanged += handleSelection;
+			Box.Unloaded += (s, e) => Box.SelectionChanged -= handleSelection;
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_With_ItemTemplate.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_With_ItemTemplate.xaml
@@ -1,0 +1,30 @@
+﻿<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.ComboBox_With_ItemTemplate"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:android="http:///umbrella/ui/android"
+	mc:Ignorable="d android"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock Text="You should see a ComboBox with a ComboBoxItem foreground set to Green" />
+		<android:TextBlock Text="Limitation : - we have the same ItemTemplate applied for 'SelectedItem' and for 'ComboBoxItem'" />
+		<android:TextBlock Text="- can't style the arrow because it comes from the Spinner control" />
+
+		<ComboBox Name="Box">
+			<ComboBox.ItemTemplate>
+				<DataTemplate>
+					<TextBlock VerticalAlignment="Center"
+							   Foreground="Green"
+							   Text="{Binding }" />
+				</DataTemplate>
+			</ComboBox.ItemTemplate>
+		</ComboBox>
+
+		<TextBlock Name="Txt" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_With_ItemTemplate.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_With_ItemTemplate.xaml.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.Generic;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_With_ItemTemplate")]
+	public sealed partial class ComboBox_With_ItemTemplate : UserControl
+	{
+
+		const int FrameRate = 500;
+
+		public ComboBox_With_ItemTemplate()
+		{
+			this.InitializeComponent();
+			this.DataContext = this;
+
+			this.Loaded += OnLoaded;
+		}
+
+		private void OnLoaded(object sender, RoutedEventArgs e)
+		{
+			this.Loaded -= OnLoaded;
+
+			InitList();
+		}
+
+		public List<string> Lst { get; set; }
+
+		private void InitList()
+		{
+			Lst = new List<string>();
+			Lst.Add("Item 1");
+			Lst.Add("Item 2");
+			Lst.Add("Item 3");
+			Lst.Add("Item 4");
+			Lst.Add("Item 5");
+			Lst.Add("Item 6");
+			Lst.Add("Item 7");
+			Lst.Add("Item 8");
+			Lst.Add("Item 9");
+			Lst.Add("Item 10");
+
+			Box.ItemsSource = Lst.ToArray();
+
+			void handleSelection(object sender, object args)
+			{
+				var item = (string)Box.SelectedItem;
+				Txt.Text = "Current selection : " + item.ToString();
+			}
+
+			Box.Loaded += (s, e) => Box.SelectionChanged += handleSelection;
+			Box.Unloaded += (s, e) => Box.SelectionChanged -= handleSelection;
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/Models/ComboBoxViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/Models/ComboBoxViewModel.cs
@@ -1,0 +1,34 @@
+﻿using System.Windows.Input;
+using Windows.UI.Core;
+using Uno.UI.Samples.UITests.Helpers;
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.Models
+{
+	public class ComboBoxViewModel : ViewModelBase
+	{
+		private string _header;
+		private const string HeaderText = "Please select:";
+
+		public ComboBoxViewModel(CoreDispatcher dispatcher) : base(dispatcher)
+		{
+			ToggleHeader = CreateCommand(ExecuteToggleHeader);
+		}
+
+		public string Header
+		{
+			get => _header;
+			set
+			{
+				_header = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public ICommand ToggleHeader { get; }
+
+		private void ExecuteToggleHeader()
+		{
+			Header = Header == null ? HeaderText : null;
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/Models/ComboBoxViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/Models/ComboBoxViewModel.cs
@@ -1,9 +1,11 @@
 ﻿using System.Windows.Input;
 using Windows.UI.Core;
+using Windows.UI.Xaml.Data;
 using Uno.UI.Samples.UITests.Helpers;
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.Models
 {
+	[Bindable]
 	public class ComboBoxViewModel : ViewModelBase
 	{
 		private string _header;

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/Models/ListViewViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/Models/ListViewViewModel.cs
@@ -18,6 +18,7 @@ using Uno.UI.Samples.UITests.Helpers;
 
 namespace SamplesApp.Windows_UI_Xaml_Controls.ComboBox.Models
 {
+	[Bindable]
 	public class ListViewViewModel : ViewModelBase
 	{
 		private static readonly object[] RandomValues = new object[] { null, new object(), 0, -1, 0, 0.5, 1, "", " ", "test", 'a', ' ', new string[] { "A", "B", "C" }, DateTime.Now };

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/Models/ListViewViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/Models/ListViewViewModel.cs
@@ -1,0 +1,312 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Windows.ApplicationModel.Core;
+using Windows.UI;
+using Windows.UI.Core;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Data;
+using Uno;
+using Uno.Extensions;
+using Uno.Logging;
+using Uno.UI.Samples.UITests.Helpers;
+
+namespace SamplesApp.Windows_UI_Xaml_Controls.ComboBox.Models
+{
+	public class ListViewViewModel : ViewModelBase
+	{
+		private static readonly object[] RandomValues = new object[] { null, new object(), 0, -1, 0, 0.5, 1, "", " ", "test", 'a', ' ', new string[] { "A", "B", "C" }, DateTime.Now };
+		private object[] _randomItems = new object[0];
+		private string _newInput = "1,1,2,2,3,3";
+		private List<string> _sampleItemsGenerated = new List<string> { "1", "1", "2", "2", "3", "3" };
+		private double _variableWidth = 500d;
+		private string _selectedItem = "3";
+
+		public ListViewViewModel(CoreDispatcher dispatcher) : base(dispatcher)
+		{
+			RefreshRandomItems = CreateCommand(ExecuteRefreshRandomItems);
+			DoSomething = CreateCommand(ExecuteDoSomething);
+			VaryWidth = CreateCommand(ExecuteVaryWidth);
+			UpdateWithNewInput = CreateCommand(ExecuteOnUpdateWithNewInput);
+
+			VariableLengthItemsLong = CreateVariableLengthItemsLong().ToArray();
+			VariableLengthItemsLongLazy = CreateVariableLengthItemsLong();
+			EmptyItemsLong = Enumerable.Range(0, 1000).Select(_ => "").ToArray();
+		}
+
+		public ICommand RefreshRandomItems { get; }
+		public ICommand DoSomething { get; }
+
+		public ICommand VaryWidth { get; }
+
+		public ICommand UpdateWithNewInput { get; }
+
+		public Orientation SelectedOrientation => Orientation.Horizontal;
+
+		public string[] SampleItems => GetSampleItems();
+		public string Header => "My Header";
+		public string Footer => "My Footer";
+
+		public IEnumerable<object> VariableLengthGroupHeaders => GetAsCollectionViewSource(GetGroupsWithVariableLengthKeys());
+
+		public IEnumerable<object> GroupedCompoundSampleItems => GetAsCollectionViewSource(GetGroupedCompoundItems());
+
+		public NumberViewModel[] CompoundSampleItems => GetCompoundItems();
+
+		public string[] SampleItemsDuplicates => GetSampleItemsWithDuplicates();
+
+		public string SelectedItem
+		{
+			get => _selectedItem;
+			set
+			{
+				_selectedItem = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		private void ExecuteRefreshRandomItems()
+		{
+			var randomItems = RandomValues
+				.OrderBy(x => Guid.NewGuid()) // shuffle
+				.Take(10)
+				.ToArray();
+
+			RandomItems = randomItems;
+		}
+
+		public object[] RandomItems
+		{
+			get => _randomItems;
+			private set
+			{
+				_randomItems = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public string NewInput
+		{
+			get => _newInput;
+			private set
+			{
+				_newInput = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public List<string> SampleItemsGenerated
+		{
+			get => _sampleItemsGenerated;
+			private set
+			{
+				_sampleItemsGenerated = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		private void ExecuteOnUpdateWithNewInput()
+		{
+			SampleItemsGenerated = NewInput.Split(',').ToList();
+		}
+
+		private void ExecuteDoSomething()
+		{
+			this.Log().Error("============= Item Clicked");
+		}
+
+		private static string[] GetSampleItems()
+		{
+			return Enumerable
+				.Range(1, 10)
+				.Select(i => i.ToString(CultureInfo.InvariantCulture))
+				.ToArray();
+		}
+
+		private string[] GetSampleItemsWithDuplicates()
+		{
+			return Enumerable
+				.Range(1, 10)
+				.SelectMany(i => new string[] { i.ToString(CultureInfo.InvariantCulture), i.ToString(CultureInfo.InvariantCulture) })
+				.ToArray();
+		}
+
+		public double VariableWidth
+		{
+			get => _variableWidth;
+			set
+			{
+				_variableWidth = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		private void ExecuteVaryWidth()
+		{
+			var newWidth = (new Random()).NextDouble() * 100d + 300d;
+			this.Log().Warn($"Changing {nameof(VariableWidth)} to {newWidth}");
+			VariableWidth =  newWidth;
+		}
+
+		private static IEnumerable<IGrouping<string, string>> GetGroupsWithVariableLengthKeys()
+		{
+			return _variableLengthItems
+				.Select(s =>
+					new Grouping<string, string>(s, s.Select(c => c.ToString())
+				)
+			);
+		}
+
+		private static IEnumerable<object> GetAsCollectionViewSource<T1, T2>(IEnumerable<IGrouping<T1, T2>> groups)
+		{
+			var source = new CollectionViewSource()
+			{
+				Source = groups,
+				IsSourceGrouped = true
+			}.View;
+
+			return source;
+		}
+
+		public string[] VariableLengthItems => _variableLengthItems;
+
+		private static string[] _variableLengthItems { get; } =
+		{
+			"Does the first item matter, or the non-databound template?",
+			"Alas, poor Yorick!",
+			"I knew him, Horatio: a fellow of infinite jest, of most excellent fancy:",
+			"he hath borne me on his back a thousand times;",
+			"and now, how abhorred in my imagination it is!",
+			"my gorge rims at it.",
+			"Here hung those lips that I have kissed I know not how oft.",
+			"Where be your gibes now?",
+			"your gambols?",
+			"your songs?",
+			"your flashes of merriment, that were wont to set the table on a roar?",
+			"Not one now, to mock your own grinning?",
+			"quite chap-fallen?",
+			"Now get you to my lady's chamber, and tell her, let her paint an inch thick, to this favour she must come;",
+			"make her laugh at that.",
+			"Prithee, Horatio, tell me one thing.",
+		};
+
+		public string[] VariableLengthItemsLong { get; }
+		public IEnumerable<string> VariableLengthItemsLongLazy { get; }
+		private IEnumerable<string> CreateVariableLengthItemsLong()
+		{
+			var sb = new StringBuilder();
+			const int items = 2000;
+			for (int i = 0; i < items; i++)
+			{
+				sb.Clear();
+				const int maxWords = 40;
+				int wordCount = i % maxWords;
+				if (wordCount > 0)
+				{
+					sb.Append(i + 1);
+					sb.Append(". ");
+				}
+				for (int j = 0; j < wordCount; j++)
+				{
+					sb.Append(wordCount);
+					sb.Append(" ");
+				}
+				yield return sb.ToString();
+			}
+		}
+
+		public string[] EmptyItemsLong { get; }
+
+		public Orientation[] Orientations { get; } =
+		{
+			Orientation.Horizontal,
+			Orientation.Vertical
+		};
+
+		public int[] SampleItemsLong { get; } = Enumerable.Range(1, 2000).Select(i => i * 10000).ToArray();
+
+		public double[] WidthChoices { get; } = Enumerable.Range(1, 5).Select(i => i * 100d).ToArray();
+
+		public Color[] SampleColors { get; } = CreateColorSeries();
+
+		private static Color[] CreateColorSeries()
+		{
+			const byte increments = 12;
+			var colors = new List<Color>();
+			var delta = byte.MaxValue / increments;
+			for (byte b = 0; b < increments; b++)
+			{
+				for (byte g = 0; g < increments; g++)
+				{
+					for (byte r = 0; r < increments; r++)
+					{
+						var color = Color.FromArgb(byte.MaxValue, (byte)(r * delta), (byte)(g * delta), (byte)(b * delta));
+						colors.Add(color);
+					}
+				}
+			}
+			return colors.ToArray();
+		}
+
+		private static NumberViewModel[] GetCompoundItems()
+		{
+			var random = new Random(2012);
+
+			return Enumerable.Range(0, 30).Select(_ => new NumberViewModel(random.Next(1, 6))).ToArray();
+		}
+
+		private static IEnumerable<IGrouping<int, NumberViewModel>> GetGroupedCompoundItems()
+		{
+			var random = new Random(1778);
+			int group = 0;
+			return GetCompoundItems().GroupBy(
+					_ => group = random.Next(4),
+						nvm =>
+						{
+							nvm.Group = group;
+							return nvm;
+						}
+					).ToArray();
+		}
+
+		public string LargeText1 { get; } = "When the child of morning rosy-fingered Dawn appeared, Ulysses put on his shirt and cloak, while the goddess wore a dress of a light gossamer fabric, very fine and graceful, with a beautiful golden girdle about her waist and a veil to cover her head. She at once set herself to think how she could speed Ulysses on his way. So she gave him a great bronze axe that suited his hands; it was sharpened on both sides, and had a beautiful olive-wood handle fitted firmly on to it. She also gave him a sharp adze, and then led the way to the far end of the island where the largest trees grew—alder, poplar and pine, that reached the sky—very dry and well seasoned, so as to sail light for him in the water. 53 Then, when she had shown him where the best trees grew, Calypso went home, leaving him to cut them, which he soon finished doing. He cut down twenty trees in all and adzed them smooth, squaring them by rule in good workmanlike fashion. Meanwhile Calypso came back with some augers, so he bored holes with them and fitted the timbers together with bolts and rivets. He made the raft as broad as a skilled shipwright makes the beam of a large vessel, and he fixed a deck on top of the ribs, and ran a gunwale all round it. He also made a mast with a yard arm, and a rudder to steer with. He fenced the raft all round with wicker hurdles as a protection against the waves, and then he threw on a quantity of wood. By and by Calypso brought him some linen to make the sails, and he made these too, excellently, making them fast with braces and sheets. Last of all, with the help of levers, he drew the raft down into the water.";
+		public string LargeText2 { get; } = "In four days he had completed the whole work, and on the fifth Calypso sent him from the island after washing him and giving him some clean clothes. She gave him a goat skin full of black wine, and another larger one of water; she also gave him a wallet full of provisions, and found him in much good meat. Moreover, she made the wind fair and warm for him, and gladly did Ulysses spread his sail before it, while he sat and guided the raft skilfully by means of the rudder. He never closed his eyes, but kept them fixed on the Pleiads, on late-setting Bootes, and on the Bear—which men also call the wain, and which turns round and round where it is, facing Orion, and alone never dipping into the stream of Oceanus—for Calypso had told him to keep this to his left. Days seven and ten did he sail over the sea, and on the eighteenth the dim outlines of the mountains on the nearest part of the Phaeacian coast appeared, rising like a shield on the horizon.";
+
+		public class NumberViewModel
+		{
+			public string Quote { get; private set; }
+			public int[] Items { get; private set; }
+			public int Group { get; set; }
+
+			public NumberViewModel(int number)
+			{
+				Quote = GetNumberQuote(number);
+				Items = Enumerable.Range(0, number).ToArray();
+			}
+		}
+
+		private static string GetNumberQuote(int n)
+		{
+			switch (n)
+			{
+				case 1:
+					return "It's very easy to be number one: find the guy who is number one, and score one point higher than he does.";
+				case 2:
+					return "No man can serve two masters.";
+				case 3:
+					return "In three words I can sum up everything I've learned about life: it goes on.";
+				case 4:
+					return "When angry, count to four; when very angry, swear.";
+				case 5:
+					return "It takes 20 years to build a reputation and five minutes to ruin it. If you think about that, you'll do things differently.";
+			}
+
+			return "Two things are infinite: the universe and human stupidity; and I'm not sure about the universe.";
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/Picker_Resizable.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/Picker_Resizable.xaml
@@ -1,0 +1,30 @@
+<UserControl
+	x:Class="SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox.Picker_Resizable" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="Uno.UI.Samples.Content.UITests.ComboBox"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:not_ios="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Picker (normally internal to iOS ComboBox) which can be resized (which should cause app to not crash).">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<not_ios:TextBlock Text="Picker is an iOS-specific control."/>
+				<ios:StackPanel>
+					<Picker ItemsSource="{Binding [SampleItems]}"
+							Width="{Binding [VariableWidth]}"/>
+					<Button Content="Change width" Command="{Binding [VaryWidth]}"/>
+				</ios:StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/Picker_Resizable.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/Picker_Resizable.xaml.cs
@@ -1,0 +1,28 @@
+using Uno.UI.Samples.Controls;
+
+#if NETFX_CORE
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+#elif XAMARIN
+using Windows.UI.Xaml.Controls;
+using System.Globalization;
+#endif
+
+namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "Picker_Resizable", typeof(Uno.UI.Samples.Presentation.SamplePages.ListViewViewModel))]
+	public sealed partial class Picker_Resizable : UserControl
+	{
+		public Picker_Resizable()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/Picker_Resizable.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/Picker_Resizable.xaml.cs
@@ -1,23 +1,10 @@
+using SamplesApp.Windows_UI_Xaml_Controls.ComboBox.Models;
 using Uno.UI.Samples.Controls;
-
-#if NETFX_CORE
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
-#elif XAMARIN
-using Windows.UI.Xaml.Controls;
-using System.Globalization;
-#endif
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
 {
-	[SampleControlInfo("ComboBox", "Picker_Resizable", typeof(Uno.UI.Samples.Presentation.SamplePages.ListViewViewModel))]
+	[SampleControlInfo("ComboBox", "Picker_Resizable", typeof(ListViewViewModel))]
 	public sealed partial class Picker_Resizable : UserControl
 	{
 		public Picker_Resizable()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Models/ImageWithLateSourceViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ImageTests/Models/ImageWithLateSourceViewModel.cs
@@ -12,18 +12,18 @@ using Windows.UI.Core;
 
 namespace Uno.UI.Samples.UITests.ImageTests.Models
 {
-    public class ImageWithLateSourceViewModel : ViewModelBase
-    {
+	public class ImageWithLateSourceViewModel : ViewModelBase
+	{
 		public ImageWithLateSourceViewModel(CoreDispatcher dispatcher) : base(dispatcher)
 		{
-			SetSource  = new DelegateCommand(async () => await OnSetSource(CancellationToken.None));
+			SetSource = CreateCommand(OnSetSource);
 		}
 
 		private string _sourceUri;
 
 		public string SourceUri
 		{
-			get { return _sourceUri; }
+			get => _sourceUri;
 			set
 			{
 				_sourceUri = value;
@@ -31,14 +31,14 @@ namespace Uno.UI.Samples.UITests.ImageTests.Models
 			}
 		}
 
-		private ICommand SetSource { get; }
+		public ICommand SetSource { get; }
 
-		private async Task OnSetSource(CancellationToken ct)
-        {
-            const string source = "http://lh5.ggpht.com/lxBMauupBiLIpgOgu5apeiX_YStXeHRLK1oneS4NfwwNt7fGDKMP0KpQIMwfjfL9GdHRVEavmg7gOrj5RYC4qwrjh3Y0jCWFDj83jzg";
-            this.Log().Warn("Setting image source to " + source);
+		private void OnSetSource()
+		{
+			const string source = "http://lh5.ggpht.com/lxBMauupBiLIpgOgu5apeiX_YStXeHRLK1oneS4NfwwNt7fGDKMP0KpQIMwfjfL9GdHRVEavmg7gOrj5RYC4qwrjh3Y0jCWFDj83jzg";
+			this.Log().Warn("Setting image source to " + source);
 
-            SourceUri = source;
-        }
-    }
+			SourceUri = source;
+		}
+	}
 }

--- a/src/Uno.UI.Wasm/Uno.UI.Wasm.csproj
+++ b/src/Uno.UI.Wasm/Uno.UI.Wasm.csproj
@@ -45,6 +45,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<EmbeddedResource Update="WasmScripts\*.js" />
+	</ItemGroup>
+	<ItemGroup>
 	  <Folder Include="tsBindings\" />
 	</ItemGroup>
 	

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -171,7 +171,8 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (_contentPresenter != null)
 			{
-				_contentPresenter.Content = SelectedItem;
+				var item = SelectedItem is ComboBoxItem cbi ? cbi.Content : SelectedItem;
+				_contentPresenter.Content = item;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBoxItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBoxItem.cs
@@ -2,14 +2,47 @@
 using System.Collections.Generic;
 using System.Text;
 using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
 	public partial class ComboBoxItem : SelectorItem
 	{
-		public ComboBoxItem()
+		protected override void OnLoaded()
 		{
+			var popup = GetPopupControl();
+			popup.Opened += OnPopupOpened;
 
+			base.OnLoaded();
+		}
+
+		private void OnPopupOpened(object sender, object e)
+		{
+			if (Content is DependencyObject content)
+			{
+				// Reconnect content with current element
+				Content = null;
+				Content = content;
+			}
+		}
+
+		public Popup GetPopupControl()
+		{
+			DependencyObject GetParent(DependencyObject e) => (e as FrameworkElement)?.Parent ?? VisualTreeHelper.GetParent(e);
+
+			var parent = GetParent(this);
+
+			while (parent != null)
+			{
+				if (parent is PopupPanel pnl)
+				{
+					return pnl.Popup;
+				}
+
+				parent = GetParent(parent);
+			}
+
+			return null;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBoxItem.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBoxItem.cs
@@ -8,28 +8,59 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class ComboBoxItem : SelectorItem
 	{
+		private Popup _popup;
+
 		protected override void OnLoaded()
 		{
-			var popup = GetPopupControl();
-			popup.Opened += OnPopupOpened;
-
 			base.OnLoaded();
+
+			var popup = GetPopupControl();
+			if (popup != _popup)
+			{
+				if(_popup != null)
+				{
+					_popup.Opened -= OnPopupOpened;
+				}
+				popup.Opened += OnPopupOpened;
+				_popup = popup;
+			}
+
+			CheckContentKidnapped();
+		}
+
+		protected override void OnUnloaded()
+		{
+			base.OnUnloaded();
+
+			if (_popup != null)
+			{
+				_popup.Opened -= OnPopupOpened;
+				_popup = null;
+			}
 		}
 
 		private void OnPopupOpened(object sender, object e)
 		{
+			CheckContentKidnapped();
+		}
+
+		private void CheckContentKidnapped()
+		{
 			if (Content is DependencyObject content)
 			{
-				// Reconnect content with current element
-				Content = null;
-				Content = content;
+				var currentParent = GetParent(content);
+
+				if (currentParent != Content)
+				{
+					// Content has been kidnapped: reconnect content with current element
+					Content = null;
+					Content = content;
+				}
 			}
 		}
 
 		public Popup GetPopupControl()
 		{
-			DependencyObject GetParent(DependencyObject e) => (e as FrameworkElement)?.Parent ?? VisualTreeHelper.GetParent(e);
-
 			var parent = GetParent(this);
 
 			while (parent != null)
@@ -39,10 +70,21 @@ namespace Windows.UI.Xaml.Controls
 					return pnl.Popup;
 				}
 
+#if __WASM__
+				var popup = PopupRoot.GetPopup(parent);
+				if (popup != null)
+				{
+					return popup;
+				}
+#endif
+
 				parent = GetParent(parent);
 			}
 
 			return null;
 		}
+
+		private DependencyObject GetParent(DependencyObject e)
+			=> (e as FrameworkElement)?.Parent ?? VisualTreeHelper.GetParent(e);
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsPresenter.cs
@@ -25,9 +25,10 @@ namespace Windows.UI.Xaml.Controls
 {
 	public partial class ItemsPresenter : FrameworkElement, IScrollSnapPointsInfo
 	{
-		internal protected override void OnTemplatedParentChanged(DependencyPropertyChangedEventArgs e)
+		protected internal override void OnTemplatedParentChanged(DependencyPropertyChangedEventArgs e)
 		{
 			base.OnTemplatedParentChanged(e);
+
 			if (TemplatedParent is ItemsControl itemsControl && IsLoaded)
 			{
 				itemsControl.SetItemsPresenter(this);
@@ -37,6 +38,7 @@ namespace Windows.UI.Xaml.Controls
 		protected override void OnLoaded()
 		{
 			base.OnLoaded();
+
 			if (TemplatedParent is ItemsControl itemsControl && IsLoaded)
 			{
 				itemsControl.SetItemsPresenter(this);
@@ -57,8 +59,8 @@ namespace Windows.UI.Xaml.Controls
 
 		public Thickness Padding
 		{
-			get { return (Thickness)GetValue(PaddingProperty); }
-			set { SetValue(PaddingProperty, value); }
+			get => (Thickness)GetValue(PaddingProperty);
+			set => SetValue(PaddingProperty, value);
 		}
 
 		public static DependencyProperty PaddingProperty =
@@ -92,15 +94,10 @@ namespace Windows.UI.Xaml.Controls
 			true;
 #endif
 
-		private Thickness AppliedPadding
-		{
-			get
-			{
-				return IsWithinScrollableArea ?
-					Padding :
-					Thickness.Empty;
-			}
-		}
+		private Thickness AppliedPadding =>
+			IsWithinScrollableArea ?
+				Padding :
+				Thickness.Empty;
 
 		protected override bool IsSimpleLayout => true;
 

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
@@ -52,6 +52,7 @@ namespace Windows.UI.Xaml.Controls
 			if (oldChild is IDependencyObjectStoreProvider provider)
 			{
 				provider.Store.ClearValue(provider.Store.DataContextProperty, DependencyPropertyValuePrecedences.Local);
+				provider.Store.ClearValue(provider.Store.TemplatedParentProperty, DependencyPropertyValuePrecedences.Local);
 			}
 
 			UpdateDataContext();
@@ -69,6 +70,7 @@ namespace Windows.UI.Xaml.Controls
 			if (Child is IDependencyObjectStoreProvider provider)
 			{
 				provider.Store.SetValue(provider.Store.DataContextProperty, this.DataContext, DependencyPropertyValuePrecedences.Local);
+				provider.Store.SetValue(provider.Store.TemplatedParentProperty, this.TemplatedParent, DependencyPropertyValuePrecedences.Local);
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -668,6 +668,24 @@ namespace Windows.UI.Xaml
 				return;
 			}
 
+			var currentParent = child.GetParent() as UIElement;
+
+			// Remove child from current parent, if any
+			if (currentParent != this && currentParent != null)
+			{
+				// ---IMPORTANT---
+				// This behavior is different than UWP:
+				// On UWP the behavior would be to throw an "Element already has a logical parent" exception.
+
+				// It is done here to align Wasm with Android and iOS where the control is
+				// simply "moved" when attached to another parent.
+
+				// This could lead to "child kidnapping", like the one happening in ComboBox & ComboBoxItem
+
+				this.Log().Info($"{this}.AddChild({child}): Removing child {child} from its current parent {currentParent}.");
+				currentParent.RemoveChild(child);
+			}
+
 			child.SetParent(this);
 
 			OnAddingChild(child);
@@ -746,7 +764,7 @@ namespace Windows.UI.Xaml
 			{
 				if (child.IsLoaded)
 				{
-					this.Log().Error("Inconsistent state: child is already loaded");
+					this.Log().Error($"{this}: Inconsistent state: child {child} is already loaded (OnAddingChild)");
 				}
 				else
 				{
@@ -763,7 +781,7 @@ namespace Windows.UI.Xaml
 			{
 				if (child.IsLoaded)
 				{
-					this.Log().Error("Inconsistent state: child is already loaded");
+					this.Log().Error($"{this}: Inconsistent state: child {child} is already loaded (OnChildAdded)");
 				}
 				else
 				{
@@ -784,7 +802,7 @@ namespace Windows.UI.Xaml
 				}
 				else
 				{
-					this.Log().Error("Inconsistent state: child is not loaded");
+					this.Log().Error($"{this}: Inconsistent state: child {child} is not loaded (OnChildRemoved)");
 				}
 			}
 		}


### PR DESCRIPTION
## Bugfix
ComboBox were broken on Wasm platform

## What is the current behavior?
Opening a ComboBox were always presenting an empty popup.

The `TemplatedParent` property were losing its value when the popup content were
reattached in the `PopupRoot` panel.

## What is the new behavior?
The `TemplatedParent` is now copied the same way the `DataContext` is.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->

## Other changes:
* Include new samples from private repo
* Include a refactoring of ViewModels for the samples
* Changed a way the Parent is handled in Wasm to align with other platforms

Internal Issue (If applicable):
* #87 
* <https://nventive.visualstudio.com/Umbrella/_workitems/edit/124046>