### PR TITLE
Fix issue when video metadata reports a width or height of 0

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -71,6 +71,7 @@
 ### Bug fixes
  * MediaPlayerElement [iOS] Subtitles are not disable on initial launch anymore
  * MediaPlayerElement [Android]Player status is now properly updated on media end
+ * MediaPlayerElement [Android]Fix issue when video metadata reports a width or height of 0
  * #388 Slider: NRE when vertical template is not defined
  * 138117 [Android] Removing a bookmarked/downloaded lesson can duplicate the assets of a different lesson.
  * [Wasm] Fix VirtualizingPanelAdapter measure and arrange

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.Android.cs
@@ -342,12 +342,18 @@ namespace Windows.Media.Playback
 
 					var width = parent.Width;
 					var height = parent.Height;
-					var parentRatio = (double)width / height;
+					var parentRatio = (double)width / global::System.Math.Max(1, height);
 
 					var videoWidth = _player.VideoWidth;
 					var videoHeight = _player.VideoHeight;
-					var ratio = (double)_player.VideoWidth / _player.VideoHeight;
+					
+					if (videoWidth == 0 || videoHeight == 0)
+					{
+						return;
+					}
 
+					var ratio = (double)_player.VideoWidth / global::System.Math.Max(1, _player.VideoHeight);
+					
 					_currentStretch = stretch;
 
 					switch (stretch)


### PR DESCRIPTION
GitHub Issue (If applicable): #
None

## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
Video not properly displayed when video metadata reports a width or height of 0

## What is the new behavior?
Video is shown as expected

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/NGL/_workitems/edit/144787
