### PR TITLE
Add support for MediaPlaybackList

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -71,6 +71,7 @@
 * Add support for JS unhandled exception logging for CoreDispatcher (support for Mixed mode troubleshooting)
 * [WASM] Improve element arrange and transform performance
 * Restore original SymbolIcon.SymbolProperty as a C# property
+* Add support for `MediaPlaybackList`
 
 ### Breaking changes
 * Refactored ToggleSwitch Default Native XAML Styles. (cf. 'NativeDefaultToggleSwitch' styles in Generic.Native.xaml)

--- a/doc/articles/MediaPlayerElement.md
+++ b/doc/articles/MediaPlayerElement.md
@@ -13,7 +13,7 @@ See [MediaPlayerElement](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xam
 | MPEG-Dash	Support										| -     | -  		| 									|
 | Smooth Streaming Support								| -     | -  		| 									|
 
-_If you need to set source programmatically (ie, using `_mediaPlayerElement.Source = [source]`), please note that only source created with `MediaSource.CreateFromUri()` are currently supported_
+_If you need to set source programmatically (ie, using `_mediaPlayerElement.Source = [source]`), please note that only sources created with `MediaSource.CreateFromUri()` are currently supported_
 
 ## Features
 
@@ -41,9 +41,9 @@ _If you need to set source programmatically (ie, using `_mediaPlayerElement.Sour
 |						| Show buffering progress						  		| X     | X  		|												|
 |						| Zoom mode												| X     | X  		| 												|
 |						| Fullscreen mode								  		| X     | X  		|												|
+|						| Playlists support		  								| X     | X  		|												|
 |						| Change playback rate									| -     | -  		|												|
 |						| Player controls on locked screen support  			| -     | -  		|												|
-|						| Playlists support		  								| -     | -  		|												|
 |						| Subtitles	support			  							| -     | -  		|												|
 |						| Languages	support			  							| -     | -  		|												|
 
@@ -51,7 +51,7 @@ _If you need to set source programmatically (ie, using `_mediaPlayerElement.Sour
 
 ### iOS
 
-Add the folowwing to your info.plist
+Add the following to your info.plist
 
 ```xml
 <key>NSAppTransportSecurity</key>
@@ -83,6 +83,7 @@ Add the folowwing to your AndroidManifest.xml
 - Subtitles support
 - Languages support	
 - Display poster for audio media
+- Buffering of next playlist element when using MediaPlaybackList
 
 ## Known issues
 

--- a/src/Uno.Foundation/Collections/ObservableVector.cs
+++ b/src/Uno.Foundation/Collections/ObservableVector.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using Windows.Foundation.Collections;
 
-namespace Windows.UI.Xaml
+namespace Windows.Foundation.Collections
 {
 	internal class ObservableVector<T> : IObservableVector<T>
 	{

--- a/src/Uno.Foundation/Collections/ObservableVector.cs
+++ b/src/Uno.Foundation/Collections/ObservableVector.cs
@@ -6,7 +6,7 @@ using Windows.Foundation.Collections;
 
 namespace Windows.Foundation.Collections
 {
-	internal class ObservableVector<T> : IObservableVector<T>
+	public class ObservableVector<T> : IObservableVector<T>
 	{
 		private readonly List<T> _list = new List<T>();
 

--- a/src/Uno.Foundation/Collections/ObservableVectorEnumerableWrapper.cs
+++ b/src/Uno.Foundation/Collections/ObservableVectorEnumerableWrapper.cs
@@ -5,7 +5,7 @@ using System.Text;
 using Uno.Extensions.Specialized;
 using Windows.Foundation.Collections;
 
-namespace Windows.UI.Xaml
+namespace Windows.Foundation.Collections
 {
 #if __IOS__
 	[global::Foundation.Preserve(AllMembers = true)]

--- a/src/Uno.Foundation/Collections/ObservableVectorListWrapper.cs
+++ b/src/Uno.Foundation/Collections/ObservableVectorListWrapper.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using Windows.Foundation.Collections;
 
-namespace Windows.UI.Xaml
+namespace Windows.Foundation.Collections
 {
 #if __IOS__
 	[global::Foundation.Preserve(AllMembers = true)]

--- a/src/Uno.Foundation/Collections/ObservableVectorWrapper.cs
+++ b/src/Uno.Foundation/Collections/ObservableVectorWrapper.cs
@@ -7,7 +7,7 @@ using System.Text;
 using Uno.Extensions;
 using Windows.Foundation.Collections;
 
-namespace Windows.UI.Xaml
+namespace Windows.Foundation.Collections
 {
 #if __IOS__
 	[global::Foundation.Preserve(AllMembers = true)]

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -19,6 +19,7 @@ using Uno.UI.Helpers.WinUI;
 using Windows.ApplicationModel.Core;
 using Windows.ApplicationModel.Resources;
 using Windows.Foundation;
+using Windows.Foundation.Collections;
 using Windows.System;
 using Windows.UI.Composition;
 using Windows.UI.Core;

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackItem.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackItem.cs
@@ -2,7 +2,7 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.Media.Playback
 {
-	#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
+	#if NET46 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class MediaPlaybackItem : global::Windows.Media.Playback.IMediaPlaybackSource
@@ -17,7 +17,7 @@ namespace Windows.Media.Playback
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
+		#if NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Media.Core.MediaSource Source
 		{
@@ -145,7 +145,7 @@ namespace Windows.Media.Playback
 		}
 		#endif
 		// Forced skipping of method Windows.Media.Playback.MediaPlaybackItem.MediaPlaybackItem(Windows.Media.Core.MediaSource, System.TimeSpan, System.TimeSpan)
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
+		#if NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public MediaPlaybackItem( global::Windows.Media.Core.MediaSource source) 
 		{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackList.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.Media.Playback/MediaPlaybackList.cs
@@ -55,7 +55,7 @@ namespace Windows.Media.Playback
 			}
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET46 || __WASM__ || __MACOS__
+		#if NET46 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.Foundation.Collections.IObservableVector<global::Windows.Media.Playback.MediaPlaybackItem> Items
 		{

--- a/src/Uno.UWP/Media/Playback/IMediaPlaybackList.cs
+++ b/src/Uno.UWP/Media/Playback/IMediaPlaybackList.cs
@@ -1,0 +1,9 @@
+#if __IOS__ || __ANDROID__
+
+namespace Windows.Media.Playback
+{
+	public partial interface IMediaPlaybackList 
+	{
+	}
+}
+#endif

--- a/src/Uno.UWP/Media/Playback/MediaPlaybackItem.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlaybackItem.cs
@@ -1,0 +1,16 @@
+﻿#if __ANDROID__ || __IOS__
+using Windows.Media.Core;
+
+namespace Windows.Media.Playback
+{
+	public partial class MediaPlaybackItem : IMediaPlaybackSource
+	{
+		public MediaSource Source;
+
+		public MediaPlaybackItem(MediaSource source)
+		{
+			Source = source;
+		}
+	}
+}
+#endif

--- a/src/Uno.UWP/Media/Playback/MediaPlaybackList.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlaybackList.cs
@@ -1,0 +1,11 @@
+#if __ANDROID__ || __IOS__
+using Windows.Foundation.Collections;
+
+namespace Windows.Media.Playback
+{
+	public partial class MediaPlaybackList : IMediaPlaybackList, IMediaPlaybackSource
+	{
+		public ObservableVector<MediaPlaybackItem> Items { get; set; } = new ObservableVector<MediaPlaybackItem>();
+	}
+}
+#endif


### PR DESCRIPTION

## PR Type
What kind of change does this PR introduce?

- Feature

## What is the new behavior?

The `MediaPlaybackList` is now supported. The queued `MediaPlaybackItem`'s will play seamlessly one after the other.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information

Internal Issue: https://nventive.visualstudio.com/NGL/_workitems/edit/144487/
