### PR TITLE
Fix invalid code generation for multiple event handlers

### DIFF
--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1964,8 +1964,8 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 												// use the WeakReferenceProvider to get a self reference to avoid adding the cost of the
 												// creation of a WeakReference.
 												//
-												writer.AppendLineInvariant($"var {member.Value}_That = ({eventSource} as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;");
-												writer.AppendLineInvariant($"{closureName}.{member.Member.Name} += ({parms}) => ({member.Value}_That.Target as {_className.className}).{member.Value}({parms});");
+												writer.AppendLineInvariant($"var {member.Member.Name}_{member.Value}_That = ({eventSource} as global::Uno.UI.DataBinding.IWeakReferenceProvider).WeakReference;");
+												writer.AppendLineInvariant($"{closureName}.{member.Member.Name} += ({parms}) => ({member.Member.Name}_{member.Value}_That.Target as {_className.className}).{member.Value}({parms});");
 											}
 											else
 											{

--- a/src/SourceGenerators/XamlGenerationTests/XamlEvents.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/XamlEvents.xaml
@@ -8,6 +8,6 @@
 			 d:DesignHeight="300"
 			 d:DesignWidth="400">
 	<Grid>
-		<Button Click="Button_Click" />
+		<Button Click="Button_Click" Loaded="OnLoadUnload" Unloaded="OnLoadUnload" />
 	</Grid>
 </UserControl>

--- a/src/SourceGenerators/XamlGenerationTests/XamlEvents.xaml.cs
+++ b/src/SourceGenerators/XamlGenerationTests/XamlEvents.xaml.cs
@@ -14,5 +14,10 @@ namespace XamlGenerationTests.Shared
 		{
 
 		}
+
+		private void OnLoadUnload(object sender, object e)
+		{
+
+		}
 	}
 }


### PR DESCRIPTION
## PR Type
- Bugfix

## What is the current behavior?
This code fails to compile `<Button Click="Button_Click" Loaded="OnLoadUnload" Unloaded="OnLoadUnload" />`

## What is the new behavior?
The above code build properly. This regression was introduced by the #497.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes