### PR TITLE
Fix text resources not working on Android with latest Xamarin

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/Strings/en/Resources.resw
+++ b/src/SamplesApp/SamplesApp.Shared/Strings/en/Resources.resw
@@ -135,4 +135,7 @@
   <data name="Given_ResourceService.ValidResource" xml:space="preserve">
     <value>ValidResource (en)</value>
   </data>
+  <data name="Given_ResourcesService.When_Get_ResourceFromResw" xml:space="preserve">
+    <value>Value for When_Get_ResourceFromResw</value>
+  </data>
 </root>

--- a/src/SourceGenerators/Uno.UI.Tasks/ResourcesGenerator/ResourcesGenerationTask.cs
+++ b/src/SourceGenerators/Uno.UI.Tasks/ResourcesGenerator/ResourcesGenerationTask.cs
@@ -95,7 +95,7 @@ namespace Uno.UI.Tasks.ResourcesGenerator
 			{
 				if (TargetPlatform == "android")
 				{
-					yield return GenerateAndroidResources(language, sourceLastWriteTime, resources, comment);
+					yield return GenerateAndroidResources(language, sourceLastWriteTime, resources, comment, resource);
 				}
 				else if (TargetPlatform == "ios")
 				{
@@ -133,7 +133,7 @@ namespace Uno.UI.Tasks.ResourcesGenerator
 			}
 
 
-			string resourceMapName = Path.GetFileNameWithoutExtension(resource.ItemSpec);
+			var resourceMapName = Path.GetFileNameWithoutExtension(resource.ItemSpec);
 			var logicalTargetPath = Path.Combine(buildBasePath(), resourceMapName + ".upri");
 			var actualTargetPath = Path.Combine(OutputPath, logicalTargetPath);
 
@@ -192,7 +192,7 @@ namespace Uno.UI.Tasks.ResourcesGenerator
 			);
 		}
 
-		private ITaskItem GenerateAndroidResources(string language, DateTime sourceLastWriteTime, Dictionary<string, string> resources, string comment)
+		private ITaskItem GenerateAndroidResources(string language, DateTime sourceLastWriteTime, Dictionary<string, string> resources, string comment, ITaskItem resource)
 		{
 			string localizedDirectory;
 			if (language == DefaultLanguage)
@@ -216,7 +216,9 @@ namespace Uno.UI.Tasks.ResourcesGenerator
 					: $"values-b+{languageOnly.IetfLanguageTag}+{cultureWithRegion.LCID}";
 			}
 
-			var logicalTargetPath = Path.Combine(localizedDirectory, "strings.xml"); // this path is required by Xamarin
+			// The file name have to be unique, otherwise it could be overwritten by a file with the same named defined directly in the application's head
+			var resourceMapName = Path.GetFileNameWithoutExtension(resource.ItemSpec)?.ToLowerInvariant();
+			var logicalTargetPath = Path.Combine(localizedDirectory, $"{resourceMapName}_resw-strings.xml");
 			var actualTargetPath = Path.Combine(OutputPath, logicalTargetPath);
 
 			var targetLastWriteTime = new FileInfo(actualTargetPath).LastWriteTimeUtc;

--- a/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Services/Given_ResourceService.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Uno_UI_Services/Given_ResourceService.cs
@@ -1,8 +1,8 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using Windows.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Services
 {
@@ -15,6 +15,15 @@ namespace Uno.UI.RuntimeTests.Tests.Uno_UI_Services
 		{
 			Assert.AreEqual("SamplesApp", ResourceHelper.ResourcesService.Get("ApplicationName"));
 			Assert.AreEqual("ValidResource (en)", ResourceHelper.ResourcesService.Get("Given_ResourceService.ValidResource"));
+		}
+		
+		[TestMethod]
+		public void When_Get_ResourceFromResw()
+		{
+			var sut = ResourceHelper.ResourcesService;
+			var value = sut.Get("Given_ResourcesService.When_Get_ResourceFromResw");
+
+			Assert.AreEqual($"Value for {nameof(When_Get_ResourceFromResw)}", value);
 		}
 	}
 #endif


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The text resources generated from a `.resw` file are being overwritten by the `values/string.xml` from the head project if any defined.

## What is the new behavior?
The generated file now have a custom name so it does not conflict with any other file.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
This issue might be also present on other resources types, like images. 

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146273
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146286
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146288
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146270
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146592
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146596
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146601
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146606
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146627
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146628
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146630