### PR TITLE
fix - Time picker missing "OK" confirmation button

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -65,6 +65,7 @@
   [iOS] For BindableUISwitch : Background property was changed for OnTintColorBrush and Foreground property for ThumbTintColorBrush.
   [Android] BindableSwitch was renamed BindableSwitchCompat in order to avoid confusion with the Switch control.
 * Remove invalid Windows.UI.Xaml.Input.VirtualKeyModifiers
+* Time picker flyout default styles has been changed to include done and cancel buttons 
 * DataTemplateSelector implementations are now called using the 2 parameters overload first with a fallback to the 1 parameter overload on null returned value.
   Old behavior could be restored using `FeatureConfiguration.DataTemplateSelector.UseLegacyTemplateSelectorOverload = true`.
 
@@ -103,6 +104,7 @@
  * Add workaround for iOS stackoverflow during initialization.
  * Improve the file locking issues of Uno.UI.Tasks MSBuild task
  * Fix `VisibleBoundsPadding` memory leak
+ * [ios] Time picker missing "OK" confirmation button
  * #87 / 124046 ComboBox incorrect behavior when using Items property
  * [Wasm] ComboBox wasn't working anymore since few versions
  * Fix memory leak with defining event handlers in XAML documents

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -153,6 +153,18 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\Sample2.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\Sample1.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\Sample2_styles.xaml">
+    <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ComboBoxItem_Selection.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1014,6 +1026,12 @@
       <DependentUpon>Picker_Resizable.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Models\ImageWithLateSourceViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\Sample2.xaml.cs">
+      <DependentUpon>Sample2.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\Sample1.xaml.cs">
+      <DependentUpon>Sample1.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\DelayedImagePresenter\DelayedImagePresenter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\HorizontalListViewImage.xaml.cs">
       <DependentUpon>HorizontalListViewImage.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample1.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample1.xaml
@@ -1,0 +1,28 @@
+﻿<Page x:Class="SamplesApp.Samples.TimePicker.Sample1"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:ControlTests"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:xamarin="http://nventive.com/xamarin"
+      xmlns:ios="http://nventive.com/ios"
+      xmlns:android="http://nventive.com/android"
+      xmlns:native_ios="using:UIKit"
+      xmlns:native_android="using:Android.Widget"
+      xmlns:controls="using:Uno.UI.Samples.Controls"
+      mc:Ignorable="xamarin android ios native_ios native_android">
+
+    <controls:SampleControl SampleDescription="Sample1">
+        <controls:SampleControl.SampleContent>
+            <DataTemplate>
+                <Grid Background="White">
+                    <TimePicker ios:FlyoutPlacement="Full"
+                                HorizontalAlignment="Center"
+                                MinuteIncrement="5"
+                                ClockIdentifier="12HourClock">
+                    </TimePicker>
+                </Grid>
+            </DataTemplate>
+        </controls:SampleControl.SampleContent>
+    </controls:SampleControl>
+
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample1.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample1.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace SamplesApp.Samples.TimePicker
+{
+	[SampleControlInfo("Time Picker", "Sample1")]
+	public sealed partial class Sample1 : Page
+	{
+		public Sample1()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample2.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample2.xaml
@@ -1,0 +1,36 @@
+﻿<Page x:Class="SamplesApp.Samples.TimePicker.Sample2"
+      xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+      xmlns:local="using:ControlTests"
+      xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+      xmlns:xamarin="http://nventive.com/xamarin"
+      xmlns:ios="http://nventive.com/ios"
+      xmlns:android="http://nventive.com/android"
+      xmlns:native_ios="using:UIKit"
+      xmlns:native_android="using:Android.Widget"
+      xmlns:controls="using:Uno.UI.Samples.Controls"
+      mc:Ignorable="xamarin android ios native_ios native_android">
+    <Page.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Sample2_styles.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Page.Resources>
+
+    <controls:SampleControl SampleDescription="Sample2">
+        <controls:SampleControl.SampleContent>
+            <DataTemplate>
+                <Grid Background="White">
+                    <TimePicker Style="{StaticResource FlatTimePickerStyle}"
+                                ios:FlyoutPlacement="Full"
+                                VerticalAlignment="Stretch"
+                                HorizontalAlignment="Center"
+                                MinuteIncrement="5"
+                                ClockIdentifier="12HourClock">
+                    </TimePicker>
+                </Grid>
+            </DataTemplate>
+        </controls:SampleControl.SampleContent>
+    </controls:SampleControl>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample2.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample2.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+namespace SamplesApp.Samples.TimePicker
+{
+	[SampleControlInfo("Time Picker", "Sample2")]
+	public sealed partial class Sample2 : Page
+	{
+		public Sample2()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample2_Styles.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample2_Styles.xaml
@@ -1,0 +1,185 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:local="using:Encore.Views.Styles.Controls"
+                    xmlns:xamarin="http://nventive.com/xamarin"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:ios="http://nventive.com/ios"
+                    xmlns:android="http://nventive.com/android"
+                    xmlns:native_ios="using:UIKit"
+                    xmlns:native_android="using:Android.Widget"
+                    mc:Ignorable="xamarin android ios native_ios native_android">
+
+    <Style x:Key="TimePickerFlyoutButtonStyle"
+           TargetType="Button">
+        <Setter Property="UseSystemFocusVisuals"
+                Value="False" />
+        <Setter Property="Padding"
+                Value="0,5" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Grid Background="Transparent">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="PointerOver" />
+                                <VisualState x:Name="Pressed">
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="ContentPresenter"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         Duration="0"
+                                                         To="0.7" />
+                                    </Storyboard>
+                                </VisualState>
+                                <VisualState x:Name="Disabled">
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="ContentPresenter"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         Duration="0"
+                                                         To="0.5" />
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                            <VisualStateGroup x:Name="FocusStates" />
+                        </VisualStateManager.VisualStateGroups>
+                        <ContentPresenter x:Name="ContentPresenter"
+                                          Content="{TemplateBinding Content}"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          HorizontalContentAlignment="Stretch"
+                                          VerticalContentAlignment="Center"
+                                          VerticalAlignment="Center"
+                                          AutomationProperties.AccessibilityView="Raw" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="FlatTimePickerStyle"
+           TargetType="TimePicker">
+        <Setter Property="FontSize"
+                Value="16" />
+        <Setter Property="FontWeight"
+                Value="Light" />
+        <Setter Property="IsTabStop"
+                Value="False" />
+        <Setter Property="Background"
+                Value="Transparent" />
+        <Setter Property="HorizontalAlignment"
+                Value="Center" />
+        <Setter Property="VerticalAlignment"
+                Value="Stretch" />
+        <Setter Property="MinWidth"
+                Value="0" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="TimePicker">
+                    <StackPanel  x:Name="LayoutRoot"
+                                 VerticalAlignment="Stretch"
+                                 HorizontalAlignment="Stretch">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal" />
+                                <VisualState x:Name="Disabled">
+                                    <Storyboard>
+                                        <DoubleAnimation Storyboard.TargetName="LayoutRoot"
+                                                         Storyboard.TargetProperty="Opacity"
+                                                         Duration="0"
+                                                         To="0.5" />
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
+
+                        <ContentPresenter x:Name="HeaderContentPresenter"
+                                          Grid.Row="0"
+                                          x:DeferLoadStrategy="Lazy"
+                                          Visibility="Collapsed"
+                                          Content="{TemplateBinding Header}"
+                                          ContentTemplate="{TemplateBinding HeaderTemplate}"
+                                          Margin="0,0,0,0"
+                                          Foreground="{TemplateBinding Foreground}"
+                                          AutomationProperties.AccessibilityView="Raw" />
+
+                        <Button x:Name="FlyoutButton"
+                                Grid.Row="1"
+                                Style="{StaticResource TimePickerFlyoutButtonStyle}"
+                                FontFamily="{TemplateBinding FontFamily}"
+                                FontWeight="{TemplateBinding FontWeight}"
+                                FontSize="{TemplateBinding FontSize}"
+                                Foreground="{TemplateBinding Foreground}"
+                                IsEnabled="{TemplateBinding IsEnabled}"
+                                HorizontalAlignment="Stretch"
+                                HorizontalContentAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                VerticalContentAlignment="Stretch"
+                                Height="48">
+
+                            <Grid x:Name="FlyoutButtonContentGrid">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"
+                                                      x:Name="FirstTextBlockColumn" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto"
+                                                      x:Name="SecondTextBlockColumn" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="Auto"
+                                                      x:Name="ThirdTextBlockColumn" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+
+                                <Border x:Name="FirstPickerHost"
+                                        Grid.Column="0">
+                                    <TextBlock x:Name="HourTextBlock"
+                                               TextAlignment="Center"
+                                               AutomationProperties.AccessibilityView="Raw" />
+                                </Border>
+
+                                <TextBlock Text=":"
+                                           Grid.Column="1"
+                                           VerticalAlignment="Center"
+                                           Margin="0,0,0,0" />
+
+                                <Border x:Name="SecondPickerHost"
+                                        Grid.Column="2">
+                                    <TextBlock x:Name="MinuteTextBlock"
+                                               TextAlignment="Center"
+                                               AutomationProperties.AccessibilityView="Raw" />
+                                </Border>
+
+                                <Rectangle x:Name="SecondColumnDivider"
+                                           Fill="Transparent"
+                                           HorizontalAlignment="Center"
+                                           Width="2"
+                                           Grid.Column="3" />
+
+                                <!-- SEPERATOR -->
+                                <Rectangle Width="1"
+                                           Fill="Black"
+                                           Margin="3,0,3,0"
+                                           Grid.Column="3" />
+
+                                <Border x:Name="ThirdPickerHost"
+                                        Grid.Column="4">
+                                    <TextBlock x:Name="PeriodTextBlock"
+                                               TextAlignment="Center"
+                                               AutomationProperties.AccessibilityView="Raw" />
+                                </Border>
+
+                                <Grid Visibility="Collapsed"
+                                      Grid.Column="5">
+                                    <Polygon x:Name="DropDownGlyph"
+                                             Points="0,0 1,0 5,4 9,0 10,0 5,5"
+                                             Fill="Black"
+                                             VerticalAlignment="Center"
+                                             Margin="10,0,0,0" />
+                                </Grid>
+                            </Grid>
+                        </Button>
+                    </StackPanel>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/Flyout.cs
@@ -20,11 +20,10 @@ namespace Windows.UI.Xaml.Controls
 {
 	[ContentProperty(Name = "Content")]
 	public partial class Flyout : FlyoutBase
-    {
-		private readonly FlyoutPresenter _presenter = new FlyoutPresenter();
-		internal protected Popup _popup;
-
+	{
 		private readonly SerialDisposable _sizeChangedDisposable = new SerialDisposable();
+		internal protected readonly FlyoutPresenter _presenter = new FlyoutPresenter();
+		internal protected Popup _popup;
 
 		public Style FlyoutPresenterStyle
 		{
@@ -34,12 +33,12 @@ namespace Windows.UI.Xaml.Controls
 
 		// Using a DependencyProperty as the backing store for FlyoutPresenterStyle.  This enables animation, styling, binding, etc...
 		public static readonly DependencyProperty FlyoutPresenterStyleProperty =
-			DependencyProperty.Register("FlyoutPresenterStyle", typeof(Style), typeof(Flyout), new PropertyMetadata((Style)null,OnFlyoutPresenterStyleChanged));
+			DependencyProperty.Register("FlyoutPresenterStyle", typeof(Style), typeof(Flyout), new PropertyMetadata((Style)null, OnFlyoutPresenterStyleChanged));
 
 		private static void OnFlyoutPresenterStyleChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
 		{
 			var flyout = dependencyObject as Flyout;
-            if (flyout._presenter != null)
+			if (flyout._presenter != null)
 			{
 				flyout._presenter.Style = (Style)args.NewValue;
 			}
@@ -53,7 +52,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		public static readonly DependencyProperty ContentProperty =
-			DependencyProperty.Register("Content", typeof(IUIElement), typeof(Flyout), new PropertyMetadata(default(IUIElement),OnContentChanged));
+			DependencyProperty.Register("Content", typeof(IUIElement), typeof(Flyout), new PropertyMetadata(default(IUIElement), OnContentChanged));
 
 		private static void OnContentChanged(object dependencyObject, DependencyPropertyChangedEventArgs args)
 		{
@@ -88,7 +87,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var child = _popup.Child as FrameworkElement;
 
-			if(child != null)
+			if (child != null)
 			{
 				SizeChangedEventHandler handler = (_, __) => SetPopupPositionPartial(Target);
 
@@ -98,7 +97,7 @@ namespace Windows.UI.Xaml.Controls
 					.Create(() => child.SizeChanged -= handler);
 			}
 		}
-
+		
 		partial void InitializePartial();
 
 		private void OnPopupClosed(object sender, object e)

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/Strings/en/Resources.resw
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/Strings/en/Resources.resw
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TimePickerAcceptButton.Content" xml:space="preserve">
+    <value>Done</value>
+  </data>
+  <data name="TimePickerDismissButton.Content" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+</root>

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/Strings/fr/Resources.resw
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/Strings/fr/Resources.resw
@@ -1,0 +1,126 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="TimePickerAcceptButton.Content" xml:space="preserve">
+    <value>Ok</value>
+  </data>
+  <data name="TimePickerDismissButton.Content" xml:space="preserve">
+    <value>Cancel</value>
+  </data>
+</root>

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.md
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.md
@@ -1,0 +1,36 @@
+# TimePicker
+
+## Summary
+
+TimePicker is use to select a specific time of the day in hour and minute (AM/PM).
+
+Time button open the time picker flyout popup. 
+Cancel button cancel the new time selection. You can also click outside the time picker to do the same.
+Done/OK button save the new selected time. 
+
+### Styles
+Time button style: TimePickerFlyoutButtonStyle
+Time picker flyout popup style: default generic TimePickerFlyoutPresenterStyle
+TimePickerSelector is a platform specific wrapper for IOS/Android time pickers
+
+### Device-specific implementation quirks
+
+There might be differences in the time picker on different platform since it wraps platform specific ios/android time picker
+
+#### Android
+
+Native time picker is wrapped in the flyout.
+Timepicker flyout appear centered to screen.
+You can change the flyout button by copying and modifying TimePickerFlyoutButtonStyle.
+You can change the flyout button by copying and modifying TimePickerFlyoutPresenterStyle.
+
+#### iOS
+Native time picker is wrapped in the flyout.
+Timepicker flyout appear at bottom of the screen.
+You can change the flyout button by copying and modifying TimePickerFlyoutButtonStyle.
+You can change the flyout button by copying and modifying TimePickerFlyoutPresenterStyle.
+
+Some ColorBrushes are specific to IOS and could be changed by copying and redoing the new style so they use your own color brushes  
+ IOSTimePickerAcceptButtonForegroundBrush  Color="#324f85"
+ IOSTimePickerDismissButtonForegroundBrush  Color="#324f85"
+ IOSTimePickerHeaderBackgroundBrush  Color="#f8f8f8" 

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
@@ -1,58 +1,85 @@
 ﻿#if XAMARIN_IOS
-using System;
-using System.Collections.Generic;
-using System.Text;
+
 using Uno.UI.Common;
-using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
 
 namespace Windows.UI.Xaml.Controls
 {
-	//TODO: should inherit from PickerFlyoutBase
 	public partial class TimePickerFlyout : Flyout
 	{
-		private bool _hasAcceptButton = false;
-
 		public TimePickerFlyout()
 		{
 			InitializeContent();
 		}
 
+		private void OnTap(object sender, Input.PointerRoutedEventArgs e) => e.Handled = true;
+
+		protected internal override void Close()
+		{
+			var timePickerPresenter = _presenter as TimePickerFlyoutPresenter;
+			var headerUntapZone = timePickerPresenter?.FindName("HeaderUntapableZone") as FrameworkElement;
+
+			if (headerUntapZone != null)
+			{
+				headerUntapZone.PointerPressed -= OnTap;
+			}
+
+			var timeSelector = Content as TimePickerSelector;
+
+			if (timeSelector != null)
+			{
+				timeSelector.Cancel();
+			}
+
+			base.Close();
+		}
+
+		protected internal override void Open()
+		{
+			base.Open();
+
+			var timePickerPresenter = _presenter as TimePickerFlyoutPresenter;
+			var headerUntapZone = timePickerPresenter?.FindName("HeaderUntapableZone") as FrameworkElement;
+
+			if (headerUntapZone != null)
+			{
+				//Gobbling pressed tap on the flyout header background so that it doesn't close the flyout popup. 
+				headerUntapZone.PointerPressed += OnTap;
+			}
+		}
+
 		private void InitializeContent()
 		{
-			Content = new TimePickerSelector();
+			Content = new TimePickerSelector()
+			{
+				BorderThickness = Thickness.Empty,
+				HorizontalAlignment = HorizontalAlignment.Stretch,
+				HorizontalContentAlignment = HorizontalAlignment.Stretch
+			};
+
 			BindToContent(nameof(Time));
 			BindToContent(nameof(ClockIdentifier));
-
-			AttachAcceptCommand((TimePickerSelector)Content);
-
-			this.Closed += (_, __) =>
-			{
-				// If no accept button is explicitly part of the template, then update the set Time on light dismiss
-				if (!_hasAcceptButton)
-				{
-					(Content as TimePickerSelector)?.UpdateTime();
-				}
-			};
 		}
 
 		protected override Control CreatePresenter()
 		{
-			var presenter = new TimePickerFlyoutPresenter()
+			var timePickerPresenter = new TimePickerFlyoutPresenter() { Content = Content };
+
+			void onLoad(object sender, RoutedEventArgs e)
 			{
-				Style = FlyoutPresenterStyle,
-				Content = Content
-			};
+				AttachAcceptCommand(timePickerPresenter);
+				AttachDismissCommand(timePickerPresenter);
+				timePickerPresenter.Loaded -= onLoad;
+			}
 
-			AttachAcceptCommand(presenter);
+			if (timePickerPresenter != null)
+			{
+				timePickerPresenter.Loaded += onLoad;
+			}
 
-			return presenter;
+			return timePickerPresenter;
 		}
 
-		/// <summary>
-		/// Propagate 2-way binding to property on TimePickerSelector of the same name
-		/// </summary>
-		/// <param name="propertyName"></param>
 		private void BindToContent(string propertyName)
 		{
 			this.Binding(propertyName, propertyName, Content, BindingMode.TwoWay);
@@ -61,18 +88,38 @@ namespace Windows.UI.Xaml.Controls
 		private void AttachAcceptCommand(IFrameworkElement rootControl)
 		{
 			var acceptButton = rootControl.FindName("AcceptButton") as Button;
+
 			if (acceptButton != null && acceptButton.Command == null)
 			{
 				acceptButton.Command = new DelegateCommand(Accept);
-				_hasAcceptButton = true;
+			}
+		}
+
+		private void AttachDismissCommand(IFrameworkElement rootControl)
+		{
+			var dismissButton = rootControl.FindName("DismissButton") as Button;
+
+			if (dismissButton != null && dismissButton.Command == null)
+			{
+				dismissButton.Command = new DelegateCommand(Dismiss);
 			}
 		}
 
 		private void Accept()
 		{
-			// Update the bound Time when the flyout is dismissed, as on Windows.
-			(Content as TimePickerSelector)?.UpdateTime();
-            Hide();
+			var timeSelector = Content as TimePickerSelector;
+
+			if (timeSelector != null)
+			{
+				timeSelector.SaveTime();
+			}
+
+			Hide(false);
+		}
+
+		private void Dismiss()
+		{
+			Hide(false);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -1804,17 +1804,17 @@
 	<xamarin:Style TargetType="GridViewItem"
 				   BasedOn="{StaticResource GridViewItemExpanded}" />
 
-	<!--Default style for TimePickerSelector - Xamarin-only control internal to TimePickerFlyout-->
+		<!--Default style for TimePickerSelector - Xamarin-only control internal to TimePickerFlyout-->
 	<xamarin:Style TargetType="TimePickerSelector">
 		<ios:Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="TimePickerSelector">
-					<Border Background="White"
-							CornerRadius="10"
-							HorizontalAlignment="Center"
-							VerticalAlignment="Center">
+					<ContentControl HorizontalAlignment="Stretch"
+									VerticalAlignment="Stretch"
+									HorizontalContentAlignment="Stretch"
+									VerticalContentAlignment="Stretch">
 						<native_ios:UIDatePicker />
-					</Border>
+					</ContentControl>
 				</ControlTemplate>
 			</Setter.Value>
 		</ios:Setter>
@@ -1830,7 +1830,6 @@
 			</Setter.Value>
 		</android:Setter>
 	</xamarin:Style>
-
 
 	<xamarin:Style x:Key="TimePickerFlyoutButtonStyle"
 				   TargetType="Button">
@@ -1929,36 +1928,6 @@
 										  HorizontalContentAlignment="Stretch"
 										  VerticalContentAlignment="Stretch"
 										  AutomationProperties.AccessibilityView="Raw" />
-					</Grid>
-				</ControlTemplate>
-			</Setter.Value>
-		</Setter>
-	</xamarin:Style>
-
-	<!--Default style for TimePicker - Xamarin-only control internal to TimePickerFlyout-->
-	<xamarin:Style TargetType="TimePickerFlyoutPresenter">
-		<Setter Property="VerticalAlignment"
-				Value="Stretch" />
-		<Setter Property="HorizontalAlignment"
-				Value="Stretch" />
-		<Setter Property="HorizontalContentAlignment"
-				Value="Center" />
-		<Setter Property="VerticalContentAlignment"
-				Value="Center" />
-		<Setter Property="Template">
-			<Setter.Value>
-				<ControlTemplate TargetType="FlyoutPresenter">
-					<Grid>
-						<Border HorizontalAlignment="Stretch"
-								VerticalAlignment="Stretch"
-								IsHitTestVisible="False"
-								Opacity="0.5"
-								Background="Black" />
-						<ContentPresenter
-							ContentTemplate="{TemplateBinding ContentTemplate}"
-							ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-							Content="{TemplateBinding Content}" />
-
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>
@@ -2091,6 +2060,162 @@
 			</Setter.Value>
 		</Setter>
 	</xamarin:Style>
+
+	<!--Default style for TimePicker - Xamarin-only control internal to TimePickerFlyout-->
+	<android:Style TargetType="TimePickerFlyoutPresenter">
+		<Setter Property="VerticalAlignment"
+				Value="Stretch" />
+		<Setter Property="HorizontalAlignment"
+				Value="Stretch" />
+		<Setter Property="HorizontalContentAlignment"
+				Value="Center" />
+		<Setter Property="VerticalContentAlignment"
+				Value="Center" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="FlyoutPresenter">
+					<Grid>
+						<Border HorizontalAlignment="Stretch"
+								VerticalAlignment="Stretch"
+								IsHitTestVisible="False"
+								Opacity="0.50"
+								Background="Black" />
+						<ContentPresenter Content="{TemplateBinding Content}" />
+
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</android:Style>
+
+	<SolidColorBrush x:Key="IOSTimePickerAcceptButtonForegroundBrush"
+					 Color="#055bb7" />
+	<SolidColorBrush x:Key="IOSTimePickerDismissButtonForegroundBrush"
+					 Color="#055bb7" />
+	<SolidColorBrush x:Key="IOSTimePickerHeaderBackgroundBrush"
+					 Color="#f8f8f8" />
+
+	<ios:Style x:Key="IOSTimePickerDoneCancelButtonStyle"
+			   TargetType="Button">
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="Button">
+					<Grid x:Name="ButtonLayoutGrid">
+						<VisualStateManager.VisualStateGroups>
+							<VisualStateGroup x:Name="CommonStates">
+								<VisualState x:Name="Normal" />
+								<VisualState x:Name="PointerOver" />
+
+								<VisualState x:Name="Pressed">
+									<Storyboard>
+										<DoubleAnimation Storyboard.TargetName="ButtonText"
+														 Storyboard.TargetProperty="Opacity"
+														 To="0.7" />
+									</Storyboard>
+								</VisualState>
+								<VisualState x:Name="Disabled" />
+							</VisualStateGroup>
+						</VisualStateManager.VisualStateGroups>
+						<TextBlock x:Name="ButtonText"
+								   Margin="{TemplateBinding Padding}"
+								   Text="{TemplateBinding Content}"
+								   Foreground="{TemplateBinding Foreground}"
+								   VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+								   HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+								   FontStyle="{TemplateBinding FontStyle}"
+								   FontSize="{TemplateBinding FontSize}"
+								   FontFamily="{TemplateBinding FontFamily}" />
+					</Grid>
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</ios:Style>
+
+	<ios:Style TargetType="TimePickerFlyoutPresenter">
+		<Setter Property="Background"
+				Value="White" />
+		<Setter Property="VerticalAlignment"
+				Value="Stretch" />
+		<Setter Property="HorizontalAlignment"
+				Value="Stretch" />
+		<Setter Property="HorizontalContentAlignment"
+				Value="Stretch" />
+		<Setter Property="VerticalContentAlignment"
+				Value="Bottom" />
+		<Setter Property="BorderThickness"
+				Value="0" />
+		<Setter Property="IsTabStop"
+				Value="False" />
+		<Setter Property="AutomationProperties.AutomationId"
+				Value="TimePickerFlyoutPresenter" />
+		<Setter Property="Template">
+			<Setter.Value>
+				<ControlTemplate TargetType="TimePickerFlyoutPresenter">
+					<Grid>
+						<Border x:Name="FlyoutScrim"
+								Opacity="0.30"
+								Background="Black" />
+
+						<Grid x:Name="ContentPanel"
+							  Background="{TemplateBinding Background}"
+							  BorderBrush="{TemplateBinding BorderBrush}"
+							  BorderThickness="{TemplateBinding BorderThickness}"
+							  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+							  VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
+
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
+							</Grid.RowDefinitions>
+
+							<Grid Background="{StaticResource IOSTimePickerHeaderBackgroundBrush}">
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="Auto" />
+									<ColumnDefinition Width="*" />
+									<ColumnDefinition Width="Auto" />
+								</Grid.ColumnDefinitions>
+
+								<Button x:Name="DismissButton"
+										x:Uid="TimePickerDismissButton"
+										Style="{StaticResource IOSTimePickerDoneCancelButtonStyle}"
+										Foreground="{StaticResource IOSTimePickerDismissButtonForegroundBrush}"
+										Grid.Column="0"
+										Padding="15"
+										Content="Cancel"
+										FontSize="19"
+										HorizontalAlignment="Left" />
+
+								<Border x:Name="HeaderUntapableZone"
+										Background="Transparent"
+										Grid.Column="1"
+										BorderThickness="0" />
+
+								<Button x:Name="AcceptButton"
+										x:Uid="TimePickerAcceptButton"
+										Style="{StaticResource IOSTimePickerDoneCancelButtonStyle}"
+										Foreground="{StaticResource IOSTimePickerAcceptButtonForegroundBrush}"
+										Grid.Column="2"
+										FontWeight="Bold"
+										Padding="15"
+										Content="Done"
+										FontSize="19"
+										HorizontalAlignment="Right" />
+							</Grid>
+
+							<ContentPresenter Grid.Row="1"
+											  Content="{TemplateBinding Content}"
+											  Foreground="{TemplateBinding Foreground}"
+											  HorizontalContentAlignment="Stretch"
+											  VerticalContentAlignment="Stretch"
+											  HorizontalAlignment="Stretch"
+											  VerticalAlignment="Stretch" />
+						</Grid>
+					</Grid>
+
+				</ControlTemplate>
+			</Setter.Value>
+		</Setter>
+	</ios:Style>
 
 	<SolidColorBrush x:Key="SplitViewDismissBackgroundColor"
 					 Color="Black"
@@ -9262,3 +9387,4 @@
 	<SolidColorBrush x:Key="SystemControlHighlightListMediumRevealBackgroundBrush" Color="{StaticResource SystemListMediumColor}" />
 
 </ResourceDictionary>
+	

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -337,6 +337,10 @@
 		</EmbeddedResource>
 	</ItemGroup>
 
+	<ItemGroup>
+	  <Page Include="UI\Xaml\Style\Generic\Generic.xaml" />
+	</ItemGroup>
+
 	<Target Name="BuildManualDependencies" BeforeTargets="_UnoSourceGenerator" Condition="!Exists($(T4Bin))">
 		<Message Text="Building Generators" Importance="high" />
 		<!-- This is required because the non-reference dependencies are not properly handled -->

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -337,10 +337,6 @@
 		</EmbeddedResource>
 	</ItemGroup>
 
-	<ItemGroup>
-	  <Page Include="UI\Xaml\Style\Generic\Generic.xaml" />
-	</ItemGroup>
-
 	<Target Name="BuildManualDependencies" BeforeTargets="_UnoSourceGenerator" Condition="!Exists($(T4Bin))">
 		<Message Text="Building Generators" Importance="high" />
 		<!-- This is required because the non-reference dependencies are not properly handled -->


### PR DESCRIPTION
### Bugs fixed
-  133813 [ios] Time picker missing "OK" confirmation button

### Features added
- Time picker sample in SamplesApp

### Documentations added
- TimePicker.md

### Old behavior
  In iOS, time picker is missing done, cancel buttons and related functionalities

###  New behavior
  In iOS, time picker now have working done, cancel button with related functionalities

###  PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

###  Breaking changes
-  Time picker flyout default styles has been changed to include done and cancel buttons 

###  Tasks
-  https://nventive.visualstudio.com/Umbrella/_workitems/edit/133813/
