### PR TITLE
Fix the `Transform.TransformBounds`

### DIFF
--- a/src/Uno.Foundation/Rect.cs
+++ b/src/Uno.Foundation/Rect.cs
@@ -10,16 +10,68 @@ namespace Windows.Foundation
 	[DebuggerDisplay("[Rect {rect.X}-{rect.Y}-{rect.Width}-{rect.Height}]")]
 	public partial struct Rect
 	{
-		public Rect(Point point, Size size) : this(point.X, point.Y, size.Width, size.Height) { }
+		private const string _negativeErrorMessage = "Non-negative number required.";
 
-		public Rect(Point point1, Point point2) : this(point1.X, point1.Y, point2.X - point1.X, point2.Y - point1.Y) { }
+		public static Rect Empty { get; } = new Rect
+		{
+			X = double.PositiveInfinity,
+			Y = double.PositiveInfinity,
+			Width = double.NegativeInfinity,
+			Height = double.NegativeInfinity
+		};
+
+		public Rect(Point point, Size size) : this(point.X, point.Y, size.Width, size.Height) { }
 
 		public Rect(double x, double y, double width, double height)
 		{
+			if (width < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(width), _negativeErrorMessage);
+			}
+			if (height < 0)
+			{
+				throw new ArgumentOutOfRangeException(nameof(width), _negativeErrorMessage);
+			}
+
 			X = x;
 			Y = y;
 			Width = width;
 			Height = height;
+		}
+
+		public Rect(Point point1, Point point2)
+		{
+			if (point1.X < point2.X) // This will return false is any is NaN, and as it's the common case, we keep it first
+			{
+				X = point1.X;
+				Width = point2.X - point1.X;
+			}
+			else if (double.IsNaN(point1.X) || double.IsNaN(point2.X))
+			{
+				X = double.NaN;
+				Width = double.NaN;
+			}
+			else
+			{
+				X = point2.X;
+				Width = point1.X - point2.X;
+			}
+
+			if (point1.Y < point2.Y) // This will return false is any is NaN, and as it's the common case, we keep it first
+			{
+				Y = point1.Y;
+				Height = point2.Y - point1.Y;
+			}
+			else if (double.IsNaN(point1.Y) || double.IsNaN(point2.Y))
+			{
+				Y = double.NaN;
+				Height = double.NaN;
+			}
+			else
+			{
+				Y = point2.Y;
+				Height = point1.Y - point2.Y;
+			}
 		}
 
 		public double X { get; set; }
@@ -32,15 +84,7 @@ namespace Windows.Foundation
 		public double Right => X + Width;
 		public double Bottom => Y + Height;
 
-		public bool IsEmpty => Empty.Equals(this);
-
-		public static Rect Empty => new Rect
-		(
-			Double.PositiveInfinity,
-			Double.PositiveInfinity,
-			Double.NegativeInfinity,
-			Double.NegativeInfinity
-		);
+		public bool IsEmpty => Empty.Equals(this);	
 
 		public static implicit operator Rect(string text)
 		{
@@ -69,10 +113,7 @@ namespace Windows.Foundation
 		/// <remarks>This property is not provided by UWP, hence it is marked internal.</remarks>
 		internal Size Size
 		{
-			get
-			{
-				return new Size(Width, Height);
-			}
+			get => new Size(Width, Height);
 			set
 			{
 				Width = value.Width;
@@ -86,10 +127,7 @@ namespace Windows.Foundation
 		/// <remarks>This property is not provided by UWP, hence it is marked internal.</remarks>
 		internal Point Location
 		{
-			get
-			{
-				return new Point(X, Y);
-			}
+			get => new Point(X, Y);
 			set
 			{
 				X = value.X;

--- a/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_MatrixTranform.cs
+++ b/src/Uno.UI.RuntimeTests/Tests/Windows_UI_Xaml_Media/Given_MatrixTranform.cs
@@ -134,13 +134,13 @@ namespace Uno.UI.RuntimeTests.Tests.Windows_UI_Xaml_Media
 					Matrix = MatrixHelper.FromMatrix3x2(Matrix3x2.CreateRotation((float)Math.PI / 4))
 				};
 
-				var expected = new Rect(-4.24264097213745, 1.41421353816986, 7.77817463874817, 7.77817499637604);
+				var expected = new Rect(-4.242640495300293, 1.4142135381698608, 7.77817440032959, 7.7781739234924316);
 				var actual = SUT.TransformBounds(new Rect(1, 1, 5, 6));
 
-				Assert.AreEqual(expected.Y, actual.Y, 1e-10, $"{expected} != {actual}");
-				Assert.AreEqual(expected.X, actual.X, 1e-10, $"{expected} != {actual}");
-				Assert.AreEqual(expected.Width, actual.Width, 1e-10, $"{expected} != {actual}");
-				Assert.AreEqual(expected.Height, actual.Height, 1e-10, $"{expected} != {actual}");
+				Assert.AreEqual(expected.X, actual.X, 1e-5, $"X: {expected} != {actual}");
+				Assert.AreEqual(expected.Y, actual.Y, 1e-5, $"Y: {expected} != {actual}");
+				Assert.AreEqual(expected.Width, actual.Width, 1e-5, $"W: {expected} != {actual}");
+				Assert.AreEqual(expected.Height, actual.Height, 1e-5, $"H: {expected} != {actual}");
 			});
 		}
 	}

--- a/src/Uno.UI.Tests/CustomPanelTests/Given_CustomPanel.cs
+++ b/src/Uno.UI.Tests/CustomPanelTests/Given_CustomPanel.cs
@@ -26,7 +26,7 @@ namespace Uno.UI.Tests.CustomPanelTests
 
 			SUT.Measure(default(Windows.Foundation.Size));
 			var size = SUT.DesiredSize;
-			SUT.Arrange(Windows.Foundation.Rect.Empty);
+			SUT.Arrange(default(Windows.Foundation.Rect));
 
 			Assert.AreEqual(default(Windows.Foundation.Size), size);
 			Assert.IsTrue(SUT.GetChildren().None());

--- a/src/Uno.UI.Tests/Extensions/Given_Matrix3x2Extensions.cs
+++ b/src/Uno.UI.Tests/Extensions/Given_Matrix3x2Extensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Foundation;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.Extensions;
+
+namespace Uno.UI.Tests.Extensions
+{
+	[TestClass]
+	public class Given_Matrix3x2Extensions
+	{
+		[TestMethod]
+		public void When_TransformPoint_RotateQuarter()
+		{
+			var matrix = Matrix3x2.CreateRotation((float)Math.PI / 4);
+
+			var expected = new Point(0, Math.Sqrt(2) * 42);
+			var actual = matrix.Transform(new Point(42, 42));
+
+			Assert.AreEqual(expected.X, actual.X, 1e-5, $"X: {expected} != {actual}");
+			Assert.AreEqual(expected.Y, actual.Y, 1e-5, $"Y: {expected} != {actual}");
+		}
+
+		[TestMethod]
+		public void When_TransformRect_RotateQuarter()
+		{
+			var matrix = Matrix3x2.CreateRotation((float) Math.PI / 4);
+
+			var expected = new Rect(-4.242640495300293, 1.4142135381698608, 7.77817440032959, 7.7781739234924316);
+			var actual = matrix.Transform(new Rect(1, 1, 5, 6));
+
+			Assert.AreEqual(expected.X, actual.X, 1e-5, $"X: {expected} != {actual}");
+			Assert.AreEqual(expected.Y, actual.Y, 1e-5, $"Y: {expected} != {actual}");
+			Assert.AreEqual(expected.Width, actual.Width, 1e-5, $"W: {expected} != {actual}");
+			Assert.AreEqual(expected.Height, actual.Height, 1e-5, $"H: {expected} != {actual}");
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Foundation/Given_Rect.cs
+++ b/src/Uno.UI.Tests/Foundation/Given_Rect.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+
+namespace Uno.UI.Tests.Foundation
+{
+	[TestClass]
+	public class Given_Rect
+	{
+		[TestMethod]
+		[ExpectedException(typeof(ArgumentOutOfRangeException))]
+		public void When_Create_WithNegativeWidth()
+		{
+			new Rect(0, 0, -42, 0);
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(ArgumentOutOfRangeException))]
+		public void When_Create_WithNegativeHeight()
+		{
+			new Rect(0, 0, 0, -42);
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(ArgumentOutOfRangeException))]
+		public void When_Create_WithNegativeSizeWidth()
+		{
+			new Rect(new Point(0, 0), new Size(-42, 0));
+		}
+
+		[TestMethod]
+		[ExpectedException(typeof(ArgumentOutOfRangeException))]
+		public void When_Create_WithNegativeSizeHeight()
+		{
+			new Rect(new Point(0, 0), new Size(0, -42));
+		}
+
+		[TestMethod]
+		public void When_Create_WithDisorderedPoints_1()
+		{
+			var sut = new Rect(new Point(0, 0), new Point(-42, 42));
+
+			Assert.AreEqual(-42, sut.X);
+			Assert.AreEqual(0, sut.Y);
+			Assert.AreEqual(42, sut.Width);
+			Assert.AreEqual(42, sut.Height);
+
+			Assert.AreEqual(-42, sut.Left);
+			Assert.AreEqual(0, sut.Top);
+			Assert.AreEqual(0, sut.Right);
+			Assert.AreEqual(42, sut.Bottom);
+		}
+
+		[TestMethod]
+		public void When_Create_WithDisorderedPoints_2()
+		{
+			var sut = new Rect(new Point(0, 0), new Point(42, -42));
+
+			Assert.AreEqual(0, sut.X);
+			Assert.AreEqual(-42, sut.Y);
+			Assert.AreEqual(42, sut.Width);
+			Assert.AreEqual(42, sut.Height);
+
+			Assert.AreEqual(0, sut.Left);
+			Assert.AreEqual(-42, sut.Top);
+			Assert.AreEqual(42, sut.Right);
+			Assert.AreEqual(0, sut.Bottom);
+		}
+
+		[TestMethod]
+		public void When_Create_WithDisorderedPoints_3()
+		{
+			var sut = new Rect(new Point(0, 0), new Point(-42, -42));
+
+			Assert.AreEqual(-42, sut.X);
+			Assert.AreEqual(-42, sut.Y);
+			Assert.AreEqual(42, sut.Width);
+			Assert.AreEqual(42, sut.Height);
+
+			Assert.AreEqual(-42, sut.Left);
+			Assert.AreEqual(-42, sut.Top);
+			Assert.AreEqual(0, sut.Right);
+			Assert.AreEqual(0, sut.Bottom);
+		}
+
+		[TestMethod]
+		public void When_Create_WithNaNWidth()
+		{
+			var sut = new Rect(0, 0, double.NaN, 42);
+
+			Assert.AreEqual(0, sut.X);
+			Assert.AreEqual(0, sut.Y);
+			Assert.AreEqual(double.NaN, sut.Width);
+			Assert.AreEqual(42, sut.Height);
+
+			Assert.AreEqual(0, sut.Left);
+			Assert.AreEqual(0, sut.Top);
+			Assert.AreEqual(double.NaN, sut.Right);
+			Assert.AreEqual(42, sut.Bottom);
+		}
+
+		[TestMethod]
+		public void When_Create_WithNaNHeight()
+		{
+			var sut = new Rect(0, 0, 42, double.NaN);
+
+			Assert.AreEqual(0, sut.X);
+			Assert.AreEqual(0, sut.Y);
+			Assert.AreEqual(42, sut.Width);
+			Assert.AreEqual(double.NaN, sut.Height);
+
+			Assert.AreEqual(0, sut.Left);
+			Assert.AreEqual(0, sut.Top);
+			Assert.AreEqual(42, sut.Right);
+			Assert.AreEqual(double.NaN, sut.Bottom);
+		}
+
+		[TestMethod]
+		public void When_Create_WithNaNPoints_1()
+		{
+			var sut = new Rect(new Point(double.NaN, 0), new Point(-42, 42));
+
+			Assert.AreEqual(double.NaN, sut.X);
+			Assert.AreEqual(0, sut.Y);
+			Assert.AreEqual(double.NaN, sut.Width);
+			Assert.AreEqual(42, sut.Height);
+
+			Assert.AreEqual(double.NaN, sut.Left);
+			Assert.AreEqual(0, sut.Top);
+			Assert.AreEqual(double.NaN, sut.Right);
+			Assert.AreEqual(42, sut.Bottom);
+		}
+
+		[TestMethod]
+		public void When_Create_WithNaNPoints_2()
+		{
+			var sut = new Rect(new Point(0, double.NaN), new Point(-42, 42));
+
+			Assert.AreEqual(-42, sut.X);
+			Assert.AreEqual(double.NaN, sut.Y);
+			Assert.AreEqual(42, sut.Width);
+			Assert.AreEqual(double.NaN, sut.Height);
+
+			Assert.AreEqual(-42, sut.Left);
+			Assert.AreEqual(double.NaN, sut.Top);
+			Assert.AreEqual(0, sut.Right);
+			Assert.AreEqual(double.NaN, sut.Bottom);
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -26,6 +26,7 @@
 		<PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="1.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
 		<PackageReference Include="MSTest.TestAdapter">
       <Version>1.3.2</Version>
     </PackageReference>

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid.cs
@@ -27,7 +27,7 @@ namespace Uno.UI.Tests.GridTests
 
 			SUT.Measure(default(Windows.Foundation.Size));
 			var size = SUT.DesiredSize;
-			SUT.Arrange(Windows.Foundation.Rect.Empty);
+			SUT.Arrange(default(Windows.Foundation.Rect));
 
 			Assert.AreEqual(default(Windows.Foundation.Size), size);
 			Assert.IsTrue(SUT.GetChildren().None());
@@ -40,7 +40,7 @@ namespace Uno.UI.Tests.GridTests
 
 			SUT.Measure(new Windows.Foundation.Size(10, 10));
 			var size = SUT.DesiredSize;
-			SUT.Arrange(Windows.Foundation.Rect.Empty);
+			SUT.Arrange(default(Windows.Foundation.Rect));
 
 			Assert.AreEqual(size, default(Windows.Foundation.Size));
 			Assert.IsTrue(SUT.GetChildren().None());

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/PivotTests/Given_Pivot.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/PivotTests/Given_Pivot.cs
@@ -23,7 +23,7 @@ namespace Uno.UI.Tests.PivotTests
 			grid.ForceLoaded();
 
 			SUT.Measure(default(Size));
-			SUT.Arrange(Rect.Empty);
+			SUT.Arrange(default(Rect));
 
 			Assert.AreEqual(default(Size), SUT.DesiredSize);
 			Assert.IsTrue(SUT.GetChildren().None());

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/RelativePanelTests/Given_RelativePanel.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/RelativePanelTests/Given_RelativePanel.cs
@@ -15,7 +15,7 @@ namespace Uno.UI.Tests.RelativePanelTests
 			var SUT = new RelativePanel() { Name = "test" };
 
 			SUT.Measure(default(Size));
-			SUT.Arrange(Rect.Empty);
+			SUT.Arrange(default(Rect));
 
 			Assert.AreEqual(default(Size), SUT.DesiredSize);
 			Assert.IsTrue(SUT.GetChildren().None());

--- a/src/Uno.UI/UI/Xaml/Media/Transform.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Transform.cs
@@ -113,11 +113,7 @@ namespace Windows.UI.Xaml.Media
 			}
 			else
 			{
-				outPoint = new Point
-				(
-					(inPoint.X * matrix.M11) + (inPoint.Y * matrix.M21) + matrix.M31,
-					(inPoint.X * matrix.M12) + (inPoint.Y * matrix.M22) + matrix.M32
-				);
+				outPoint = matrix.Transform(inPoint);
 				return true;
 			}
 		}
@@ -125,7 +121,7 @@ namespace Windows.UI.Xaml.Media
 		/// <inheritdoc />
 		protected override Rect TransformBoundsCore(Rect rect)
 		{
-			return rect.Transform(MatrixCore);
+			return MatrixCore.Transform(rect);
 		}
 		#endregion
 	}

--- a/src/Uno.UWP/Extensions/Matrix3x2Extensions.cs
+++ b/src/Uno.UWP/Extensions/Matrix3x2Extensions.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Text;
+using Windows.Foundation;
+
+namespace Uno.Extensions
+{
+	internal static class Matrix3x2Extensions
+	{
+		/// <summary>
+		/// Creates a transformed <see cref="Point"/> using a <see cref="Matrix3x2"/>.
+		/// </summary>
+		/// <param name="point">The point to transform</param>
+		/// <param name="matrix">The matrix to use to transform the <paramref name="point"/></param>
+		/// <returns>A new rectangle</returns>
+		public static Point Transform(this Matrix3x2 matrix, Point point)
+			=> matrix.Transform(point.X, point.Y);
+
+		/// <summary>
+		/// Creates a transformed point using a <see cref="Matrix3x2"/>.
+		/// </summary>
+		/// <param name="x">The x coordinate of the point to transform</param>
+		/// <param name="y">The y coordinate of the point to transform</param>
+		/// <param name="matrix">The matrix to use to transform the point</param>
+		/// <returns>A new rectangle</returns>
+		public static Point Transform(this Matrix3x2 matrix, double x, double y)
+		{
+			if (matrix.IsIdentity)
+			{
+				return new Point(x, y);
+			}
+
+			return new Point(
+				(x * matrix.M11) + (y * matrix.M21) + matrix.M31,
+				(x * matrix.M12) + (y * matrix.M22) + matrix.M32);
+		}
+
+		/// <summary>
+		/// Creates a transformed bounds <see cref="Rect"/> using a <see cref="Matrix3x2"/>.
+		/// </summary>
+		/// <param name="rect">The rectangle to transform</param>
+		/// <param name="matrix">The matrix to use to transform the <paramref name="rect"/></param>
+		/// <returns>A new rectangle</returns>
+		public static Rect Transform(this Matrix3x2 matrix, Rect rect)
+		{ 
+			var leftTop = matrix.Transform(rect.Left, rect.Top);
+			var leftBottom = matrix.Transform(rect.Left, rect.Bottom);
+			var rightTop = matrix.Transform(rect.Right, rect.Top);
+			var rightBottom = matrix.Transform(rect.Right, rect.Bottom);
+
+			var point1 = Min(leftTop, leftBottom, rightTop, rightBottom);
+			var point2 = Max(leftTop, leftBottom, rightTop, rightBottom);
+
+			return new Rect(point1, point2);
+		}
+
+		private static Point Min(Point point1, Point point2, Point point3, Point point4)
+		{
+			var x = point1.X;
+			x = Math.Min(point2.X, x);
+			x = Math.Min(point3.X, x);
+			x = Math.Min(point4.X, x);
+
+			var y = point1.Y;
+			y = Math.Min(point2.Y, y);
+			y = Math.Min(point3.Y, y);
+			y = Math.Min(point4.Y, y);
+
+			return new Point(x, y);
+		}
+
+		private static Point Max(Point point1, Point point2, Point point3, Point point4)
+		{
+			var x = point1.X;
+			x = Math.Max(point2.X, x);
+			x = Math.Max(point3.X, x);
+			x = Math.Max(point4.X, x);
+
+			var y = point1.Y;
+			y = Math.Max(point2.Y, y);
+			y = Math.Max(point3.Y, y);
+			y = Math.Max(point4.Y, y);
+
+			return new Point(x, y);
+		}
+	}
+}

--- a/src/Uno.UWP/Extensions/RectExtensions.cs
+++ b/src/Uno.UWP/Extensions/RectExtensions.cs
@@ -16,15 +16,7 @@ namespace Uno.Extensions
 		/// <param name="m">The matrix to use to transform the <paramref name="rect"/></param>
 		/// <returns>A new rectangle</returns>
 		internal static Rect Transform(this Rect rect, Matrix3x2 m)
-		{
-			var leftTop = new Vector2((float)rect.Left, (float)rect.Top);
-			var rightBottom = new Vector2((float)rect.Right, (float)rect.Bottom);
-
-			var leftTop2 = Vector2.Transform(leftTop, m);
-			var rightBottom2 = Vector2.Transform(rightBottom, m);
-
-			return new Rect(leftTop2.ToPoint(), rightBottom2.ToPoint());
-		}
+			=> Matrix3x2Extensions.Transform(m, rect);
 
 		/// <summary>
 		/// Returns the orientation of the rectangle.


### PR DESCRIPTION
- Make sure that `Rect` properly calculate its `Width` and `Height` when created from 2 points
- Includes the 4 edges points when calculating the bounds of a transformed `Rect`

GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The `Transform.TransformBounds` does not calculate the right bounds rectangle as soon as the transform includes a rotation without a lower than 1 scaling.

## What is the new behavior?
It works

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
