### PR TITLE
fixed ListView group headers messed up on item update

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -123,6 +123,7 @@
  * #528 ComboBoxes are empty when no datacontext
  * Ensure that Uno.UI can be used with VS15.8 and earlier (prevent the use of VS15.9 and later String APIs)
  * [Android] Listview Items stay visually in a pressed state,(can click multiple) when you click then scroll down, click another item, and scroll back up
+ * 144101 fixed `ListView` group headers messed up on item update
 
 ## Release 1.42
 

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -710,6 +710,7 @@ namespace Windows.UI.Xaml.Controls
 						)
 							.DisposeWith(disposables);
 						bindableGroup.PropertyChanged += onPropertyChanged;
+						OnGroupPropertyChanged(group, insideLoop);
 
 						void onPropertyChanged(object sender, PropertyChangedEventArgs e)
 						{


### PR DESCRIPTION
## PR Type
Bugfix

## What is the current behavior?
When a collection group is added, the group headers are messed up:
- newly added group[n] uses the header of the group[n+1] below
- if group[n+2] is in the view, the above effect will occur on group[n+1] also

## What is the new behavior?
The correct group header should be displayed.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
[AB#144101](https://nventive.visualstudio.com/Umbrella/_workitems/edit/144101)