### PR TITLE
[Android] Listview Selected items update

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -122,6 +122,7 @@
  * `ListViewBase.SelectedItems` is updated on selection change in Single selection mode
  * #528 ComboBoxes are empty when no datacontext
  * Ensure that Uno.UI can be used with VS15.8 and earlier (prevent the use of VS15.9 and later String APIs)
+ * [Android] Listview Items stay visually in a pressed state,(can click multiple) when you click then scroll down, click another item, and scroll back up
 
 ## Release 1.42
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Android.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Windows.Foundation;
@@ -1568,6 +1568,9 @@ namespace Windows.UI.Xaml.Controls
 			if (holder.IsDetached)
 			{
 				AttachView(view);
+
+				// Here we want to check if the attached view is part of the current selection or not and update it accordingly
+				UpdateSelection(view);
 			}
 		}
 
@@ -1580,6 +1583,31 @@ namespace Windows.UI.Xaml.Controls
 			if (!holder.IsDetached)
 			{
 				DetachView(view);
+			}
+		}
+
+		/// <summary>
+		/// Checks to see if the recently attached view is up to date with selection
+		/// </summary>
+		private void UpdateSelection(View view)
+		{
+			var selectorItem = view as SelectorItem;
+			
+			var item = XamlParent?.GetItemFromIndex(XamlParent?.IndexFromContainer(selectorItem) ?? -1);
+			var selectedItems = XamlParent?.SelectedItems;
+
+			if(item != null)
+			{
+				var isItemInSelection = selectedItems.Contains(item);
+
+				if (isItemInSelection && !selectorItem.IsSelected)
+				{
+					selectorItem.IsSelected = true;
+				}
+				else if (!isItemInSelection && selectorItem.IsSelected)
+				{
+					selectorItem.IsSelected = false;
+				}
 			}
 		}
 


### PR DESCRIPTION
* Item selection is now updated properly by checking  validating selected items when attaching the views to the layout.

GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
At the moment when the list view has selected items and the selection state is changed when the item/view is detached (Not visible), the item is not updated accordingly and when it comes back into view it remains with the previous selected state. The only way to refresh the selected state is by having the item leave the visible panel (Into it's caching buffer) so that it rebinds itself and updates the selected state.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
When a view is being reattached into the Recycler view there is now a check to see if there is any discrepancy between selected items and the state of the attached view. If yes, it gets updated to it's proper state.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->
This bug fix can be validated and tested with the Uno ListView SelectedItems Sample

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://nventive.visualstudio.com/Umbrella/_workitems/edit/145176
