### PR TITLE
Add string.Contains(char) as excluded method for vs15.9

### DIFF
--- a/src/SourceGenerators/System.Xaml/System.Xaml/XamlType.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/XamlType.cs
@@ -467,7 +467,7 @@ namespace Uno.Xaml
 			var bf = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
 
 			foreach (var pi in UnderlyingType.GetProperties (bf)) {
-				if (pi.Name.Contains ('.')) // exclude explicit interface implementations.
+				if (pi.Name.Contains (".")) // exclude explicit interface implementations.
 					continue;
 				if (pi.CanRead && (pi.CanWrite || IsCollectionType (pi.PropertyType) || typeof (IXmlSerializable).IsAssignableFrom (pi.PropertyType)) && pi.GetIndexParameters ().Length == 0)
 					yield return new XamlMember (pi, SchemaContext);

--- a/src/Uno.MonoAnalyzers/MonoNotSupportedAPIAnalyzer.cs
+++ b/src/Uno.MonoAnalyzers/MonoNotSupportedAPIAnalyzer.cs
@@ -76,6 +76,7 @@ namespace Uno.Analyzers
 							"IndexOfAny",
 							"Join",
 							"StartsWith",
+							"Contains",
 						},
 						Validation = new Func<IMethodSymbol, bool>(
 							m => m.Parameters.FirstOrDefault()?.Type == _charSymbol


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
Add an exclusion for `string.Contains(char)` for vs15.8 compatibility


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
