### PR TITLE
[Wasm] Use Uno.UI Assembly for namespace type lookup

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -132,6 +132,7 @@
  * Transforms are now fully functionnal
  * #527 Fix for `Selector.SelectionChanged` is raised twice on updated selection
  * [Wasm] Fixed ListView infinite loop when using custom containers
+ * [Wasm] Use Uno.UI Assembly for namespace type lookup in `XamlReader`
 
 ## Release 1.42
 

--- a/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
+++ b/src/Uno.UI/UI/Xaml/Markup/Reader/XamlTypeResolver.cs
@@ -13,6 +13,8 @@ namespace Windows.UI.Xaml.Markup.Reader
 {
     internal class XamlTypeResolver
     {
+		private readonly static Assembly _frameworkElementAssembly = typeof(FrameworkElement).Assembly;
+
         private readonly Func<string, Type> _findType;
         private readonly Func<Type, string, bool> _isAttachedProperty;
         private readonly XamlFileDefinition FileDefinition;
@@ -20,7 +22,7 @@ namespace Windows.UI.Xaml.Markup.Reader
         private readonly Func<XamlMember, Type> _findPropertyTypeByXamlMember;
         private readonly Func<Type, PropertyInfo> _findContentProperty;
 
-        public static ImmutableDictionary<string, string[]> KnownNamespaces { get; } 
+		public static ImmutableDictionary<string, string[]> KnownNamespaces { get; } 
 			= new Dictionary<string, string[]>
 			{
 				{
@@ -321,7 +323,10 @@ namespace Windows.UI.Xaml.Markup.Reader
                 // Search first using the default namespace
                 foreach (var clrNamespace in clrNamespaces)
                 {
-                    var type = Type.GetType(clrNamespace + "." + name);
+					// This lookup is performed in the current assembly as it is the
+					// original behavior, and the Wasm AOT engine does not yet respect this
+					// behavior (because of Wasm missing stack walking feature)
+					var type = _frameworkElementAssembly.GetType(clrNamespace + "." + name);
 
                     if (type != null)
                     {


### PR DESCRIPTION
This enables Wasm compatibility.

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The XamlReader fails to find types under Full AOT runtime

## What is the new behavior?
Framework and Uno Types are now explicitly qualified.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)