### PR TITLE
Add a JS error handler for unhandled dispatcher exceptions

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -68,6 +68,7 @@
 * Add support for `ViewBox`
 * Add support for `AutoSuggestBox.ItemsSource`
 * Add support for `Selector.SelectedValuePath` (e.g. useful for ComboBox)
+* Add support for JS unhandled exception logging for CoreDispatcher (support for Mixed mode troubleshooting)
 
 ### Breaking changes
 * Refactored ToggleSwitch Default Native XAML Styles. (cf. 'NativeDefaultToggleSwitch' styles in Generic.Native.xaml)

--- a/src/Uno.UI.Wasm/ts/CoreDispatcher.ts
+++ b/src/Uno.UI.Wasm/ts/CoreDispatcher.ts
@@ -32,6 +32,16 @@
 				window.setTimeout(() => this.WakeUp(), 5000);
 			} else {
 				(<any>window).setImmediate(() => CoreDispatcher._coreDispatcherCallback());
+
+				window.setImmediate(() => {
+					try {
+						CoreDispatcher._coreDispatcherCallback();
+					}
+					catch (e) {
+						console.error(`Unhandled dispatcher exception: ${e} (${e.stack})`);
+						throw e;
+					}
+				});
 			}
 
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Feature

## What is the current behavior?
An unhandled exception raised in the context of the JS side of the CoreDispatcher don't show stack frames.

## What is the new behavior?
The JS debugger console now shows unhandled exceptions stacktraces.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
