### PR TITLE
Add Uno.MonoAnalyzers to prevent using string APIs introduced in 15.9 and later

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -158,7 +158,7 @@ phases:
 
   - task: NuGetToolInstaller@0
     inputs:
-      versionSpec: 4.7.0
+      versionSpec: 4.9.1
       checkLatest: false
 
   - task: NuGetCommand@2

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -121,6 +121,7 @@
  * Support for duplicate XAML `AutomationProperties.Name`
  * `ListViewBase.SelectedItems` is updated on selection change in Single selection mode
  * #528 ComboBoxes are empty when no datacontext
+ * Ensure that Uno.UI can be used with VS15.8 and earlier (prevent the use of VS15.9 and later String APIs)
 
 ## Release 1.42
 

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -198,7 +198,7 @@ namespace SampleControl.Presentation
 
 			public bool Matches(string path)
 			{
-				var pathMembers = path.Split('.');
+				var pathMembers = path.Split(new char[] { '.' });
 				return Matches(category: pathMembers.ElementAtOrDefault(0), sampleName: pathMembers.ElementAtOrDefault(1));
 			}
 

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/StarStackPanel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Views/Controls/StarStackPanel.cs
@@ -540,7 +540,7 @@ namespace Uno.UI.Samples.Controls
 
 		private static GridLength[] ParseGridLength(string s)
 		{
-			var parts = s.Split(',');
+			var parts = s.Split(new[] { ',' });
 
 			var result = new List<GridLength>(parts.Length);
 

--- a/src/Uno.Analyzers/Uno.Analyzers.csproj
+++ b/src/Uno.Analyzers/Uno.Analyzers.csproj
@@ -71,5 +71,5 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-<Import Project="..\Common.targets" />
+  <Import Project="..\Common.targets" />
 </Project>

--- a/src/Uno.Foundation/Point.cs
+++ b/src/Uno.Foundation/Point.cs
@@ -51,10 +51,9 @@ namespace Windows.Foundation
         public static implicit operator Point(string point)
         {
             var parts = point
-                .Split(',')
+                .Split(new[] { ',' })
                 .Select(value => double.Parse(value, CultureInfo.InvariantCulture))
                 .ToArray();
-
 
             return new Point(parts[0], parts[1]);
         }

--- a/src/Uno.Foundation/Rect.cs
+++ b/src/Uno.Foundation/Rect.cs
@@ -45,7 +45,7 @@ namespace Windows.Foundation
 		public static implicit operator Rect(string text)
 		{
 			var parts = text
-				.Split(',')
+				.Split(new[] { ',' })
 				.Select(double.Parse)
 				.ToArray();
 

--- a/src/Uno.Foundation/SizeConverter.cs
+++ b/src/Uno.Foundation/SizeConverter.cs
@@ -28,7 +28,7 @@ namespace Windows.Foundation
 			if (stringValue != null)
 			{
 				var values = stringValue
-					.Split(',')
+					.Split(new[] { ',' })
 					.Select(s => double.Parse(s, CultureInfo.InvariantCulture))
 					.ToArray();
 

--- a/src/Uno.Foundation/Uno.Foundation.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.csproj
@@ -36,7 +36,15 @@
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETStandard'">
 		<PackageReference Include="System.Runtime.InteropServices.WindowsRuntime" Version="4.3.0" />
 	</ItemGroup>
-	
+
+	<ItemGroup>
+		<ProjectReference Include="..\Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj">
+			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+			<UndefineProperties>TargetFramework</UndefineProperties>
+		</ProjectReference>
+	</ItemGroup>
+
 	<Import Project="..\Uno.CrossTargetting.props" />
 
 </Project>

--- a/src/Uno.Foundation/Uno.Foundation.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.csproj
@@ -26,7 +26,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net461\Uno.MonoAnalyzers.dll" />
+		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/Uno.Foundation/Uno.Foundation.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.csproj
@@ -36,15 +36,16 @@
 	<ItemGroup Condition="'$(TargetFrameworkIdentifier)'=='.NETStandard'">
 		<PackageReference Include="System.Runtime.InteropServices.WindowsRuntime" Version="4.3.0" />
 	</ItemGroup>
-
+	
 	<ItemGroup>
-		<ProjectReference Include="..\Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj">
+		<!-- Disable sub project loading during docs generation to avoid https://github.com/nventive/Uno.SourceGeneration/issues/2 -->
+		<ProjectReference Include="..\Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj" Condition="'$(DocsGeneration)'==''">
 			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
 			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
 			<UndefineProperties>TargetFramework</UndefineProperties>
 		</ProjectReference>
 	</ItemGroup>
-
+	
 	<Import Project="..\Uno.CrossTargetting.props" />
 
 </Project>

--- a/src/Uno.Foundation/Uno.Foundation.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.csproj
@@ -24,6 +24,10 @@
       <ExcludeAssets>Runtime</ExcludeAssets>
     </PackageReference>
 	</ItemGroup>
+
+	<ItemGroup>
+		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net461\Uno.MonoAnalyzers.dll" />
+	</ItemGroup>
 	
 	<ItemGroup>
 		<UpToDateCheckInput Include="**\*.cs" Exclude="bin\**\*.cs;obj\**\*.cs;" />

--- a/src/Uno.MonoAnalyzers/MonoNotSupportedAPIAnalyzer.cs
+++ b/src/Uno.MonoAnalyzers/MonoNotSupportedAPIAnalyzer.cs
@@ -13,7 +13,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Uno.Analyzers
 {
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
-	public class UnoNotImplementedAnalyzer : DiagnosticAnalyzer
+	public class MonoNotSupportedAPIAnalyzer : DiagnosticAnalyzer
 	{
 		internal const string Title = "This API is not available in VS15.8 and ealier";
 		internal const string MessageFormat = "{0} is not available in VS15.8 and ealier";
@@ -25,7 +25,7 @@ namespace Uno.Analyzers
 			Title,
 			MessageFormat,
 			Category,
-			DiagnosticSeverity.Warning,
+			DiagnosticSeverity.Error,
 			isEnabledByDefault: true,
 			description: Description
 		);
@@ -46,22 +46,12 @@ namespace Uno.Analyzers
 			});
 		}
 
-		private static bool HasNotImplementedAttribute(INamedTypeSymbol notImplementedSymbol, ISymbol namedSymbol)
-		{
-			return namedSymbol.GetAttributes().Any(a => a.AttributeClass == notImplementedSymbol);
-		}
-
 		private void OnMemberAccessExpression(
 			SyntaxNodeAnalysisContext contextAnalysis,
 			INamedTypeSymbol stringSymbol,
 			INamedTypeSymbol charSymbol
 		)
 		{
-			if (IsBindableMetadata(contextAnalysis))
-			{
-				return;
-			}
-
 			var memberAccess = contextAnalysis.Node as MemberAccessExpressionSyntax;
 			var member = contextAnalysis.SemanticModel.GetSymbolInfo(memberAccess);
 
@@ -87,18 +77,6 @@ namespace Uno.Analyzers
 					contextAnalysis.ReportDiagnostic(diagnostic);
 				}
 			}
-		}
-
-		private static bool IsUnoSymbol(SymbolInfo member)
-		{
-			string name = member.Symbol?.ContainingAssembly?.Name ?? "";
-
-			return name.StartsWith("Uno", StringComparison.Ordinal) || name.Equals("TestProject", StringComparison.Ordinal);
-		}
-
-		private static bool IsBindableMetadata(SyntaxNodeAnalysisContext contextAnalysis)
-		{
-			return Path.GetFileName(contextAnalysis.Node?.GetLocation()?.SourceTree?.FilePath) == "BindableMetadata.g.cs";
 		}
 	}
 }

--- a/src/Uno.MonoAnalyzers/Uno.MonoAnalyzers.csproj
+++ b/src/Uno.MonoAnalyzers/Uno.MonoAnalyzers.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras">
 
   <PropertyGroup>
     <TargetFramework>net46</TargetFramework>

--- a/src/Uno.MonoAnalyzers/Uno.MonoAnalyzers.csproj
+++ b/src/Uno.MonoAnalyzers/Uno.MonoAnalyzers.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+  </PropertyGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis">
+			<Version>1.2.0</Version>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CodeAnalysis.Common">
+			<Version>1.2.0</Version>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp">
+			<Version>1.2.0</Version>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
+			<Version>1.2.0</Version>
+		</PackageReference>
+		<PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common">
+			<Version>1.2.0</Version>
+		</PackageReference>
+	</ItemGroup>
+
+</Project>

--- a/src/Uno.MonoAnalyzers/Uno.MonoAnalyzers.csproj
+++ b/src/Uno.MonoAnalyzers/Uno.MonoAnalyzers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net46</TargetFramework>
   </PropertyGroup>
 	
 	<ItemGroup>

--- a/src/Uno.MonoAnalyzers/UnoNotImplementedAnalyzer.cs
+++ b/src/Uno.MonoAnalyzers/UnoNotImplementedAnalyzer.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Uno.Analyzers
+{
+	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+	public class UnoNotImplementedAnalyzer : DiagnosticAnalyzer
+	{
+		internal const string Title = "This API is not available in VS15.8 and ealier";
+		internal const string MessageFormat = "{0} is not available in VS15.8 and ealier";
+		internal const string Description = "This API is not available in VS15.8 and ealier, choose a different overload";
+		internal const string Category = "Compatibility";
+
+		internal static DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+			"Uno0002",
+			Title,
+			MessageFormat,
+			Category,
+			DiagnosticSeverity.Warning,
+			isEnabledByDefault: true,
+			description: Description
+		);
+
+		public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
+
+		public override void Initialize(AnalysisContext context)
+		{
+			context.EnableConcurrentExecution();
+			context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+			context.RegisterCompilationStartAction(csa =>
+			{
+				var stringSymbol = csa.Compilation.GetTypeByMetadataName("System.String");
+				var charSymbol = csa.Compilation.GetTypeByMetadataName("System.Char");
+
+				csa.RegisterSyntaxNodeAction(c => OnMemberAccessExpression(c, stringSymbol, charSymbol), SyntaxKind.SimpleMemberAccessExpression);
+			});
+		}
+
+		private static bool HasNotImplementedAttribute(INamedTypeSymbol notImplementedSymbol, ISymbol namedSymbol)
+		{
+			return namedSymbol.GetAttributes().Any(a => a.AttributeClass == notImplementedSymbol);
+		}
+
+		private void OnMemberAccessExpression(
+			SyntaxNodeAnalysisContext contextAnalysis,
+			INamedTypeSymbol stringSymbol,
+			INamedTypeSymbol charSymbol
+		)
+		{
+			if (IsBindableMetadata(contextAnalysis))
+			{
+				return;
+			}
+
+			var memberAccess = contextAnalysis.Node as MemberAccessExpressionSyntax;
+			var member = contextAnalysis.SemanticModel.GetSymbolInfo(memberAccess);
+
+			if (member.Symbol != null && member.Symbol.ContainingSymbol == stringSymbol)
+			{
+				var validateMembers = new[] {
+					"Split",
+					"TrimStart",
+					"TrimEnd"
+				};
+
+				if(
+					validateMembers.Any(m => member.Symbol.Name == m)
+					&& member.Symbol is IMethodSymbol method
+					&& method.Parameters.FirstOrDefault()?.Type == charSymbol
+				)
+				{
+					var diagnostic = Diagnostic.Create(
+						SupportedDiagnostics.First(),
+						contextAnalysis.Node.GetLocation(),
+						member.Symbol.ToDisplayString()
+					);
+					contextAnalysis.ReportDiagnostic(diagnostic);
+				}
+			}
+		}
+
+		private static bool IsUnoSymbol(SymbolInfo member)
+		{
+			string name = member.Symbol?.ContainingAssembly?.Name ?? "";
+
+			return name.StartsWith("Uno", StringComparison.Ordinal) || name.Equals("TestProject", StringComparison.Ordinal);
+		}
+
+		private static bool IsBindableMetadata(SyntaxNodeAnalysisContext contextAnalysis)
+		{
+			return Path.GetFileName(contextAnalysis.Node?.GetLocation()?.SourceTree?.FilePath) == "BindableMetadata.g.cs";
+		}
+	}
+}

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -106,6 +106,14 @@
 
 	<!-- Override existing target, this project cannot be published -->
 	<Target Name="Publish" />
+	
+	<ItemGroup>
+		<ProjectReference Include="..\Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj">
+			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+			<UndefineProperties>TargetFramework</UndefineProperties>
+		</ProjectReference>
+	</ItemGroup>
 
 	<PropertyGroup>
 		<UnoUIGeneratorsBinPath>..\SourceGenerators\Uno.UI.SourceGenerators\bin\$(Configuration)</UnoUIGeneratorsBinPath>

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -111,14 +111,6 @@
 		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
 	</ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-			<UndefineProperties>TargetFramework</UndefineProperties>
-		</ProjectReference>
-	</ItemGroup>
-
 	<PropertyGroup>
 		<UnoUIGeneratorsBinPath>..\SourceGenerators\Uno.UI.SourceGenerators\bin\$(Configuration)</UnoUIGeneratorsBinPath>
 	</PropertyGroup>

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -106,7 +106,11 @@
 
 	<!-- Override existing target, this project cannot be published -->
 	<Target Name="Publish" />
-	
+
+	<ItemGroup>
+		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
+	</ItemGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj">
 			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>

--- a/src/Uno.UI.sln
+++ b/src/Uno.UI.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28306.52
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28516.95
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Uno.UI", "Uno.UI", "{416684CF-A4E3-4079-B380-3FF0B00E433C}"
 EndProject
@@ -121,6 +121,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Uno.UI.RuntimeTests", "Uno.UI.RuntimeTests\Uno.UI.RuntimeTests.csproj", "{028F3EE0-D51B-469A-A72C-C272585DCD40}"
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "UITests.Shared", "SamplesApp\UITests.Shared\UITests.Shared.shproj", "{BEB0AB3A-16A7-49CF-AD5E-F4A53B985AFE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Uno.MonoAnalyzers", "Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj", "{99243583-D3A8-4E16-B404-6133CE4A097A}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -3869,6 +3871,102 @@ Global
 		{028F3EE0-D51B-469A-A72C-C272585DCD40}.Release|x64.Build.0 = Release|Any CPU
 		{028F3EE0-D51B-469A-A72C-C272585DCD40}.Release|x86.ActiveCfg = Release|Any CPU
 		{028F3EE0-D51B-469A-A72C-C272585DCD40}.Release|x86.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Ad-Hoc|Any CPU.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Ad-Hoc|Any CPU.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Ad-Hoc|ARM.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Ad-Hoc|ARM.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Ad-Hoc|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Ad-Hoc|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Ad-Hoc|x64.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Ad-Hoc|x64.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Ad-Hoc|x86.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Ad-Hoc|x86.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.AppStore|Any CPU.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.AppStore|Any CPU.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.AppStore|ARM.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.AppStore|ARM.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.AppStore|iPhone.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.AppStore|iPhone.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.AppStore|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.AppStore|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.AppStore|x64.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.AppStore|x64.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.AppStore|x86.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.AppStore|x86.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Debug|ARM.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Debug|x64.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Debug|x86.Build.0 = Debug|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_Android|Any CPU.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_Android|Any CPU.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_Android|ARM.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_Android|ARM.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_Android|iPhone.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_Android|iPhone.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_Android|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_Android|iPhoneSimulator.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_Android|x64.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_Android|x64.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_Android|x86.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_Android|x86.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_iOS|Any CPU.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_iOS|Any CPU.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_iOS|ARM.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_iOS|ARM.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_iOS|iPhone.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_iOS|iPhone.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_iOS|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_iOS|iPhoneSimulator.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_iOS|x64.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_iOS|x64.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_iOS|x86.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_iOS|x86.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_NoSamples|Any CPU.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_NoSamples|Any CPU.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_NoSamples|ARM.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_NoSamples|ARM.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_NoSamples|iPhone.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_NoSamples|iPhone.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_NoSamples|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_NoSamples|iPhoneSimulator.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_NoSamples|x64.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_NoSamples|x64.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_NoSamples|x86.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_NoSamples|x86.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_UWP|Any CPU.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_UWP|Any CPU.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_UWP|ARM.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_UWP|ARM.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_UWP|iPhone.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_UWP|iPhone.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_UWP|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_UWP|iPhoneSimulator.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_UWP|x64.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_UWP|x64.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_UWP|x86.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release_UWP|x86.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release|ARM.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release|ARM.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release|iPhone.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release|x64.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release|x64.Build.0 = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release|x86.ActiveCfg = Release|Any CPU
+		{99243583-D3A8-4E16-B404-6133CE4A097A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -3918,6 +4016,7 @@ Global
 		{95F17106-3548-4CD5-B315-060C048903F5} = {416684CF-A4E3-4079-B380-3FF0B00E433C}
 		{028F3EE0-D51B-469A-A72C-C272585DCD40} = {416684CF-A4E3-4079-B380-3FF0B00E433C}
 		{BEB0AB3A-16A7-49CF-AD5E-F4A53B985AFE} = {995C1054-AB61-42EE-9A17-C32155BD6D13}
+		{99243583-D3A8-4E16-B404-6133CE4A097A} = {EB8A2299-312B-495E-AFCC-D33D6ED2F8A8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9B2608F4-D82B-4B72-B399-33E822DF01D0}

--- a/src/Uno.UI/Controls/BindableImageSource.Android.cs
+++ b/src/Uno.UI/Controls/BindableImageSource.Android.cs
@@ -165,7 +165,7 @@ namespace Uno.UI.Controls
 
 			if (newUri.Scheme == "resource")
 			{
-				Resource = GetResourceId(newUri.PathAndQuery.TrimStart('/'));
+				Resource = GetResourceId(newUri.PathAndQuery.TrimStart(new[] { '/' }));
 			}
 			else if (UriSource.StartsWith("res:///", StringComparison.OrdinalIgnoreCase))
 			{

--- a/src/Uno.UI/Controls/BindableImageView.Android.cs
+++ b/src/Uno.UI/Controls/BindableImageView.Android.cs
@@ -237,7 +237,7 @@ namespace Uno.UI.Controls
                 || newUri.IsFile
                 || newUri.IsLocalResource())
 			{
-				SetImageResource(GetResourceId(newUri.PathAndQuery.TrimStart('/')));			
+				SetImageResource(GetResourceId(newUri.PathAndQuery.TrimStart(new[] { '/' })));			
 			}
 			else if (UriSource.StartsWith("res:///", StringComparison.OrdinalIgnoreCase))
 			{

--- a/src/Uno.UI/Controls/NSFontHelper.macOS.cs
+++ b/src/Uno.UI/Controls/NSFontHelper.macOS.cs
@@ -87,7 +87,7 @@ namespace Windows.UI
 			//In Windows we define FontFamily with the path to the font file followed by the font family name, separated by a #
 			if (fontPath.Contains("#"))
 			{
-				var pathParts = fontPath.Split('#');
+				var pathParts = fontPath.Split(new[] { '#' });
 				var file = pathParts[0];
 				var familyName = pathParts[1];
 
@@ -230,7 +230,7 @@ namespace Windows.UI
 		{
 			//based on Fonts available @ http://iosfonts.com/
 			//for Windows parity feature, we will not support FontFamily="HelveticaNeue-Bold" (will ignore Bold and must be set by FontWeight property instead)
-			var rootFontFamilyName = fontFamilyName.Split('-').FirstOrDefault();
+			var rootFontFamilyName = fontFamilyName.Split(new[] { '-' }).FirstOrDefault();
 
 			if (rootFontFamilyName.HasValue())
 			{

--- a/src/Uno.UI/Controls/UIFontHelper.iOS.cs
+++ b/src/Uno.UI/Controls/UIFontHelper.iOS.cs
@@ -97,7 +97,7 @@ namespace Windows.UI
 			//In Windows we define FontFamily with the path to the font file followed by the font family name, separated by a #
 			if (fontPath.Contains("#"))
 			{
-				var pathParts = fontPath.Split('#');
+				var pathParts = fontPath.Split(new[] { '#' });
 				var file = pathParts[0];
 				var familyName = pathParts[1];
 
@@ -235,7 +235,7 @@ namespace Windows.UI
 		{
 			//based on Fonts available @ http://iosfonts.com/
 			//for Windows parity feature, we will not support FontFamily="HelveticaNeue-Bold" (will ignore Bold and must be set by FontWeight property instead)
-			var rootFontFamilyName = fontFamilyName.Split('-').FirstOrDefault();
+			var rootFontFamilyName = fontFamilyName.Split(new[] { '-' }).FirstOrDefault();
 
 			if (rootFontFamilyName.HasValue())
 			{

--- a/src/Uno.UI/Controls/UIImageHelper.iOS.cs
+++ b/src/Uno.UI/Controls/UIImageHelper.iOS.cs
@@ -16,7 +16,7 @@ namespace Uno.UI
 			}
 
 			var bundleName = Path.GetFileName(uri.AbsolutePath);
-			var bundlePath = uri.PathAndQuery.TrimStart('/');
+			var bundlePath = uri.PathAndQuery.TrimStart(new[] { '/' });
 
 			var image = UIImage.FromFile(bundleName) ?? UIImage.FromFile(bundlePath); 
 			return image;

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.FastConvert.cs
@@ -401,7 +401,7 @@ namespace Uno.UI.DataBinding
 			if (outputType == typeof(Windows.UI.Xaml.Media.Matrix))
 			{
 				var fields = input
-					.Split(',')
+					.Split(new[] { ',' })
 					?.Select(v => double.Parse(v, CultureInfo.InvariantCulture))
 					?.ToArray();
 
@@ -417,7 +417,7 @@ namespace Uno.UI.DataBinding
 			if (outputType == typeof(System.Drawing.PointF))
 			{
 				var fields = input
-					.Split(',')
+					.Split(new[] { ',' })
 					?.Select(v => float.Parse(v, CultureInfo.InvariantCulture))
 					?.ToArray();
 
@@ -442,7 +442,7 @@ namespace Uno.UI.DataBinding
 			if (outputType == typeof(Windows.Foundation.Point))
 			{
 				var fields = input
-					.Split(',')
+					.Split(new[] { ',' })
 					?.Select(v => double.Parse(v, CultureInfo.InvariantCulture))
 					?.ToArray();
 

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -373,7 +373,7 @@ namespace Uno.UI.DataBinding
 			{
 				var parts = property
 					.Replace(":", ".") // ':' is sometimes used to separate namespace from type
-					.Split('.')
+					.Split(new[] { '.' })
 					.Reverse()
 					.Take(2) // type name + property name
 					.Reverse()

--- a/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/WebView/WebView.iOS.cs
@@ -188,16 +188,16 @@ namespace Windows.UI.Xaml.Controls
 						var cc = new[] { "" };
 						var bcc = new[] { "" };
 
-						var recipients = mailtoUri.AbsoluteUri.Split(':')[1].Split('?')[0].Split(',');
-						var parameters = mailtoUri.Query.Split('?');
+						var recipients = mailtoUri.AbsoluteUri.Split(new[] { ':' })[1].Split(new[] { '?' })[0].Split(new[] { ',' });
+						var parameters = mailtoUri.Query.Split(new[] { '?' });
 
 						parameters = parameters.Length > 1 ?
-										parameters[1].Split('&') :
+										parameters[1].Split(new[] { '&' }) :
 										new string[0];
 
 						foreach (string param in parameters)
 						{
-							var keyValue = param.Split('=');
+							var keyValue = param.Split(new[] { '=' });
 							var key = keyValue[0];
 							var value = keyValue[1];
 

--- a/src/Uno.UI/UI/Xaml/CornerRadiusConverter.cs
+++ b/src/Uno.UI/UI/Xaml/CornerRadiusConverter.cs
@@ -31,7 +31,7 @@ namespace Windows.UI.Xaml
 			if (value is string stringValue)
 			{
 				var values = stringValue
-					.Split(',')
+					.Split(new[] { ',' })
 					.Select(s => double.Parse(s, CultureInfo.InvariantCulture))
 					.ToArray();
 

--- a/src/Uno.UI/UI/Xaml/DependencyPropertyDescriptor.cs
+++ b/src/Uno.UI/UI/Xaml/DependencyPropertyDescriptor.cs
@@ -28,12 +28,12 @@ namespace Windows.UI.Xaml
 			{
 				// (Uno.UI.Tests.BinderTests:Attachable.MyValue)
 
-				var bindingParts = propertyPath.Trim(new[] { '(', ')' }).Split(':');
+				var bindingParts = propertyPath.Trim(new[] { '(', ')' }).Split(new[] { ':' });
 
 				if (bindingParts.Length == 2)
 				{
 					var ns = bindingParts[0];
-					var propertyParts = bindingParts[1].Split('.');
+					var propertyParts = bindingParts[1].Split(new[] { '.' });
 
 					if (propertyParts.Length == 2)
 					{

--- a/src/Uno.UI/UI/Xaml/GridLength.cs
+++ b/src/Uno.UI/UI/Xaml/GridLength.cs
@@ -77,7 +77,7 @@ namespace Windows.UI.Xaml
 
 		public static GridLength[] ParseGridLength(string s)
 		{
-			var parts = s.Split(',');
+			var parts = s.Split(new[] { ',' });
 
 			var result = new List<GridLength>(parts.Length);
 

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlObjectBuilder.cs
@@ -145,7 +145,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 							// if there is no ":" this means that the type is using the default
 							// namespace, so try to resolve the best way we can.
 
-							var parts = match.Value.Trim(new[] { '(', ')' }).Split('.');
+							var parts = match.Value.Trim(new[] { '(', ')' }).Split(new[] { '.' });
 
 							if (parts.Length == 2)
 							{

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
@@ -292,7 +292,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 
             if (name.Contains(":"))
             {
-                var fields = name.Split(':');
+                var fields = name.Split(new[] { ':' });
 
                 var ns = FileDefinition.Namespaces.FirstOrDefault(n => n.Prefix == fields[0]);
 
@@ -302,7 +302,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 
                     if (nsName.StartsWith("clr-namespace:"))
                     {
-                        nsName = nsName.Split(';')[0].TrimStart("clr-namespace:");
+                        nsName = nsName.Split(new[] { ';' })[0].TrimStart("clr-namespace:");
                     }
 
                     name = nsName + "." + fields[1];
@@ -339,7 +339,7 @@ namespace Windows.UI.Xaml.Markup.Reader
 				() => Type.GetType(originalName),
 
 				// As a partial name using the non-qualified name
-				() => Type.GetType(originalName.Split(':').ElementAtOrDefault(1) ?? ""),
+				() => Type.GetType(originalName.Split(new[] { ':' }).ElementAtOrDefault(1) ?? ""),
 
 				// Look for the type in all loaded assemblies
 				() => AppDomain.CurrentDomain

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.Android.cs
@@ -35,7 +35,7 @@ namespace Windows.UI.Xaml.Media.Animation
 
 			var info = timeline.PropertyInfo.GetPathItems().Last();
 			var target = info.DataContext;
-			var property = info.PropertyName.Split('.').Last().Replace("(", "").Replace(")", "");
+			var property = info.PropertyName.Split(new[] { '.' }).Last().Replace("(", "").Replace(")", "");
 
 			if (target is View view)
 			{

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.Android.cs
@@ -110,7 +110,7 @@ namespace Windows.UI.Xaml.Media
 
 		partial void InitFromResource(Uri uri)
 		{
-			ResourceString = uri.PathAndQuery.TrimStart('/');
+			ResourceString = uri.PathAndQuery.TrimStart(new[] { '/' });
 			ResourceId = FindResourceId(ResourceString);
 		}
 

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.iOS.cs
@@ -282,7 +282,7 @@ namespace Windows.UI.Xaml.Media
 		{
 			var path = uri
 				.PathAndQuery
-				.TrimStart('/')
+				.TrimStart(new[] { '/' })
 
 				// UWP supports backward slash in path for directory separators.
 				.Replace("\\", "/");

--- a/src/Uno.UI/UI/Xaml/Media/ImageSource.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Media/ImageSource.macOS.cs
@@ -210,7 +210,7 @@ namespace Windows.UI.Xaml.Media
 		{
 			var path = uri
 				.PathAndQuery
-				.TrimStart('/')
+				.TrimStart(new[] { '/' })
 
 				// UWP supports backward slash in path for directory separators.
 				.Replace("\\", "/");

--- a/src/Uno.UI/UI/Xaml/ThicknessConverter.cs
+++ b/src/Uno.UI/UI/Xaml/ThicknessConverter.cs
@@ -27,7 +27,7 @@ namespace Windows.UI.Xaml
 			if (value is string stringValue)
 			{
 				var values = stringValue
-					.Split(',')
+					.Split(new[] { ',' })
 					.Select(s => double.Parse(s, CultureInfo.InvariantCulture))
 					.ToArray();
 

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -212,10 +212,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net461\Uno.MonoAnalyzers.dll" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<MixinInput Include=".\Mixins\Android\BaseActivity.Callbacks.tt" />
 		<MixinInput Include=".\Mixins\Android\FrameworkElementMixins.tt" />
 		<MixinInput Include=".\Mixins\Android\VisualStatesMixins.tt" />

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -331,6 +331,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net461\Uno.MonoAnalyzers.dll" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<ProjectReference Include="..\SourceGenerators\Uno.UI.SourceGenerators\Uno.UI.SourceGenerators.csproj">
 			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
 			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
@@ -346,9 +350,15 @@
 			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
 			<UndefineProperties>TargetFramework</UndefineProperties>
 		</ProjectReference>
+
+		<ProjectReference Include="..\Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj">
+			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+			<UndefineProperties>TargetFramework</UndefineProperties>
+		</ProjectReference>
 	</ItemGroup>
 
-	<Target Name="GetPackagingOutputs" Condition=" '$(TargetFramework)' == 'uap10.0' " />
+		<Target Name="GetPackagingOutputs" Condition=" '$(TargetFramework)' == 'uap10.0' " />
 
 	<Target Name="GetBuiltProjectOutputRecursive" Condition=" '$(TargetFramework)' == 'xamarinios10' " />
 	<Target Name="GetTargetPath" Condition=" '$(TargetFramework)' == 'xamarinios10' " />

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -350,8 +350,8 @@
 			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
 			<UndefineProperties>TargetFramework</UndefineProperties>
 		</ProjectReference>
-
-		<ProjectReference Include="..\Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj">
+		<!-- Disable sub project loading during docs generation to avoid https://github.com/nventive/Uno.SourceGeneration/issues/2 -->
+		<ProjectReference Include="..\Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj" Condition="'$(DocsGeneration)'==''">
 			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
 			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
 			<UndefineProperties>TargetFramework</UndefineProperties>

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -346,15 +346,15 @@
 			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
 			<UndefineProperties>TargetFramework</UndefineProperties>
 		</ProjectReference>
-		<!-- Disable sub project loading during docs generation to avoid https://github.com/nventive/Uno.SourceGeneration/issues/2 -->
-		<ProjectReference Include="..\Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj" Condition="'$(DocsGeneration)'==''">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-			<UndefineProperties>TargetFramework</UndefineProperties>
-		</ProjectReference>
 	</ItemGroup>
+	
+	<Target Name="BuildManualDependencies" BeforeTargets="Build" Condition="!Exists($(T4Bin))">
+		<Message Text="Building manual dependencies" Importance="high" />
+		<!-- This is required because the non-reference dependencies are not properly handled by the documentation tooling -->
+		<MSBuild Properties="Configuration=$(Configuration);Platform=AnyCPU" Targets="Build" Projects="..\Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj" RebaseOutputs="false" />
+	</Target>
 
-		<Target Name="GetPackagingOutputs" Condition=" '$(TargetFramework)' == 'uap10.0' " />
+	<Target Name="GetPackagingOutputs" Condition=" '$(TargetFramework)' == 'uap10.0' " />
 
 	<Target Name="GetBuiltProjectOutputRecursive" Condition=" '$(TargetFramework)' == 'xamarinios10' " />
 	<Target Name="GetTargetPath" Condition=" '$(TargetFramework)' == 'xamarinios10' " />

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -331,7 +331,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net461\Uno.MonoAnalyzers.dll" />
+		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -212,6 +212,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net461\Uno.MonoAnalyzers.dll" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<MixinInput Include=".\Mixins\Android\BaseActivity.Callbacks.tt" />
 		<MixinInput Include=".\Mixins\Android\FrameworkElementMixins.tt" />
 		<MixinInput Include=".\Mixins\Android\VisualStatesMixins.tt" />

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -348,12 +348,6 @@
 		</ProjectReference>
 	</ItemGroup>
 	
-	<Target Name="BuildManualDependencies" BeforeTargets="Build" Condition="!Exists($(T4Bin))">
-		<Message Text="Building manual dependencies" Importance="high" />
-		<!-- This is required because the non-reference dependencies are not properly handled by the documentation tooling -->
-		<MSBuild Properties="Configuration=$(Configuration);Platform=AnyCPU" Targets="Build" Projects="..\Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj" RebaseOutputs="false" />
-	</Target>
-
 	<Target Name="GetPackagingOutputs" Condition=" '$(TargetFramework)' == 'uap10.0' " />
 
 	<Target Name="GetBuiltProjectOutputRecursive" Condition=" '$(TargetFramework)' == 'xamarinios10' " />

--- a/src/Uno.UWP/ApplicationModel/Resources/Core/AndroidResourceConverter.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/Core/AndroidResourceConverter.cs
@@ -47,7 +47,7 @@ namespace Windows.ApplicationModel.Resources.Core
 
 		private static void ValidateResourceName(ResourceCandidate resourceCandidate)
 		{
-			var resourceName = Path.GetFileName(resourceCandidate.LogicalPath).Split('.')[0];
+			var resourceName = Path.GetFileName(resourceCandidate.LogicalPath).Split(new char[] { '.' })[0];
 			
 			if (string.IsNullOrWhiteSpace(resourceName) || !ValidResourceName.IsMatch(resourceName))
 			{

--- a/src/Uno.UWP/ApplicationModel/Resources/Core/ResourceCandidate.cs
+++ b/src/Uno.UWP/ApplicationModel/Resources/Core/ResourceCandidate.cs
@@ -45,14 +45,14 @@ namespace Windows.ApplicationModel.Resources.Core
 		{
 			var directoryNameWithoutQualifiers = Path
 				.GetDirectoryName(path)
-				.Split(Path.DirectorySeparatorChar)
+				.Split(new[] { Path.DirectorySeparatorChar })
 				.Where(x => ResourceQualifier.Parse(x) == null)
 				.ToArray()
 				.Apply(Path.Combine);
 
 			var fileNameWithoutQualifiers = Path
 				.GetFileName(path)
-				.Split('.')
+				.Split(new[] { '.' })
 				.Where(x => ResourceQualifier.Parse(x) == null)
 				.Apply(x => string.Join(".", x));
 

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
@@ -152,7 +152,7 @@ namespace Windows.Media.Playback
 		{
 			if (!uri.IsAbsoluteUri || uri.Scheme == "")
 			{
-				uri = new Uri(MsAppXScheme + ":///" + uri.OriginalString.TrimStart("/"));
+				uri = new Uri(MsAppXScheme + ":///" + uri.OriginalString.TrimStart(new char[] { '/' }));
 			}
 
 			var isResource = uri.Scheme.Equals(MsAppXScheme, StringComparison.OrdinalIgnoreCase)
@@ -160,7 +160,7 @@ namespace Windows.Media.Playback
 
 			if (isResource)
 			{
-				var file = uri.PathAndQuery.TrimStart('/');
+				var file = uri.PathAndQuery.TrimStart(new[] { '/' });
 				var fileName = Path.GetFileNameWithoutExtension(file);
 				var fileExtension = Path.GetExtension(file)?.Replace(".", "");
 				return NSBundle.MainBundle.GetUrlForResource(fileName, fileExtension);

--- a/src/Uno.UWP/UI/Colors.cs
+++ b/src/Uno.UWP/UI/Colors.cs
@@ -77,7 +77,7 @@ namespace Windows.UI
 			byte a, r, b, g;
 			a = r = g = b = new byte();
 
-			colorCode = colorCode.TrimStart('#');
+			colorCode = colorCode.TrimStart(new char[] { '#' });
 
 			if (colorCode.Length == 3)
 			{

--- a/src/Uno.UWP/Uno.csproj
+++ b/src/Uno.UWP/Uno.csproj
@@ -68,7 +68,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net461\Uno.MonoAnalyzers.dll" />
+		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UWP/Uno.csproj
+++ b/src/Uno.UWP/Uno.csproj
@@ -72,14 +72,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj">
-			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
-			<UndefineProperties>TargetFramework</UndefineProperties>
-		</ProjectReference>
-	</ItemGroup>
-
-	<ItemGroup>
 		<ProjectReference Include="..\Uno.Foundation\Uno.Foundation.csproj" />
 	</ItemGroup>
 	

--- a/src/Uno.UWP/Uno.csproj
+++ b/src/Uno.UWP/Uno.csproj
@@ -68,6 +68,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net461\Uno.MonoAnalyzers.dll" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<ProjectReference Include="..\Uno.Foundation\Uno.Foundation.csproj" />
 	</ItemGroup>
 	

--- a/src/Uno.UWP/Uno.csproj
+++ b/src/Uno.UWP/Uno.csproj
@@ -72,6 +72,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj">
+			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+			<UndefineProperties>TargetFramework</UndefineProperties>
+		</ProjectReference>
+	</ItemGroup>
+
+	<ItemGroup>
 		<ProjectReference Include="..\Uno.Foundation\Uno.Foundation.csproj" />
 	</ItemGroup>
 	

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -105,7 +105,7 @@ namespace Uno.UWPSyncGenerator
 
 			var process = System.Diagnostics.Process.Start(pi);
 			process.WaitForExit();
-			var installPath = process.StandardOutput.ReadToEnd().TrimEnd("\r\n");
+			var installPath = process.StandardOutput.ReadToEnd().Split('\r').First();
 
 			Environment.SetEnvironmentVariable("VSINSTALLDIR", installPath);
 
@@ -1388,6 +1388,7 @@ namespace Uno.UWPSyncGenerator
 								// { "Configuration", "Debug" },
 								//{ "BuildingInsideVisualStudio", "true" },
 								{ "SkipUnoResourceGeneration", "true" }, // Required to avoid loading a non-existent task
+								{ "DocsGeneration", "true" }, // Detect that source generation is running
 								//{ "DesignTimeBuild", "true" },
 								//{ "UseHostCompilerIfAvailable", "false" },
 								//{ "UseSharedCompilation", "false" },


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Using Uno.UI packages with visual studio 15.8 and earlier is not possible when built using VS 15.9 and later as new APIs have been added in Mono (through the import of corefx methods).

## What is the new behavior?
An analyzer is now present in Uno.UI that prevents the use of some of the newer `String.Split`, `String.TrimStart` and `String.TrimEnd` methods.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
