### PR TITLE
[Wasm] Fix rectangle clipping regression

### DIFF
--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Layout.wasm.cs
@@ -209,11 +209,23 @@ namespace Windows.UI.Xaml
 					throw new InvalidOperationException($"{this}: Invalid frame size {newRect}. No dimension should be NaN or negative value.");
 				}
 
-				// Disable clipping for Scrollviewer (edge seems to disable scrolling if 
-				// the clipping is enabled to the size of the scrollviewer, even if overflow-y is auto)
-				var clip = this is Controls.ScrollViewer ? (Rect?)null : new Rect(0, 0, newRect.Width, newRect.Height);
+				Rect? getClip()
+				{
+					// Disable clipping for Scrollviewer (edge seems to disable scrolling if 
+					// the clipping is enabled to the size of the scrollviewer, even if overflow-y is auto)
+					if(this is Controls.ScrollViewer)
+					{
+						return null;
+					}
+					else if(Clip != null)
+					{
+						return Clip.Rect;
+					}
 
-				ArrangeElementNative(newRect, clip);
+					return new Rect(0, 0, newRect.Width, newRect.Height);
+				}
+
+				ArrangeElementNative(newRect, getClip());
 			}
 			else
 			{

--- a/src/Uno.UI/UI/Xaml/Shapes/Rectangle.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Rectangle.wasm.cs
@@ -48,6 +48,8 @@ namespace Windows.UI.Xaml.Shapes
 				("width", childRect.Width.ToStringInvariant()),
 				("height", childRect.Height.ToStringInvariant())
 			);
+
+			_rectangle.Clip = new RectangleGeometry() { Rect = new Rect(0, 0, finalSize.Width, finalSize.Height) };
 			
 			return finalSize;
 		}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Rectangles are clipped incorrectly.


## What is the new behavior?
Inner rectange SVG is now clipped properly since #594, but the rectangle needs a larger clipping area. The clipping property is now applied properly, if there's one.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
