### PR TITLE
Fix animations always using top-left center when using `Forever` repeat mode on Android

### DIFF
--- a/src/Uno.UI/Extensions/ViewHelper.Android.cs
+++ b/src/Uno.UI/Extensions/ViewHelper.Android.cs
@@ -168,6 +168,34 @@ namespace Uno.UI
 			return (int)((value * FontScale) + .5f);
 		}
 
+		/// <summary>
+		/// Gets the physical representation of the provided logical pixels, 
+		/// for the <see cref="View.PivotX"/> and <see cref="View.PivotY"/> of a View (cf. Remarks)
+		/// </summary>
+		/// <remarks>Compared to <see cref="LogicalToPhysicalPixels"/>, this won't apply any rounding and returns a float.</remarks>
+		/// <param name="value">The logical value</param>
+		/// <returns>The pixels value</returns>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static float LogicalToPhysicalPivotPixels(double value)
+		{
+			if (double.IsNaN(value))
+			{
+				return 0;
+			}
+
+			if (double.IsPositiveInfinity(value))
+			{
+				return int.MaxValue;
+			}
+
+			if (double.IsNegativeInfinity(value))
+			{
+				return int.MinValue;
+			}
+
+			return (float)(value * Scale);
+		}
+
 
 		/// <summary>
 		/// Gets the physical representation of the provided logical pixels.

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.Android.cs
@@ -3,6 +3,7 @@ using Android.Views;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using Windows.Foundation;
 using Uno.UI;
@@ -127,13 +128,13 @@ namespace Windows.UI.Xaml.Media.Animation
 			switch (transform)
 			{
 				case RotateTransform rotate:
-					rotate.View.PivotX = ViewHelper.LogicalToPhysicalPixels(pivotX + rotate.CenterX);
-					rotate.View.PivotY = ViewHelper.LogicalToPhysicalPixels(pivotY + rotate.CenterY);
+					rotate.View.PivotX = ViewHelper.LogicalToPhysicalPivotPixels(pivotX + rotate.CenterX);
+					rotate.View.PivotY = ViewHelper.LogicalToPhysicalPivotPixels(pivotY + rotate.CenterY);
 					break;
 
 				case ScaleTransform scale:
-					scale.View.PivotX = ViewHelper.LogicalToPhysicalPixels(pivotX + scale.CenterX);
-					scale.View.PivotY = ViewHelper.LogicalToPhysicalPixels(pivotY + scale.CenterY);
+					scale.View.PivotX = ViewHelper.LogicalToPhysicalPivotPixels(pivotX + scale.CenterX);
+					scale.View.PivotY = ViewHelper.LogicalToPhysicalPivotPixels(pivotY + scale.CenterY);
 					break;
 			}
 		}
@@ -144,13 +145,13 @@ namespace Windows.UI.Xaml.Media.Animation
 			{
 				var origin = elt.RenderTransformOrigin;
 
-				view.PivotX = ViewHelper.LogicalToPhysicalPixels(elt.ActualWidth * origin.X + centerX);
-				view.PivotY = ViewHelper.LogicalToPhysicalPixels(elt.ActualHeight * origin.Y + centerY);
+				view.PivotX = ViewHelper.LogicalToPhysicalPivotPixels(elt.ActualWidth * origin.X + centerX);
+				view.PivotY = ViewHelper.LogicalToPhysicalPivotPixels(elt.ActualHeight * origin.Y + centerY);
 			}
 			else
 			{
-				view.PivotX = ViewHelper.LogicalToPhysicalPixels(centerX);
-				view.PivotY = ViewHelper.LogicalToPhysicalPixels(centerY);
+				view.PivotX = ViewHelper.LogicalToPhysicalPivotPixels(centerX);
+				view.PivotY = ViewHelper.LogicalToPhysicalPivotPixels(centerY);
 			}
 		}
 


### PR DESCRIPTION
Fix animations always using top-left center when using `Forever` repeat mode on Android (and fix invalid rounding).

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
- When using the repeat mode `Forever` with `RenderTransform = (.5, .5)`, the animation use the right center only for the first time, then it will use `(0, 0)` as center
- If the animated control has an actual size like `(41.2, 34.8)` the center might be offseted by 1px compared to Windows

## What is the new behavior?
- Animations always use the right center
- Center is the same as Windows

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146261
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146326