### PR TITLE
Combo Boxes were empty without a datacontext

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -69,7 +69,7 @@
   [iOS] For BindableUISwitch : Background property was changed for OnTintColorBrush and Foreground property for ThumbTintColorBrush.
   [Android] BindableSwitch was renamed BindableSwitchCompat in order to avoid confusion with the Switch control.
 * Remove invalid Windows.UI.Xaml.Input.VirtualKeyModifiers
-* Time picker flyout default styles has been changed to include done and cancel buttons 
+* Time picker flyout default styles has been changed to include done and cancel buttons
 * DataTemplateSelector implementations are now called using the 2 parameters overload first with a fallback to the 1 parameter overload on null returned value.
   Old behavior could be restored using `FeatureConfiguration.DataTemplateSelector.UseLegacyTemplateSelectorOverload = true`.
 
@@ -120,6 +120,7 @@
  * 144268 / #493 : Resources outside of 'en' folder not working
  * Support for duplicate XAML `AutomationProperties.Name`
  * `ListViewBase.SelectedItems` is updated on selection change in Single selection mode
+ * #528 ComboBoxes are empty when no datacontext
 
 ## Release 1.42
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -173,6 +173,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_NoDataContext.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\Sample2.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -999,6 +1003,9 @@
 
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\FontIcon\FontIconControlTest.xaml.cs">
       <DependentUpon>FontIconControlTest.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_NoDataContext.xaml.cs">
+      <DependentUpon>ComboBox_NoDataContext.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\StringKeyTemplateSelector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ComboBoxItem_Selection.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_NoDataContext.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_NoDataContext.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ComboBox.ComboBox_NoDataContext"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel DataContext="{x:Null}">
+		<ComboBox>
+			<ComboBoxItem>A</ComboBoxItem>
+			<ComboBoxItem>B</ComboBoxItem>
+			<ComboBoxItem>C</ComboBoxItem>
+			<ComboBoxItem>D</ComboBoxItem>
+			<ComboBoxItem>E</ComboBoxItem>
+			<ComboBoxItem>F</ComboBoxItem>
+			<ComboBoxItem>G</ComboBoxItem>
+			<ComboBoxItem>H</ComboBoxItem>
+		</ComboBox>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_NoDataContext.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_NoDataContext.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_NoDataContext")]
+	public sealed partial class ComboBox_NoDataContext : UserControl
+	{
+		public ComboBox_NoDataContext()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
@@ -25,8 +25,8 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private IDisposable _openPopupRegistration;
 
-        public event EventHandler<object> Closed;
-        public event EventHandler<object> Opened;
+		public event EventHandler<object> Closed;
+		public event EventHandler<object> Opened;
 
 		public PopupBase()
 		{
@@ -48,7 +48,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		partial void OnChildChangedPartial(View oldChild, View newChild)
-        {
+		{
 			if (oldChild is IDependencyObjectStoreProvider provider)
 			{
 				provider.Store.ClearValue(provider.Store.DataContextProperty, DependencyPropertyValuePrecedences.Local);
@@ -56,13 +56,21 @@ namespace Windows.UI.Xaml.Controls
 			}
 
 			UpdateDataContext();
+			UpdateTemplatedParent();
 		}
 
-		internal protected override void OnDataContextChanged(DependencyPropertyChangedEventArgs e)
+		protected internal override void OnDataContextChanged(DependencyPropertyChangedEventArgs e)
 		{
 			base.OnDataContextChanged(e);
 
 			UpdateDataContext();
+		}
+
+		protected internal override void OnTemplatedParentChanged(DependencyPropertyChangedEventArgs e)
+		{
+			base.OnTemplatedParentChanged(e);
+
+			UpdateTemplatedParent();
 		}
 
 		private void UpdateDataContext()
@@ -70,6 +78,13 @@ namespace Windows.UI.Xaml.Controls
 			if (Child is IDependencyObjectStoreProvider provider)
 			{
 				provider.Store.SetValue(provider.Store.DataContextProperty, this.DataContext, DependencyPropertyValuePrecedences.Local);
+			}
+		}
+
+		private void UpdateTemplatedParent()
+		{
+			if (Child is IDependencyObjectStoreProvider provider)
+			{
 				provider.Store.SetValue(provider.Store.TemplatedParentProperty, this.TemplatedParent, DependencyPropertyValuePrecedences.Local);
 			}
 		}


### PR DESCRIPTION
GitHub Issue (If applicable): #528 

## Bugfix

## What is the current behavior?
ComboBoxes were not working properly when used without a `DataContext`.

## What is the new behavior?
Bug fixed.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
