### PR TITLE
Fix Uno.UI.Tasks default values cannot be overriden in sub-msbuild

### DIFF
--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-	<UnoUIMSBuildTasksPath Condition="'$(UnoUIMSBuildTasksPath)'==''">..\Uno.UI.Tasks</UnoUIMSBuildTasksPath>
-	<UmbrellaMSBuildTasksImported>true</UmbrellaMSBuildTasksImported>
+    <UnoUIMSBuildTasksPath Condition="'$(UnoUIMSBuildTasksPath)'==''">..\Uno.UI.Tasks</UnoUIMSBuildTasksPath>
+    <UmbrellaMSBuildTasksImported>true</UmbrellaMSBuildTasksImported>
   </PropertyGroup>
 
   <ItemGroup>
-	<UnoSourceGeneratorBeforeTarget Condition="'$(XamarinProjectType)'=='android'" Include="UpdateAndroidAssets" />
+    <UnoSourceGeneratorBeforeTarget Condition="'$(XamarinProjectType)'=='android'" Include="UpdateAndroidAssets" />
   </ItemGroup>
 
   <UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.ResourcesGenerationTask_v0" />
@@ -17,38 +17,6 @@
                   AfterTargets="ResolveReferences"
 				  DependsOnTargets="AssignLinkMetadata"
 				  Condition="'$(BuildingProject)' == 'true' and '$(BuildingInsideUnoSourceGenerator)' == '' and ('$(XamarinProjectType)'!='' or '$(UnoForceProcessPRIResource)'!='')">
-
-    <MSBuild Projects="$(MSBuildProjectFile)"
-             Targets="_InnerUnoResourcesGeneration_Resources"
-             BuildInParallel="true"
-             Properties="Configuration=$(Configuration);Platform=$(Platform);Dummy1=true">
-      <Output TaskParameter="TargetOutputs" ItemName="UnoResourceFiles" />
-    </MSBuild>
-    
-	<ItemGroup>
-	  <BundleResource Condition="'%(UnoResourceFiles.UnoResourceTarget)' =='iOS'" Include="@(UnoResourceFiles)" />
-	  <AndroidResource Condition="'%(UnoResourceFiles.UnoResourceTarget)' =='Android'" Include="@(UnoResourceFiles)" />
-	  <EmbeddedResource Condition="'%(UnoResourceFiles.UnoResourceTarget)' =='Uno'" Include="@(UnoResourceFiles)" />
-	</ItemGroup>
-    
-    <MSBuild Projects="$(MSBuildProjectFile)"
-             Targets="_InnerUnoResourcesGeneration_Assets"
-             BuildInParallel="true"
-             Properties="Configuration=$(Configuration);Platform=$(Platform);Dummy2=true">
-      <Output TaskParameter="TargetOutputs" ItemName="UnoRetargetedAssetsOutput" />
-    </MSBuild>
-    
-    <ItemGroup>
-      <Content Condition="'%(UnoRetargetedAssetsOutput.OutputType)' =='Assets'" Remove="@(UnoRetargetedAssetsOutput)" />
-      <BundleResource Condition="'%(UnoRetargetedAssetsOutput.OutputType)' =='ios'" Include="@(UnoRetargetedAssetsOutput)" />
-      <AndroidResource Condition="'%(UnoRetargetedAssetsOutput.OutputType)' =='android'" Include="@(UnoRetargetedAssetsOutput)" />
-    </ItemGroup>
-
-  </Target>
-
-  <Target Name="_InnerUnoResourcesGeneration_Resources"
-		  DependsOnTargets="AssignLinkMetadata"
-          Outputs="@(UnoGeneratedFiles)">
 
     <CheckForDevenv />
 
@@ -66,60 +34,57 @@
 							   IntermediateOutputPath="$(IntermediateOutputPath)"
 							   DefaultLanguage="$(DefaultLanguage)">
       <Output TaskParameter="GeneratedFiles"
-					  ItemName="UnoGeneratedFiles" />
+					  ItemName="GeneratedFiles" />
     </ResourcesGenerationTask_v0>
-  </Target>
-  
-  <Target Name="_InnerUnoResourcesGeneration_Assets"
-		  DependsOnTargets="AssignLinkMetadata"
-          Outputs="@(UnoRetargetedAssets)">
-    
-    <CheckForDevenv />
+    <ItemGroup>
+      <BundleResource Condition="'%(GeneratedFiles.UnoResourceTarget)' =='iOS'" Include="@(GeneratedFiles)" />
+      <AndroidResource Condition="'%(GeneratedFiles.UnoResourceTarget)' =='Android'" Include="@(GeneratedFiles)" />
+      <EmbeddedResource Condition="'%(GeneratedFiles.UnoResourceTarget)' =='Uno'" Include="@(GeneratedFiles)" />
+    </ItemGroup>
 
-  <!-- Assets -->
-	<PropertyGroup>
-	  <UseHighDPIResources Condition="'$(UseHighDPIResources)'==''">True</UseHighDPIResources>
-	</PropertyGroup>
-	<RetargetAssets_v0 UseHighDPIResources="$(UseHighDPIResources)"
+    <!-- Assets -->
+    <PropertyGroup>
+      <UseHighDPIResources Condition="'$(UseHighDPIResources)'==''">True</UseHighDPIResources>
+    </PropertyGroup>
+    <RetargetAssets_v0 UseHighDPIResources="$(UseHighDPIResources)"
 						TargetPlatform="$(XamarinProjectType)"
 						DefaultLanguage="$(DefaultLanguage)"
 						ContentItems="@(Content)"
 						Condition="'$(XamarinProjectType)'!=''">
-	  <Output TaskParameter="Assets"
-					  ItemName="UnoAssets" />
-	  <Output TaskParameter="RetargetedAssets"
-					  ItemName="UnoRetargetedAssets" />
-	</RetargetAssets_v0>
-
+      <Output TaskParameter="Assets"
+					  ItemName="Assets" />
+      <Output TaskParameter="RetargetedAssets"
+					  ItemName="RetargetedAssets" />
+    </RetargetAssets_v0>
     <ItemGroup>
-      <UnoRetargetedAssets Include="@(UnoAssets)">
-        <OutputType>Assets</OutputType>
-      </UnoRetargetedAssets>
-      <UnoRetargetedAssets Include="@(RetargetedAssets)">
-        <OutputType>$(XamarinProjectType)</OutputType>
-      </UnoRetargetedAssets>
+      <Content Remove="@(Assets)" />
+      <BundleResource Condition="'$(XamarinProjectType)'=='ios'" Include="@(RetargetedAssets)" />
+      <AndroidResource Condition="'$(XamarinProjectType)'=='android'" Include="@(RetargetedAssets)" />
     </ItemGroup>
-   
   </Target>
 
-    <UsingTask
-      TaskName="CheckForDevenv"
-      TaskFactory="CodeTaskFactory"
-      AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
-      <ParameterGroup />
-      <Task>
-        <Reference Include="System.Xml"/>
-        <Using Namespace="System"/>
-        <Using Namespace="System.IO"/>
-        <Code Type="Fragment" Language="cs">
-          <![CDATA[  
+  <!--
+    Warn when the task is executed in devenv.exe: https://github.com/dotnet/project-system/issues/4494
+    -->
+
+  <UsingTask
+    TaskName="CheckForDevenv"
+    TaskFactory="CodeTaskFactory"
+    AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll" >
+    <ParameterGroup />
+    <Task>
+      <Reference Include="System.Xml"/>
+      <Using Namespace="System"/>
+      <Using Namespace="System.IO"/>
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[  
             if (System.Diagnostics.Process.GetCurrentProcess().ProcessName.Equals("devenv", System.StringComparison.OrdinalIgnoreCase))
             {
               Log.LogWarning("The Uno.UI.Tasks build task is running under devenv.exe you will have to restart Visual Studio to rebuild it.");
             }
           ]]>
-        </Code>
-      </Task>
-    </UsingTask>
+      </Code>
+    </Task>
+  </UsingTask>
 
 </Project>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix


## What is the new behavior?
The Uno.UI.Tasks could not override the DefaultLanguage property as it is being passed as a environment property.

See this for the reason of this workaround:
https://github.com/dotnet/project-system/issues/4494


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
