### PR TITLE
Adjust Uno.Xaml for invalid string overloads

### DIFF
--- a/src/SourceGenerators/System.Xaml/System.Xaml/PrefixLookup.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/PrefixLookup.cs
@@ -81,7 +81,7 @@ namespace Uno.Xaml
 				return null;
 			ns = ns.Substring (pre.Length, idx - pre.Length);
 			string ac = "";
-			foreach (string nsp in ns.Split ('.'))
+			foreach (string nsp in ns.Split (new char[] { '.' }))
 				if (nsp.Length > 0)
 					ac += nsp [0];
 			return ac.Length > 0 ? ac.ToLower (CultureInfo.InvariantCulture) : null;

--- a/src/SourceGenerators/System.Xaml/System.Xaml/XamlSchemaContext.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/XamlSchemaContext.cs
@@ -367,7 +367,7 @@ namespace Uno.Xaml
 			}
 
 			// convert xml namespace to clr namespace and assembly
-			string [] split = ns.Split (';');
+			string [] split = ns.Split (new char[] { ';' });
 			if (split.Length != 2 || split [0].Length < clr_ns_len || split [1].Length <= clr_ass_len)
 				throw new XamlParseException (string.Format ("Cannot resolve runtime namespace from XML namespace '{0}'", ns));
 			string tns = split [0].Substring (clr_ns_len);

--- a/src/SourceGenerators/System.Xaml/Uno.Xaml.csproj
+++ b/src/SourceGenerators/System.Xaml/Uno.Xaml.csproj
@@ -31,4 +31,17 @@
 		<Reference Remove="System.Xaml" />
 	</ItemGroup>
 
+	<ItemGroup>
+		<Analyzer Include="..\..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<!-- Disable sub project loading during docs generation to avoid https://github.com/nventive/Uno.SourceGeneration/issues/2 -->
+		<ProjectReference Include="..\..\Uno.MonoAnalyzers\Uno.MonoAnalyzers.csproj" Condition="'$(DocsGeneration)'==''">
+			<ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+			<SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+			<UndefineProperties>TargetFramework</UndefineProperties>
+		</ProjectReference>
+	</ItemGroup>
+
 </Project>

--- a/src/Uno.MonoAnalyzers/MonoNotSupportedAPIAnalyzer.cs
+++ b/src/Uno.MonoAnalyzers/MonoNotSupportedAPIAnalyzer.cs
@@ -50,6 +50,7 @@ namespace Uno.Analyzers
 			private readonly MonoNotSupportedAPIAnalyzer _owner;
 			private readonly INamedTypeSymbol _stringSymbol;
 			private readonly INamedTypeSymbol _charSymbol;
+			private readonly INamedTypeSymbol _stringComparisonSymbol;
 			private readonly ValidationEntry[] _validateMembers;
 
 			class ValidationEntry
@@ -63,6 +64,7 @@ namespace Uno.Analyzers
 				_owner = owner;
 				_stringSymbol = compilation.GetTypeByMetadataName("System.String");
 				_charSymbol = compilation.GetTypeByMetadataName("System.Char");
+				_stringComparisonSymbol = compilation.GetTypeByMetadataName("System.StringComparison");
 
 				_validateMembers = new [] {
 					new ValidationEntry{
@@ -70,13 +72,20 @@ namespace Uno.Analyzers
 							"Split",
 							"TrimStart",
 							"TrimEnd",
-							"IndexOf",
 							"IndexOfAny",
 							"Join",
 							"StartsWith",
 						},
 						Validation = new Func<IMethodSymbol, bool>(
 							m => m.Parameters.FirstOrDefault()?.Type == _charSymbol
+						)
+					},
+					new ValidationEntry{
+						Methods = new[] {
+							"IndexOf",
+						},
+						Validation = new Func<IMethodSymbol, bool>(
+							m => m.Parameters.ElementAtOrDefault(1)?.Type == _stringComparisonSymbol
 						)
 					},
 					new ValidationEntry{

--- a/src/Uno.MonoAnalyzers/MonoNotSupportedAPIAnalyzer.cs
+++ b/src/Uno.MonoAnalyzers/MonoNotSupportedAPIAnalyzer.cs
@@ -85,7 +85,8 @@ namespace Uno.Analyzers
 							"IndexOf",
 						},
 						Validation = new Func<IMethodSymbol, bool>(
-							m => m.Parameters.ElementAtOrDefault(1)?.Type == _stringComparisonSymbol
+							m => m.Parameters.ElementAtOrDefault(0)?.Type == _charSymbol &&
+							m.Parameters.ElementAtOrDefault(1)?.Type == _stringComparisonSymbol
 						)
 					},
 					new ValidationEntry{


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
Adjust Uno.Xaml for invalid string overloads found when building with VS 15.8

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
