### PR TITLE
[Wasm] Fix AOT crash on null enumerator

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.Members.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.Members.cs
@@ -78,7 +78,7 @@ namespace Windows.UI.Xaml.Controls
 
 		int m_indexOfLastSelectedItemInTopNav = 0;
 		object m_lastSelectedItemPendingAnimationInTopNav;
-		List<int> m_itemsRemovedFromMenuFlyout;
+		List<int> m_itemsRemovedFromMenuFlyout = new List<int>();
 
 		//winrt::ListView::ItemClick_revoker m_leftNavListViewItemClickRevoker =;
 		//winrt::ListView::Loaded_revoker m_leftNavListViewLoadedRevoker =;


### PR DESCRIPTION


## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
GetEnumerator on a null List<T> is causing https://github.com/mono/mono/issues/12998. This issue ensure that there's always an available list.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)