### PR TITLE
Fix support of resources localized with region code

### DIFF
--- a/build/_HOW-TO-BUILD-AND-DEBUG-APPS.md
+++ b/build/_HOW-TO-BUILD-AND-DEBUG-APPS.md
@@ -53,3 +53,18 @@ To do this, you need to recompile your app using a _debug_ version of Uno­
 > just to make sure other apps referencing the same version of Uno won't get weird
 > results.
 
+# How to debug generators of Uno.UI.Tasks
+There is a known issue for this project: Visual Studio is locking the dll file,
+so you cannot easily debug it.
+
+The easiest way to debug it is :
+1. Configure the `nuget_version_override.txt` as described above 
+   (If you try to debug using the Uno SampleApp you don't have to do anything as it's already configured)
+1. Close/kill all your devenv.exe, msbuild.exe, and Uno.SourceGeneration.Host.exe
+1. Open a new Visual studio an open only the project src\SourceGenerators\Uno.UI.Tasks\Uno.UI.Tasks.csproj
+1. In the _Debug_ tab of the project settings configure those:
+   * **Start external program:** `C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe`
+   * **Command line argmuents:** `[PATH_TO_YOUR_PROJECT/SOLUTION_FILE] /p:Configuration=Debug`
+
+_[PATH_TO_YOUR_PROJECT/SOLUTION_FILE] can be relative to the output folder of the Uno.UI.Tasks project, so `..\..\..\..\SamplesApp\SamplesApp.Droid\SamplesApp.Droid.csproj`
+will build the Android SampleApp_

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -108,6 +108,7 @@
  * Fix memory leak when using `x:Name` in XAML documents
  * 143170 [iOS] [WatermarkedDatePicker] When the Maxyear boundary is reached the first time, the calendar goes back two days instead of one
  * #491 DataTemplateSelector.SelectTemplate is not called on iOS and Android. The behavior is now closer to UWP.
+ * 144268 / #493 : Resources outside of 'en' folder not working
 
 ## Release 1.42
 

--- a/src/SamplesApp/SamplesApp.Shared/SamplesApp.Shared.projitems
+++ b/src/SamplesApp/SamplesApp.Shared/SamplesApp.Shared.projitems
@@ -48,6 +48,9 @@
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en-US\Resources.resw" />
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en-US\Test01.resw" />
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en\Resources.resw" />
+    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\fr-CA\Resources.resw" />
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en\Test01.resw" />
+    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\fr\Resources.resw" />
+    <PRIResource Include="$(MSBuildThisFileDirectory)Strings\sr-Cyrl-BA\Resources.resw" />
   </ItemGroup>
 </Project>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/en-US/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/en-US/Resources.resw
@@ -120,6 +120,9 @@
   <data name="ApplicationName" xml:space="preserve">
     <value>SamplesApp</value>
   </data>
+  <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
+    <value>Text in 'en-US'</value>
+  </data>
   <data name="Given_ResourceLoader.When_NamedLoader" xml:space="preserve">
     <value>This is en-US\Resources.resw</value>
   </data>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/en/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/en/Resources.resw
@@ -120,6 +120,9 @@
   <data name="ApplicationName" xml:space="preserve">
     <value>SamplesApp</value>
   </data>
+  <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
+    <value>Text in 'en'</value>
+  </data>
   <data name="Given_ResourceLoader.When_NamedLoader" xml:space="preserve">
     <value>This is en\Resources.resw</value>
   </data>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/fr-CA/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/fr-CA/Resources.resw
@@ -117,10 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApplicationName" xml:space="preserve">
-    <value>App70-fr</value>
-  </data>
   <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
-    <value>Text in 'fr'</value>
+    <value>Text in 'fr-CA'</value>
   </data>
 </root>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/fr/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/fr/Resources.resw
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApplicationName" xml:space="preserve">
-    <value>App70-fr</value>
-  </data>
   <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
     <value>Text in 'fr'</value>
   </data>

--- a/src/SamplesApp/SamplesApp.Shared/Strings/sr-Cyrl-BA/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/sr-Cyrl-BA/Resources.resw
@@ -117,10 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApplicationName" xml:space="preserve">
-    <value>App70-fr</value>
-  </data>
   <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
-    <value>Text in 'fr'</value>
+    <value>Text in 'sr-Cyrl-BA'</value>
   </data>
 </root>

--- a/src/Uno.UI.Tests/ResourceLoader/Given_ResourceLoader.cs
+++ b/src/Uno.UI.Tests/ResourceLoader/Given_ResourceLoader.cs
@@ -3,27 +3,37 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using _ResourceLoader = Windows.ApplicationModel.Resources.ResourceLoader;
 
 namespace Uno.UI.Tests.ResourceLoaderTests
 {
 	[TestClass]
 	public class Given_ResourceLoader
 	{
-		[TestCleanup]
-		public void TestCleanup()
+		[TestInitialize]
+		public void Init()
 		{
-			Windows.ApplicationModel.Resources.ResourceLoader.ClearResources();
+			CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+			_ResourceLoader.DefaultLanguage = "en-US";
+			_ResourceLoader.AddLookupAssembly(GetType().Assembly);
+		}
+
+		[TestCleanup]
+		public void Cleanup()
+		{
+			CultureInfo.CurrentUICulture = new CultureInfo("en-US");
+			_ResourceLoader.DefaultLanguage = "en-US";
 		}
 
 		[TestMethod]
 		public void When_ResourceFile_Neutral()
 		{
-			Windows.ApplicationModel.Resources.ResourceLoader.DefaultLanguage = "en";
-			Windows.ApplicationModel.Resources.ResourceLoader.AddLookupAssembly(GetType().Assembly);
+			_ResourceLoader.DefaultLanguage = "en";
 
-			Assert.AreEqual("App70-en", Windows.ApplicationModel.Resources.ResourceLoader.GetForCurrentView().GetString("ApplicationName"));
+			Assert.AreEqual("App70-en", _ResourceLoader.GetForCurrentView().GetString("ApplicationName"));
 		}
 
 		[TestMethod]
@@ -32,19 +42,35 @@ namespace Uno.UI.Tests.ResourceLoaderTests
 			void setResources(string language)
 			{
 				CultureInfo.CurrentUICulture = new CultureInfo(language);
-				Windows.ApplicationModel.Resources.ResourceLoader.ClearResources();
-				Windows.ApplicationModel.Resources.ResourceLoader.DefaultLanguage = language;
-				Windows.ApplicationModel.Resources.ResourceLoader.AddLookupAssembly(GetType().Assembly);
+				_ResourceLoader.DefaultLanguage = language;
 			}
 
 			setResources("fr");
-			Assert.AreEqual("App70-fr", Windows.ApplicationModel.Resources.ResourceLoader.GetForCurrentView().GetString("ApplicationName"));
+			Assert.AreEqual("App70-fr", _ResourceLoader.GetForCurrentView().GetString("ApplicationName"));
 
 			setResources("fr-FR");
-			Assert.AreEqual("App70-fr", Windows.ApplicationModel.Resources.ResourceLoader.GetForCurrentView().GetString("ApplicationName"));
+			Assert.AreEqual("App70-fr", _ResourceLoader.GetForCurrentView().GetString("ApplicationName"));
 
 			setResources("en");
-			Assert.AreEqual("App70-en", Windows.ApplicationModel.Resources.ResourceLoader.GetForCurrentView().GetString("ApplicationName"));
+			Assert.AreEqual("App70-en", _ResourceLoader.GetForCurrentView().GetString("ApplicationName"));
+		}
+
+		[TestMethod]
+		public void When_MissingLocalizedResource_FallbackOnParent()
+		{
+			var SUT = _ResourceLoader.GetForCurrentView();
+
+			CultureInfo.CurrentUICulture = new CultureInfo("fr-FR");
+			Assert.AreEqual(@"Text in 'fr'", SUT.GetString("Given_ResourceLoader/When_LocalizedResource"));
+		}
+
+		[TestMethod]
+		public void When_MissingLocalizedResource_FallbackOnDefault()
+		{
+			var SUT = _ResourceLoader.GetForCurrentView();
+
+			CultureInfo.CurrentUICulture = new CultureInfo("de-DE");
+			Assert.AreEqual(@"Text in 'en'", SUT.GetString("Given_ResourceLoader/When_LocalizedResource"));
 		}
 	}
 }

--- a/src/Uno.UI.Tests/ResourceLoader/Strings/en/Resources.Designer.cs
+++ b/src/Uno.UI.Tests/ResourceLoader/Strings/en/Resources.Designer.cs
@@ -68,5 +68,14 @@ namespace Uno.UI.Tests.ResourceLoader.Strings.en {
                 return ResourceManager.GetString("ApplicationName", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Text in &apos;en&apos;.
+        /// </summary>
+        internal static string Given_ResourceLoader_When_LocalizedResource {
+            get {
+                return ResourceManager.GetString("Given_ResourceLoader.When_LocalizedResource", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Uno.UI.Tests/ResourceLoader/Strings/en/Resources.resw
+++ b/src/Uno.UI.Tests/ResourceLoader/Strings/en/Resources.resw
@@ -120,4 +120,7 @@
   <data name="ApplicationName" xml:space="preserve">
     <value>App70-en</value>
   </data>
+  <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
+    <value>Text in 'en'</value>
+  </data>
 </root>

--- a/src/Uno.UI.Tests/ResourceLoader/Strings/fr/Resources.Designer.cs
+++ b/src/Uno.UI.Tests/ResourceLoader/Strings/fr/Resources.Designer.cs
@@ -68,5 +68,14 @@ namespace Uno.UI.Tests.ResourceLoader.Strings.fr {
                 return ResourceManager.GetString("ApplicationName", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Text in &apos;fr&apos;.
+        /// </summary>
+        internal static string Given_ResourceLoader_When_LocalizedResource {
+            get {
+                return ResourceManager.GetString("Given_ResourceLoader.When_LocalizedResource", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Uno.UI.Tests/ResourceLoader/Strings/sr-Cyrl-BA/Resources.resw
+++ b/src/Uno.UI.Tests/ResourceLoader/Strings/sr-Cyrl-BA/Resources.resw
@@ -117,10 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="ApplicationName" xml:space="preserve">
-    <value>App70-fr</value>
-  </data>
   <data name="Given_ResourceLoader.When_LocalizedResource" xml:space="preserve">
-    <value>Text in 'fr'</value>
+    <value>Text in 'sr-Cyrl-BA'</value>
   </data>
 </root>

--- a/src/Uno.UWP/ApplicationModel/Resources/Core/ResourceQualifier.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/Core/ResourceQualifier.cs
@@ -67,7 +67,7 @@ namespace Windows.ApplicationModel.Resources.Core
 
 		private static bool IsLanguageTag(string str)
 		{
-			return LanguageTags.Contains(str);
+			return LanguageTags.Contains(str, StringComparer.InvariantCultureIgnoreCase);
 		}
 
 		#endregion


### PR DESCRIPTION
- Fix resources generation support for resources localized with region code
- Fix fallback mechanism of the Resource loader

GitHub Issue (If applicable): #493 

## PR Type
What kind of change does this PR introduce?
 - Bugfix

## What is the current behavior?
1. If a resource file is added with a region code, the resource generator will either ignore it or place it in an invalid location for the Android localization file structure
2. When a resource is missing for the current UI culture, the `ResourceLoader` will not fallback properly on the `DefaultLanguage` (if the current UI culture is `fr-FR` and the default language is `en-US`, it tries only `fr-FR` and `fr`)

## What is the new behavior?
1. File structure is now valid so Android is able to load resources by itself
2. If the current UI culture is `fr-FR` and the default language is `en-US`, `ResourceLoader` will now try (in that order) `fr-FR` , `fr`, `en-US` and `en`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/144268
