### PR TITLE
[Wasm] Fixed ListView infinite loop when using custom containers

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -131,6 +131,7 @@
  * 144101 fixed `ListView` group headers messed up on item update
  * Transforms are now fully functionnal
  * #527 Fix for `Selector.SelectionChanged` is raised twice on updated selection
+ * [Wasm] Fixed ListView infinite loop when using custom containers
 
 ## Release 1.42
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -185,6 +185,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_OwnContainer_Virtualized.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Slider\Slider_Features.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1060,6 +1064,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_NoDataContext.xaml.cs">
       <DependentUpon>ComboBox_NoDataContext.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_OwnContainer_Virtualized.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\StringKeyTemplateSelector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ComboBoxItem_Selection.xaml.cs">
       <DependentUpon>ComboBox_ComboBoxItem_Selection.xaml</DependentUpon>
@@ -1638,6 +1643,12 @@
     </Compile>
     <Compile Update="C:\s\nv.github\uno-2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\AutoSuggestBox\BasicAutoSuggestBox.xaml.cs">
       <DependentUpon>BasicAutoSuggestBox.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\s\nv.github\uno-2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\ListView\ListViewItem_OwnContainer_Virtualized.xaml.cs">
+      <DependentUpon>ListViewItem_OwnContainer_Virtualized.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\s\nv.github\uno-2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\ListView\ListView_OwnContainer_Virtualized.xaml.cs">
+      <DependentUpon>ListView_OwnContainer_Virtualized.xaml</DependentUpon>
     </Compile>
     <Compile Update="C:\s\nv.github\uno-2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\ToggleSwitchControl\Native_ToggleSwitch.xaml.cs">
       <DependentUpon>Native_ToggleSwitch.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_OwnContainer_Virtualized.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_OwnContainer_Virtualized.xaml
@@ -1,0 +1,28 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ListView_OwnContainer_Virtualized"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ListView"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<Border Height="100">
+			<ListView>
+				<ContentControl Height="50" Content="Item 0"/>
+				<ContentControl Height="50" Content="Item 1"/>
+				<ContentControl Height="50" Content="Item 2"/>
+				<ContentControl Height="50" Content="Item 3"/>
+				<ContentControl Height="50" Content="Item 4"/>
+				<ContentControl Height="50" Content="Item 5"/>
+				<ContentControl Height="50" Content="Item 6"/>
+				<ContentControl Height="50" Content="Item 7"/>
+				<ContentControl Height="50" Content="Item 8"/>
+				<ContentControl Height="50" Content="Item 9"/>
+			</ListView>
+		</Border>
+    </Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_OwnContainer_Virtualized.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_OwnContainer_Virtualized.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls
+{
+	[SampleControlInfoAttribute("ListView", nameof(ListView_OwnContainer_Virtualized), description: Description)]
+	public sealed partial class ListView_OwnContainer_Virtualized : UserControl
+	{
+		private const string Description = "This sample uses custom items and virtualization associated with it. " +
+			"Scrolling through the list should work properly.";
+
+		public ListView_OwnContainer_Virtualized()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelAdapter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelAdapter.wasm.cs
@@ -63,25 +63,45 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var id = GetItemId(index);
 
-			if (this.Log().IsEnabled(LogLevel.Debug))
+			if (!_owner.XamlParent.IsIndexItsOwnContainer(index))
 			{
-				this.Log().LogDebug($"{GetMethodTag()} container={container} index={index}");
-			}
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					this.Log().LogDebug($"{GetMethodTag()} container={container} index={index}");
+				}
 
-			var cache = _itemContainerCache.FindOrCreate(id, () => new Stack<FrameworkElement>());
+				var cache = _itemContainerCache.FindOrCreate(id, () => new Stack<FrameworkElement>());
 
-			if (cache.Count < CacheLimit)
-			{
-				cache.Push(container);
+				if (cache.Count < CacheLimit)
+				{
+					cache.Push(container);
+				}
+				else
+				{
+					DiscardContainer(container);
+				}
 			}
 			else
 			{
-				// Cache is full, remove the view
-				var parent = (container.Parent) as Panel;
-				if (parent != null)
+				// Non-generated containers cannot be recycled as they
+				// are placed at specific positions.
+
+				if (this.Log().IsEnabled(LogLevel.Debug))
 				{
-					parent.Children.Remove(container);
+					this.Log().LogDebug($"{GetMethodTag()} itemIsItsOwnContainer container={container} index={index}");
 				}
+
+				DiscardContainer(container);
+			}
+		}
+
+		private static void DiscardContainer(FrameworkElement container)
+		{
+			// Cache is full, remove the view
+			var parent = (container.Parent) as Panel;
+			if (parent != null)
+			{
+				parent.Children.Remove(container);
 			}
 		}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Manipulating the `NavigationView`'s left pane will fall into an infinite loop, caused by the `ListView` trying to recycle custom `ListView` containers.

## What is the new behavior?
Custom `ListView` containers are now ignored by the recycler.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
