### PR TITLE
Fix for Selector.SelectionChanged is raised twice on updated selection

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -125,6 +125,7 @@
  * Ensure that Uno.UI can be used with VS15.8 and earlier (prevent the use of VS15.9 and later String APIs)
  * [Android] Listview Items stay visually in a pressed state,(can click multiple) when you click then scroll down, click another item, and scroll back up
  * 144101 fixed `ListView` group headers messed up on item update
+ * #527 Fix for `Selector.SelectionChanged` is raised twice on updated selection
 
 ## Release 1.42
 

--- a/src/SourceGenerators/System.Xaml/System.Xaml/ParsedMarkupExtensionInfo.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/ParsedMarkupExtensionInfo.cs
@@ -141,12 +141,12 @@ namespace Uno.Xaml
 				// Remove wrapping single quotes.
 				if (stringValue.StartsWith("'") && stringValue.EndsWith("'"))
 				{
-					return stringValue.Trim('\'');
+					return stringValue.Trim(new[] { '\'' });
 				}
 				// Remove wrapping double quotes.
 				else if (stringValue.StartsWith("\"") && stringValue.EndsWith("\""))
 				{
-					return stringValue.Trim('\"');
+					return stringValue.Trim(new[] { '\"' });
 				}
 			}
 

--- a/src/Uno.Foundation/Uno.Foundation.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.csproj
@@ -26,7 +26,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
+		<Analyzer Include="$(MSBuildThisFileDirectory)..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/src/Uno.MonoAnalyzers/MonoNotSupportedAPIAnalyzer.cs
+++ b/src/Uno.MonoAnalyzers/MonoNotSupportedAPIAnalyzer.cs
@@ -72,6 +72,7 @@ namespace Uno.Analyzers
 							"Split",
 							"TrimStart",
 							"TrimEnd",
+							"Trim",
 							"IndexOfAny",
 							"Join",
 							"StartsWith",

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase.cs
@@ -92,7 +92,8 @@ namespace Uno.UI.Tests.ListViewBaseTests
 
 			SUT.SetBinding(
 				Selector.SelectedItemProperty,
-				new Binding() {
+				new Binding()
+				{
 					Path = "SelectedItem",
 					Source = model,
 					Mode = BindingMode.TwoWay
@@ -105,7 +106,8 @@ namespace Uno.UI.Tests.ListViewBaseTests
 
 			var selectionChanged = 0;
 
-			SUT.SelectionChanged += (s, e) => {
+			SUT.SelectionChanged += (s, e) =>
+			{
 				selectionChanged++;
 				Assert.AreEqual(item, SUT.SelectedItem);
 
@@ -121,6 +123,35 @@ namespace Uno.UI.Tests.ListViewBaseTests
 			Assert.IsNotNull(SUT.SelectedItem);
 			Assert.AreEqual(1, selectionChanged);
 			Assert.AreEqual(1, SUT.SelectedItems.Count);
+		}
+
+		[TestMethod]
+		public void When_ResetItemsSource()
+		{
+			var style = new Style(typeof(Windows.UI.Xaml.Controls.ListViewBase))
+			{
+				Setters =  {
+					new Setter<ItemsControl>("Template", t =>
+						t.Template = Funcs.Create(() =>
+							new ItemsPresenter()
+						)
+					)
+				}
+			};
+
+			var panel = new StackPanel();
+
+			var SUT = new ListViewBase()
+			{
+				Style = style,
+				ItemsPanel = new ItemsPanelTemplate(() => panel),
+				SelectionMode = ListViewSelectionMode.Single,
+			};
+
+			SUT.ItemsSource = new int[] { 1, 2, 3 };
+			SUT.OnItemClicked(0);
+
+			SUT.ItemsSource = null;
 		}
 	}
 

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ListViewBaseTests/Given_ListViewBase.cs
@@ -8,6 +8,7 @@ using Uno.Extensions;
 using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
 
 namespace Uno.UI.Tests.ListViewBaseTests
@@ -15,40 +16,6 @@ namespace Uno.UI.Tests.ListViewBaseTests
 	[TestClass]
 	public class Given_ListViewBase
 	{
-		[TestMethod]
-		public void When_SingleSelectedItem()
-		{
-			var style = new Style(typeof(Windows.UI.Xaml.Controls.ListViewBase))
-			{
-				Setters =  {
-					new Setter<ItemsControl>("Template", t =>
-						t.Template = Funcs.Create(() =>
-							new ItemsPresenter()
-						)
-					)
-				}
-			};
-
-			var panel = new StackPanel();
-
-			var SUT = new ListViewBase()
-			{
-				Style = style,
-				ItemsPanel = new ItemsPanelTemplate(() => panel),
-				Items = {
-					new Border { Name = "b1" }
-				}
-			};
-
-			// Search on the panel for now, as the name lookup is not properly
-			// aligned on net46.
-			Assert.IsNotNull(panel.FindName("b1"));
-
-			SUT.SelectedIndex = 0;
-
-			Assert.IsNotNull(SUT.SelectedItem);
-			Assert.AreEqual(1, SUT.SelectedItems.Count);
-		}
 
 		[TestMethod]
 		public void When_MultiSelectedItem()
@@ -92,6 +59,74 @@ namespace Uno.UI.Tests.ListViewBaseTests
 			Assert.AreEqual(2, SUT.SelectedItems.Count);
 		}
 
+		[TestMethod]
+		public void When_SingleSelectedItem_Event()
+		{
+			var style = new Style(typeof(Windows.UI.Xaml.Controls.ListViewBase))
+			{
+				Setters =  {
+					new Setter<ItemsControl>("Template", t =>
+						t.Template = Funcs.Create(() =>
+							new ItemsPresenter()
+						)
+					)
+				}
+			};
+
+			var panel = new StackPanel();
+
+			var item = new Border { Name = "b1" };
+			var SUT = new ListViewBase()
+			{
+				Style = style,
+				ItemsPanel = new ItemsPanelTemplate(() => panel),
+				Items = {
+					item
+				}
+			};
+
+			var model = new MyModel
+			{
+				SelectedItem = (object)null
+			};
+
+			SUT.SetBinding(
+				Selector.SelectedItemProperty,
+				new Binding() {
+					Path = "SelectedItem",
+					Source = model,
+					Mode = BindingMode.TwoWay
+				}
+			);
+
+			// Search on the panel for now, as the name lookup is not properly
+			// aligned on net46.
+			Assert.IsNotNull(panel.FindName("b1"));
+
+			var selectionChanged = 0;
+
+			SUT.SelectionChanged += (s, e) => {
+				selectionChanged++;
+				Assert.AreEqual(item, SUT.SelectedItem);
+
+				// In windows, when programmatically changed, the bindings are updated *after*
+				// the event is raised, but *before* when the SelectedItem is changed from the UI.
+				Assert.IsNull(model.SelectedItem);
+			};
+
+			SUT.SelectedIndex = 0;
+
+			Assert.AreEqual(item, model.SelectedItem);
+
+			Assert.IsNotNull(SUT.SelectedItem);
+			Assert.AreEqual(1, selectionChanged);
+			Assert.AreEqual(1, SUT.SelectedItems.Count);
+		}
+	}
+
+	public class MyModel
+	{
+		public object SelectedItem { get; set; }
 	}
 
 	public class MyItemsControl : ItemsControl

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -108,7 +108,7 @@
 	<Target Name="Publish" />
 
 	<ItemGroup>
-		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
+		<Analyzer Include="$(MSBuildThisFileDirectory)..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
 	</ItemGroup>
 
 	<PropertyGroup>

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -174,10 +174,17 @@ namespace Windows.UI.Xaml.Controls
 			}
 			else
 			{
-				SelectedItems.Clear();
-				SelectedItems.Add(selectedItem);
-
 				base.OnSelectedItemChanged(oldSelectedItem, selectedItem);
+
+				try
+				{
+					_modifyingSelectionInternally = true;
+					SelectedItems.Update(new[] { selectedItem });
+				}
+				finally
+				{
+					_modifyingSelectionInternally = false;
+				}
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBase.cs
@@ -179,7 +179,15 @@ namespace Windows.UI.Xaml.Controls
 				try
 				{
 					_modifyingSelectionInternally = true;
-					SelectedItems.Update(new[] { selectedItem });
+
+					if (selectedItem != null)
+					{
+						SelectedItems.Update(new[] { selectedItem });
+					}
+					else
+					{
+						SelectedItems.Clear();
+					}
 				}
 				finally
 				{

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -301,7 +301,7 @@
 	</ItemGroup>
 
 	<PropertyGroup> 
-		<UnoUIGeneratorsBinPath>..\SourceGenerators\Uno.UI.SourceGenerators\bin\$(Configuration)</UnoUIGeneratorsBinPath> 
+		<UnoUIGeneratorsBinPath>$(MSBuildThisFileDirectory)..\SourceGenerators\Uno.UI.SourceGenerators\bin\$(Configuration)</UnoUIGeneratorsBinPath> 
 		<UnoUIMSBuildTasksPath>$(MSBuildThisFileDirectory)..\SourceGenerators\Uno.UI.Tasks\bin\$(Configuration)_Shadow</UnoUIMSBuildTasksPath>
 	</PropertyGroup> 
 
@@ -327,7 +327,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
+		<Analyzer Include="$(MSBuildThisFileDirectory)..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UWP/Uno.csproj
+++ b/src/Uno.UWP/Uno.csproj
@@ -68,7 +68,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Analyzer Include="..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
+		<Analyzer Include="$(MSBuildThisFileDirectory)..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
GitHub Issue (If applicable): #527 

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
When an item is selected in Single selection mode, the `Selector.SelectionChanged` is raised twice.

## What is the new behavior?
- The event is now raised only once.
- Fixed NRE when clearing `ListViewBase.ItemsSource`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)