### PR TITLE
Updated gitignore to fix compatibility with LFS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,9 +20,9 @@ Resource.Designer.cs
 *.userprefs
 
 # Build results
-[Dd]ebug[-\w]*/
+[Dd]ebug/
 [Dd]ebugPublic/
-[Rr]elease[-\w]*/
+[Rr]elease/
 [Rr]eleases/
 [Xx]64/
 [Xx]86/


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type
What kind of change does this PR introduce?
Build or CI related changes

## What is the current behavior?
The gitignore syntax currently causes the latest versions of LFS to fail.

## What is the new behavior?
The gitignore will be compatible with later version of LFS

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
https://dev.azure.com/nventive/_workitems/edit/146033
