### PR TITLE
[Wasm] Fix ListView recycling when the XamlParent is not available

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -140,6 +140,7 @@
  * 145075 [Android] [Wasm] Android and Wasm don't match all specific UWP behaviors for the Image control.
  * [Wasm] Don't fail if the dispatcher queue is empty
  * 146648 [Android] fixed ListView grouped items corruption on scroll
+ * [Wasm] Fix `ListView` recycling when the `XamlParent` is not available for `AutoSuggestBox`
 
 ## Release 1.42
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelAdapter.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelAdapter.wasm.cs
@@ -63,7 +63,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var id = GetItemId(index);
 
-			if (!_owner.XamlParent.IsIndexItsOwnContainer(index))
+			if (!(_owner.XamlParent?.IsIndexItsOwnContainer(index) ?? false))
 			{
 				if (this.Log().IsEnabled(LogLevel.Debug))
 				{


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The autosuggest box flyout only opens once.

## What is the new behavior?
The Wasm `ListView` recycler now is able to reuse items in the context of the `AutoSuggestBox`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->

## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
