### PR TITLE
Fix generated resources are not injected early enough

### DIFF
--- a/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+++ b/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
@@ -77,6 +77,10 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Uno.Foundation\Uno.Foundation.csproj" />
+    <ProjectReference Include="..\..\Uno.UI.RuntimeTests\Uno.UI.RuntimeTests.csproj">
+      <Project>{028f3ee0-d51b-469a-a72c-c272585dcd40}</Project>
+      <Name>Uno.UI.RuntimeTests</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Uno.UI\Uno.UI.csproj" />
     <ProjectReference Include="..\..\Uno.UWP\Uno.csproj" />
     <ProjectReference Include="..\..\Uno.UI.BindingHelper.Android\Uno.UI.BindingHelper.Android.csproj" />

--- a/src/SamplesApp/SamplesApp.Shared/Strings/en/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/en/Resources.resw
@@ -132,4 +132,7 @@
   <data name="Given_ResourceMap.When_MainMap" xml:space="preserve">
     <value>MainMap (en)</value>
   </data>
+  <data name="Given_ResourceService.ValidResource" xml:space="preserve">
+    <value>ValidResource (en)</value>
+  </data>
 </root>

--- a/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
+++ b/src/SourceGenerators/Uno.UI.Tasks/Content/Uno.UI.Tasks.targets
@@ -12,10 +12,14 @@
   <UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.ResourcesGenerator.ResourcesGenerationTask_v0" />
   <UsingTask AssemblyFile="$(UnoUIMSBuildTasksPath)\Uno.UI.Tasks.v0.dll" TaskName="Uno.UI.Tasks.Assets.RetargetAssets_v0" />
 
+  <!--
+  This task transforms all the Content files and PRIResources into resources files compatible for each platform.
+
+  Note: For iOS and Android, it must be run early in the build process, but no publicly stable target is available
+  to inject Uno properly. Failing to add this task early enough makes X.A and X.I miss the generated resource files.
+  -->
   <Target Name="UnoResourcesGeneration"
-				  BeforeTargets="_CheckForContent"
-                  AfterTargets="ResolveReferences"
-				  DependsOnTargets="AssignLinkMetadata"
+				  BeforeTargets="PrepareForBuild;_CheckForContent"
 				  Condition="'$(DesignTimeBuild)' != 'true' and '$(BuildingInsideUnoSourceGenerator)' == '' and ('$(XamarinProjectType)'!='' or '$(UnoForceProcessPRIResource)'!='')">
 
     <CheckForDevenv />

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Services/Given_ResourceService.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Services/Given_ResourceService.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.UI.Xaml;
+
+namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Services
+{
+#if __IOS__ || __ANDROID__
+	[TestClass]
+	public class Given_ResourceService
+	{
+		[TestMethod]
+		public void When_Valid_NativeResource()
+		{
+			Assert.AreEqual("SamplesApp", ResourceHelper.ResourcesService.Get("ApplicationName"));
+			Assert.AreEqual("ValidResource (en)", ResourceHelper.ResourcesService.Get("Given_ResourceService.ValidResource"));
+		}
+	}
+#endif
+}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Native resources are not generated properly for iOS and Android, making `Uno.UI.Services.ResourceService` return empty strings, a regression introduced in https://github.com/nventive/Uno/pull/519

## What is the new behavior?
`Uno.UI.Services.ResourceService` works properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/145484
