### PR TITLE
Add support for Selector.SelectedValuePath

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -66,6 +66,7 @@
 * Add support for MatrixTransform, UIElement.TransformToVisual now returns a MatrixTransform
 * Add support for `ViewBox`
 * Add support for `AutoSuggestBox.ItemsSource`
+* Add support for `Selector.SelectedValuePath` (e.g. useful for ComboBox)
 
 ### Breaking changes
 * Refactored ToggleSwitch Default Native XAML Styles. (cf. 'NativeDefaultToggleSwitch' styles in Generic.Native.xaml)

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/SelectorTests/Given_Selector.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/SelectorTests/Given_Selector.cs
@@ -1,0 +1,114 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls.Primitives;
+
+namespace Uno.UI.Tests.Windows_UI_XAML_Controls.SelectorTests
+{
+	[TestClass]
+	public class Given_Selector
+	{
+		[TestMethod]
+		public void When_Empty_SelectedValuePath()
+		{
+			var SUT = new Selector();
+			SUT.ItemsSource = new[] { 1, 2, 3 };
+
+			SUT.SelectedIndex = 0;
+			Assert.AreEqual(1, SUT.SelectedValue);
+
+			SUT.SelectedIndex = 1;
+			Assert.AreEqual(2, SUT.SelectedValue);
+		}
+
+		[TestMethod]
+		public void When_Single_SelectedValuePath()
+		{
+			var SUT = new Selector();
+			SUT.ItemsSource = new[] { Tuple.Create("1", 1), Tuple.Create("2", 2), Tuple.Create("3", 3) };
+			SUT.SelectedValuePath = "Item1";
+
+			SUT.SelectedIndex = 0;
+			Assert.AreEqual("1", SUT.SelectedValue);
+
+			SUT.SelectedIndex = 1;
+			Assert.AreEqual("2", SUT.SelectedValue);
+		}
+
+		[TestMethod]
+		public void When_Single_SelectedValuePath_Changed()
+		{
+			var SUT = new Selector();
+			var items = new[] { Tuple.Create("1", 1), Tuple.Create("2", 2), Tuple.Create("3", 3) };
+			SUT.ItemsSource = items;
+
+			SUT.SelectedIndex = 0;
+			Assert.AreEqual(items[0], SUT.SelectedValue);
+
+			SUT.SelectedValuePath = "Item1";
+
+			Assert.AreEqual(items[0].Item1, SUT.SelectedValue);
+
+			SUT.SelectedValuePath = "";
+
+			Assert.AreEqual(items[0], SUT.SelectedValue);
+		}
+
+		[TestMethod]
+		public void When_Invalid_SelectedValuePath()
+		{
+			var SUT = new Selector();
+			var items = new[] { Tuple.Create("1", 1), Tuple.Create("2", 2), Tuple.Create("3", 3) };
+			SUT.ItemsSource = items;
+
+			SUT.SelectedIndex = 0;
+			Assert.AreEqual(items[0], SUT.SelectedValue);
+
+			SUT.SelectedValuePath = "Item42";
+			Assert.IsNull(SUT.SelectedValue);
+
+			SUT.SelectedValuePath = "Item2";
+			Assert.AreEqual(1, SUT.SelectedValue);
+		}
+
+		[TestMethod]
+		public void When_Null_SelectedValuePath()
+		{
+			var SUT = new Selector();
+			var items = new[] { Tuple.Create("1", 1), Tuple.Create("2", 2), Tuple.Create("3", 3) };
+			SUT.ItemsSource = items;
+
+			SUT.SelectedIndex = 0;
+			Assert.AreEqual(items[0], SUT.SelectedValue);
+
+			SUT.SelectedValuePath = null;
+			Assert.AreEqual(items[0], SUT.SelectedValue);
+
+			SUT.SelectedValuePath = "Item2";
+			Assert.AreEqual(1, SUT.SelectedValue);
+		}
+
+		[TestMethod]
+		public void When_Double_SelectedValuePath()
+		{
+			var SUT = new Selector();
+
+			SUT.ItemsSource = new[] {
+				Tuple.Create("1", Tuple.Create("11", 1)),
+				Tuple.Create("2", Tuple.Create("22", 2)),
+				Tuple.Create("3", Tuple.Create("22", 3))
+			};
+
+			SUT.SelectedValuePath = "Item2.Item1";
+
+			SUT.SelectedIndex = 0;
+			Assert.AreEqual("11", SUT.SelectedValue);
+
+			SUT.SelectedIndex = 1;
+			Assert.AreEqual("22", SUT.SelectedValue);
+		}
+	}
+}

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/Selector.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls.Primitives/Selector.cs
@@ -7,34 +7,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 	#endif
 	public  partial class Selector : global::Windows.UI.Xaml.Controls.ItemsControl
 	{
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  string SelectedValuePath
-		{
-			get
-			{
-				return (string)this.GetValue(SelectedValuePathProperty);
-			}
-			set
-			{
-				this.SetValue(SelectedValuePathProperty, value);
-			}
-		}
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  object SelectedValue
-		{
-			get
-			{
-				return (object)this.GetValue(SelectedValueProperty);
-			}
-			set
-			{
-				this.SetValue(SelectedValueProperty, value);
-			}
-		}
-		#endif
 		// Skipping already declared property SelectedItem
 		// Skipping already declared property SelectedIndex
 		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
@@ -61,22 +33,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		#endif
 		// Skipping already declared property SelectedIndexProperty
 		// Skipping already declared property SelectedItemProperty
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty SelectedValuePathProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedValuePath", typeof(string), 
-			typeof(global::Windows.UI.Xaml.Controls.Primitives.Selector), 
-			new FrameworkPropertyMetadata(default(string)));
-		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty SelectedValueProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			"SelectedValue", typeof(object), 
-			typeof(global::Windows.UI.Xaml.Controls.Primitives.Selector), 
-			new FrameworkPropertyMetadata(default(object)));
-		#endif
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.Selector.SelectedIndex.get
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.Selector.SelectedIndex.set
 		// Forced skipping of method Windows.UI.Xaml.Controls.Primitives.Selector.SelectedItem.get


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Feature

## What is the new behavior?
Adds support for `Selector.SelectedValuePath` and `Selector.SelectedValue`, to be used with `ComboBox`.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
