### PR TITLE
Add support for ICollectionView.CopyTo

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -63,6 +63,7 @@
 * Add support for Flyout anchor
 * Improved XAML designer support
 * Improved DependencyObject performance under AOT (JS dynCalls for overrides/delegates inside of EH blocks)
+* Add support for `ICollectionView.CopyTo`
 * Add support for MatrixTransform, UIElement.TransformToVisual now returns a MatrixTransform
 * Add support for `ViewBox`
 * Add support for `AutoSuggestBox.ItemsSource`

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/CollectionViewTests/Given_CollectionView.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/CollectionViewTests/Given_CollectionView.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Data;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.CollectionViewTests
+{
+	[Microsoft.VisualStudio.TestTools.UnitTesting.TestClass]
+	public class Given_CollectionView
+	{
+		[TestMethod]
+		public void When_CopyTo()
+		{
+			var originalList = new List<object> { 1, 2, 3 };
+			var SUT = new CollectionView(originalList, false);
+
+			var array = new object[3];
+			(SUT as ICollection<object>).CopyTo(array, 0);
+
+			Assert.IsTrue(array.SequenceEqual(originalList));
+		}
+
+		[TestMethod]
+		public void When_CopyTo_With_Index()
+		{
+			var originalList = new List<object> { 1, 2, 3 };
+			var SUT = new CollectionView(originalList, false);
+
+			var array = new object[4];
+			array[0] = 42;
+			(SUT as ICollection<object>).CopyTo(array, 1);
+
+			Assert.IsTrue(array.Skip(1).SequenceEqual(originalList));
+			Assert.AreEqual(42, array[0]);
+		}
+
+		[TestMethod]
+		public void When_Array_CopyTo()
+		{
+			var originalList = new object[] { 1, 2, 3 };
+			var SUT = new CollectionView(originalList, false);
+
+			var array = new object[3];
+			(SUT as ICollection<object>).CopyTo(array, 0);
+
+			Assert.IsTrue(array.SequenceEqual(originalList));
+		}
+
+		[TestMethod]
+		public void When_Array_CopyTo_With_Index()
+		{
+			var originalList = new object[]{ 1, 2, 3 };
+			var SUT = new CollectionView(originalList, false);
+
+			var array = new object[4];
+			array[0] = 42;
+			(SUT as ICollection<object>).CopyTo(array, 1);
+
+			Assert.IsTrue(array.Skip(1).SequenceEqual(originalList));
+			Assert.AreEqual(42, array[0]);
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Data/CollectionView.cs
+++ b/src/Uno.UI/UI/Xaml/Data/CollectionView.cs
@@ -244,7 +244,12 @@ namespace Windows.UI.Xaml.Data
 
 		void ICollection<object>.CopyTo(object[] array, int arrayIndex)
 		{
-			throw new NotSupportedException();
+			if(_collection is ICollection<object> list)
+			{
+				list.CopyTo(array, arrayIndex);
+			}
+
+			_collection?.ToObjectArray().CopyTo(array, arrayIndex);
 		}
 
 		IEnumerator<object> IEnumerable<object>.GetEnumerator()


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Feature

## What is the new behavior?
`ICollectionView.CopyTo` is now supported in Uno's default implementation.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
