### PR TITLE
Fix support for assets retargeting

### DIFF
--- a/src/SourceGenerators/System.Xaml/Uno.Xaml.csproj
+++ b/src/SourceGenerators/System.Xaml/Uno.Xaml.csproj
@@ -32,7 +32,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Analyzer Include="..\..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
+		<Analyzer Include="$(MSBuildThisFileDirectory)..\..\Uno.MonoAnalyzers\bin\$(Configuration)\net46\Uno.MonoAnalyzers.dll" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SourceGenerators/Uno.UI.Tasks/Assets/RetargetAssets.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/Assets/RetargetAssets.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
@@ -64,14 +65,22 @@ namespace Uno.UI.Tasks.Assets
 			RetargetedAssets = Assets
 				.Select(asset =>
 				{
-					if (!asset.MetadataNames.Contains("Link"))
+					if (
+						!asset.MetadataNames.Contains("Link")
+						&& !asset.MetadataNames.Contains("DefiningProjectDirectory")
+					)
 					{
-						this.Log().Info($"Skipping '{asset.ItemSpec}' because 'Link' metadata is not set.");
+						this.Log().Info($"Skipping '{asset.ItemSpec}' because 'Link' or 'DefiningProjectDirectory' metadata is not set.");
 						return null;
 					}
 
 					var fullPath = asset.GetMetadata("FullPath");
 					var relativePath = asset.GetMetadata("Link");
+
+					if (string.IsNullOrEmpty(relativePath))
+					{
+						relativePath = fullPath.Replace(asset.GetMetadata("DefiningProjectDirectory"), "");
+					}
 
 					var resourceCandidate = ResourceCandidate.Parse(fullPath, relativePath);
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Recent builds of visual studio seem to have lost the Link metadata, making assets retargeting incorrect.

## What is the new behavior?
The assets retargeting target now uses the `DefiningProjectDirectory` metadata to determine the relative path of an asset.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)