### PR TITLE
[WASM] Misc stability fixes

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -137,6 +137,7 @@
  * [iOS] Add fail-safe on `FrameworkElement.WillMoveToSuperview` log to `Application.Current.UnhandledException`
  * [Wasm] Fixed `System.UriConverter` is being linked out
  * 145075 [Android] [Wasm] Android and Wasm don't match all specific UWP behaviors for the Image control.
+ * [Wasm] Don't fail if the dispatcher queue is empty
  * 146648 [Android] fixed ListView grouped items corruption on scroll
 
 ## Release 1.42

--- a/src/Uno.UI/UI/Xaml/ObservableVectorWrapper.cs
+++ b/src/Uno.UI/UI/Xaml/ObservableVectorWrapper.cs
@@ -14,7 +14,7 @@ namespace Windows.UI.Xaml
 #elif __ANDROID__
 	[Android.Runtime.Preserve(AllMembers = true)]
 #endif
-	internal abstract class ObservableVectorWrapper
+	internal class ObservableVectorWrapper
 	{
 		public event VectorChangedEventHandler<object> VectorChanged;
 

--- a/src/Uno.UWP/UI/Core/CoreDispatcher.cs
+++ b/src/Uno.UWP/UI/Core/CoreDispatcher.cs
@@ -282,10 +282,13 @@ namespace Windows.UI.Core
 					}
 				}
 			}
-			//else
-			//{
-			//	throw new InvalidOperationException("Dispatch queue is empty");
-			//}
+			else
+			{
+				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
+				{
+					this.Log().Error("Dispatch queue is empty");
+				}
+			}
 		}
 
 		private CoreDispatcherSynchronizationContext GetSyncContext(CoreDispatcherPriority priority)


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
- LLVM AOT may fail for an unknown reason: https://github.com/mono/mono/issues/12987
- Adjust `CoreDispatcher` empty queue processing, there's no need for an exception.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
