### PR TITLE
Restore the ability to define resources using the simple structure

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/ResourcesGenerator/ResourcesGenerationTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/ResourcesGenerator/ResourcesGenerationTask.cs
@@ -212,7 +212,7 @@ namespace Uno.UI.Tasks.ResourcesGenerator
 				}
 
 				localizedDirectory = cultureWithRegion.LCID < 255
-					? $"values-b+{languageOnly.IetfLanguageTag}" // No Region info
+					? $"values-{languageOnly.IetfLanguageTag}" // No Region info
 					: $"values-b+{languageOnly.IetfLanguageTag}+{cultureWithRegion.LCID}";
 			}
 


### PR DESCRIPTION
Restore the ability to define resources (out of *.resw) using the simple structure (like "values-fr") when not using region code.

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On Android, if you want to define ressources out of a *.resw file **and** you already have some *.resw files for this language, you have to use the BCP 47 langage tag structure (as defined here https://developer.android.com/guide/topics/resources/providing-resources#AlternativeResources , eg: "values-b+fr")

## What is the new behavior?
If the language does not have a region code, you can now use the easier "values-fr"

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
If your langage have a region code (like "fr-CA", you still have to use the BCP 47 language tag, eg: "values-b+fr+3084" for "fr-CA")
To find your region code, cf. https://github.com/libyal/libfwnt/wiki/Language-Code-identifiers

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/144860
https://nventive.visualstudio.com/Umbrella/_workitems/edit/144861
