### PR TITLE
Fix multiple memory leaks

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -28,7 +28,7 @@ Please check if your PR fulfills the following requirements:
 
 - [ ] Tested code with current [supported SDKs](../README.md#supported)
 - [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
-- [ ] Tests for the changes have been added (for bug fixes / features) (if applicable)
+- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
 - [ ] Contains **NO** breaking changes
 - [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
 - [ ] Associated with an issue (GitHub or internal)

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -100,6 +100,8 @@
  * #87 / 124046 ComboBox incorrect behavior when using Items property
  * [Wasm] ComboBox wasn't working anymore since few versions
  * Fix memory leak with defining event handlers in XAML documents
+ * Fix memory leak in `CommandBar`
+ * Fix memory leak when using `x:Name` in XAML documents
 
 ## Release 1.42
 

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -99,6 +99,7 @@
  * Fix `VisibleBoundsPadding` memory leak
  * #87 / 124046 ComboBox incorrect behavior when using Items property
  * [Wasm] ComboBox wasn't working anymore since few versions
+ * Fix memory leak with defining event handlers in XAML documents
 
 ## Release 1.42
 

--- a/doc/articles/debugging-uno-ui.md
+++ b/doc/articles/debugging-uno-ui.md
@@ -14,7 +14,7 @@ Uno.UI supports [SourceLink](https://github.com/dotnet/sourcelink/) and it now p
 step into Uno.UI without downloading the repository.
 
 Make sure **Enable source link support** check box is checked in **Tools** / **Options**
-/ **Debugging** / **General** properties page. 
+/ **Debugging** / **General** properties page.
 
 ## Debugging Uno.UI
 
@@ -30,6 +30,11 @@ To ensure that the file you have in your cache a correct, either clear the cache
 product version should contain a git CommitID.
 
 Once Uno.UI built, open the files you want to debug inside the solution running the application you need to debug, and set breakpoints there.
+
+## Running the samples applications
+
+The Uno solution provides a set of sample applications that provide a way to test features, as
+well as provide a way to write UI Tests. See [this document](working-with-the-samples-apps.md) for more information.
 
 ## Building Uno.UI for macOS using Visual Studio for Mac
 

--- a/doc/articles/working-with-the-samples-apps.md
+++ b/doc/articles/working-with-the-samples-apps.md
@@ -1,0 +1,41 @@
+# Working with the Samples Applications
+
+The Uno solution provides a set of sample applications that provide a way to test features, as
+well as provide a way to write UI Tests.
+
+Those applications are structured in a way that samples can created out of normal `UserControl` instances, marked with the `SampleControlInfoAttribute` so the sample application can discover them.
+
+Those applications are located in the `SamplesApp` folder of the solution, and a live devevelopment out of the master branch version for the WebAssembly application can be found here: https://unoui-sampleapp-unoui-sampleapp-staging.azurewebsites.net
+
+## Creating UI Tests
+
+The goal of these UI Tests is to :
+
+* Demonstrate the use of controls
+* Compare the behavior of controls between platforms
+* Provide regression testing through the sample browser
+
+To create a UI Test for the sample applications:
+- Create or reuse a folder named from the namespace of the control or class your want to test, replacing "`.`" by "`_`"
+- Create a new `UserControl` from the Visual Studio templates in the `UITests.Shared` project
+- Add `[Uno.UI.Samples.Controls.SampleControlInfo("Replace_with_control_or_class_name", "MyTestName", description: "MyDescription")]` on the code-behind class.
+- Run the samples application, and the sample should appear in the samples browser
+
+# Requirements for UI tests
+
+- Each sample should demonstrate one and only one feature of a control so
+that it can be run and have a stable screenshot taken. This screenshot is then
+using for bitmap comparison during regression testing, or used by the an automated UI Testing tool.
+- Avoid the sample for having to scroll to view content, unless you are creating a UI Tests script as well.
+- If the sample has multiple states, a Xamarin UI Test script must also be added.
+
+# Creating Non-UI Tests
+
+In the context of non-UI tests, a special sample control is available in the samples app (Unit Tests Runner). This control looks for tests in the `Uno.UI.RuntimeTests` project.
+
+Those tests use the MSTests format, and can be run as part of the running application to test for features that depend on the current platform.
+
+To create a Non-UI Test:
+- Create or reuse a folder named from the namespace of the class your want to test, replacing "`.`" by "`_`"
+- Name your class `Given_Your_Class_Name` 
+- Create your test methods using `When_Your_Scenario`

--- a/doc/articles/working-with-the-samples-apps.md
+++ b/doc/articles/working-with-the-samples-apps.md
@@ -39,3 +39,6 @@ To create a Non-UI Test:
 - Create or reuse a folder named from the namespace of the class your want to test, replacing "`.`" by "`_`"
 - Name your class `Given_Your_Class_Name` 
 - Create your test methods using `When_Your_Scenario`
+- An optional ViewModel type may be provided as an attribute so the browser automatically sets an instance as the DataContext of the sample
+
+> More information about the GivenWhenThen pattern: <https://martinfowler.com/bliki/GivenWhenThen.html>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -17,6 +17,14 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\XamlEvent_Leak.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\XamlEvent_Leak_UserControl.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\AutoBorderStretchwithbottommargin.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -629,6 +637,12 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\LoadEvents.xaml.cs">
       <DependentUpon>LoadEvents.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\XamlEvent_Leak.xaml.cs">
+      <DependentUpon>XamlEvent_Leak.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\XamlEvent_Leak_UserControl.xaml.cs">
+      <DependentUpon>XamlEvent_Leak_UserControl.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\AutoBorderStretchwithbottommargin.xaml.cs">
       <DependentUpon>AutoBorderStretchwithbottommargin.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/XamlEvent_Leak.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/XamlEvent_Leak.xaml
@@ -1,0 +1,24 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml.FrameworkElementTests.XamlEvent_Leak"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml.FrameworkElementTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<StackPanel>
+			<Button Content="Run Test" Click="OnRunTest" />
+			<TextBlock>
+				<Run Text="Active controls: "/>
+				<Run x:Name="activeControls" />
+				<Run Text="Max active controls: "/>
+				<Run x:Name="maxActiveControls" />
+			</TextBlock>
+			<ContentControl x:Name="contentHost"></ContentControl>
+		</StackPanel>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/XamlEvent_Leak.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/XamlEvent_Leak.xaml.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Threading.Tasks;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace UITests.Shared.Windows_UI_Xaml.FrameworkElementTests
+{
+	[SampleControlInfo("FrameworkElement", "XamlEvent_Leak", description: Description)]
+	public sealed partial class XamlEvent_Leak : UserControl
+	{
+		private const string Description =
+			"This sample provides a test for XAML provided event " +
+			"handlers, which must not make the declaring control leak. The counter " +
+			"should not grow and stay above a few instances, and go down back to zero " +
+			"after the end of the test. This may take a few seconds before the GC passes.";
+
+		private static int _maxCounter;
+
+		public XamlEvent_Leak()
+		{
+			this.InitializeComponent();
+		}
+
+		private static ConditionalWeakTable<FrameworkElement, Holder> _holders
+			= new ConditionalWeakTable<FrameworkElement, Holder>();
+
+		private async void OnRunTest(object sender, RoutedEventArgs e)
+		{
+			for (int i = 0; i < 30; i++)
+			{
+				var item = new XamlEvent_Leak_UserControl();
+				_holders.Add(item, new Holder(HolderUpdate));
+				contentHost.Content = item;
+				await Task.Delay(100);
+				contentHost.Content = null;
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				await Task.Delay(100);
+			}
+		}
+
+		private void HolderUpdate(int value)
+		{
+			Dispatcher.RunAsync(CoreDispatcherPriority.High,
+				() =>
+				{
+					_maxCounter = Math.Max(value, _maxCounter);
+					activeControls.Text = value.ToString();
+					maxActiveControls.Text = _maxCounter.ToString();
+				}
+			);
+		}
+
+		private class Holder
+		{
+			private Action<int> _update;
+			private static int _counter;
+
+			public Holder(Action<int> update)
+			{
+				_update = update;
+				_update(++_counter);
+			}
+
+			~Holder()
+			{
+				_update(--_counter);
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/XamlEvent_Leak_UserControl.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/XamlEvent_Leak_UserControl.xaml
@@ -10,6 +10,9 @@
     d:DesignWidth="400">
 
     <Grid>
-		<Button Content="Button With Handler" Click="Button_Click" />
+		<!-- A named button with an event must not leak -->
+		<Button x:Name="namedButton"
+				Content="Button With Handler"
+				Click="Button_Click" />
 	</Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/XamlEvent_Leak_UserControl.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/XamlEvent_Leak_UserControl.xaml
@@ -1,0 +1,15 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml.FrameworkElementTests.XamlEvent_Leak_UserControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml.FrameworkElementTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<Button Content="Button With Handler" Click="Button_Click" />
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/XamlEvent_Leak_UserControl.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/FrameworkElementTests/XamlEvent_Leak_UserControl.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml.FrameworkElementTests
+{
+    public sealed partial class XamlEvent_Leak_UserControl : UserControl
+    {
+        public XamlEvent_Leak_UserControl()
+        {
+            this.InitializeComponent();
+        }
+
+		private void Button_Click(object sender, RoutedEventArgs e)
+		{
+			Console.WriteLine("Button_Click");
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/NameScope.cs
+++ b/src/Uno.UI/UI/Xaml/NameScope.cs
@@ -2,37 +2,35 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text;
+using Uno.UI.DataBinding;
 using Windows.UI.Xaml.Markup;
 
 namespace Windows.UI.Xaml
 {
 	[EditorBrowsable(EditorBrowsableState.Never)]
-	public class NameScope :
-		Dictionary<string, object>,
-		INameScope,
-		IDictionary<string, object>,
-		ICollection<KeyValuePair<string, object>>,
-		IEnumerable<KeyValuePair<string, object>>
+	public class NameScope : INameScope
 	{
+		private Dictionary<string, ManagedWeakReference> _names = new Dictionary<string, ManagedWeakReference>();
+
 		public NameScope()
 		{
 		}
 
 		public object FindName(string name)
 		{
-			return TryGetValue(name, out var element)
-				? element
+			return _names.TryGetValue(name, out var element)
+				? element.Target
 				: null;
 		}
 
 		public void RegisterName(string name, object scopedElement)
 		{
-			Add(name, scopedElement);
+			_names.Add(name, WeakReferencePool.RentWeakReference(this, scopedElement));
 		}
 
 		public void UnregisterName(string name)
 		{
-			Remove(name);
+			_names.Remove(name);
 		}
 
 		#region NameScope attached property


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix
- Documentation content changes

## What is the current behavior?
- When defining an event handler in a XAML document, the control defining the handler, and the control it is being attached to are leaking memory on iOS.
- A XAML element marked with `x:Name` may leak memory
- A `CommandBar` instance may leak memory

## What is the new behavior?
- Attaching an event handler in XAML will not create memory leaks.
- `x:Name` elements will not create memory leaks.
- Using the `CommandBar` will not create memory leaks.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] Tests for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)