### PR TITLE
Add fail-safe on FrameworkElement.WillMoveToSuperview

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -134,6 +134,7 @@
  * #527 Fix for `Selector.SelectionChanged` is raised twice on updated selection
  * [Wasm] Fixed ListView infinite loop when using custom containers
  * [Wasm] Use Uno.UI Assembly for namespace type lookup in `XamlReader`
+ * [iOS] Add fail-safe on `FrameworkElement.WillMoveToSuperview` log to `Application.Current.UnhandledException`
 
 ## Release 1.42
 

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
@@ -115,24 +115,30 @@ namespace <#= mixin.NamespaceName #>
 		{
 			base.WillMoveToSuperview(newsuper);
 
-			if(BinderReferenceHolder.IsEnabled)
+			try
 			{
-				if(newsuper != null)
+				if(BinderReferenceHolder.IsEnabled)
 				{
-					BinderReferenceHolder.AddNativeReference(this, newsuper);
+					if(newsuper != null)
+					{
+						BinderReferenceHolder.AddNativeReference(this, newsuper);
+					}
+					else
+					{
+						BinderReferenceHolder.RemoveNativeReference(this, _superViewRef.GetTarget() as global::Foundation.NSObject);
+					}
 				}
-				else
-				{
-					BinderReferenceHolder.RemoveNativeReference(this, _superViewRef.GetTarget() as global::Foundation.NSObject);
-				}
+
+				_superViewRef = new WeakReference<UIView>(newsuper);
+
+				WillMoveToSuperviewPartial(newsuper);
+				SyncBinder(newsuper, Window);
+				((IDependencyObjectStoreProvider)this).Store.Parent = newsuper;
 			}
-
-			_superViewRef = new WeakReference<UIView>(newsuper);
-
-			WillMoveToSuperviewPartial(newsuper);
-			SyncBinder(newsuper, Window);
-			((IDependencyObjectStoreProvider)this).Store.Parent = newsuper;
-
+			catch(Exception e)
+			{
+				Application.Current.RaiseRecoverableUnhandledExceptionOrLog(e, this);
+			}
 		}
 
 		partial void WillMoveToSuperviewPartial(UIView newsuper);


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
When an exception happens in the callees of `FrameworkElement.WillMoveToSuperview` the app is terminated.


## What is the new behavior?
A fail safe has been added, this will avoid the app to crash, and log to the Application error handler.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
