### PR TITLE
Review keyboardRect calculation

### DIFF
--- a/src/Uno.UI/KeyboardRectProvider.Android.cs
+++ b/src/Uno.UI/KeyboardRectProvider.Android.cs
@@ -78,8 +78,14 @@ namespace Uno.UI
 			// [rect] displayRect	: display area = screen - (bottom: nav_bar)
 			// [rect] usableRect	: usable area = screen - (top: status_bar) - (bottom: keyboard + nav_bar)
 			var navigationRect = new Rect(0, displayRect.Bottom, realMetrics.WidthPixels, realMetrics.HeightPixels);
-			var keyboardRect = new Rect(0, usableRect.Bottom, realMetrics.WidthPixels, navigationRect.Top);
+			var keyboardRect = new Rect(0, usableRect.Bottom, realMetrics.WidthPixels, displayRect.Bottom);
 			var occupiedRect = new Rect(0, usableRect.Bottom, realMetrics.WidthPixels, realMetrics.HeightPixels);
+
+			// On dockable / undockable navigation bar devices, the keyboardRect can have a negative height. We need to avoid that behavior.
+			if(keyboardRect.Bottom < keyboardRect.Top)
+			{
+				keyboardRect.Bottom = keyboardRect.Top;
+			}
 
 			_onLayoutChanged?.Invoke(keyboardRect, navigationRect, occupiedRect);
 

--- a/src/Uno.UI/UI/ViewManagement/InputPane/InputPane.Android.cs
+++ b/src/Uno.UI/UI/ViewManagement/InputPane/InputPane.Android.cs
@@ -22,6 +22,9 @@ namespace Windows.UI.ViewManagement
 	{
 		private IDisposable _padScrollContentPresenter;
 
+		// Android specific :
+		// Since Android has un-dockable navigation bar, some calculations can depends of the keyboard and/or navigation bar size.
+		// => OccludedRect = KeyboardRect + NavigationBarRect
 		public Rect KeyboardRect { get; internal set; }
 
 		public Rect NavigationBarRect { get; internal set; }

--- a/src/Uno.UI/UI/ViewManagement/InputPane/InputPane.cs
+++ b/src/Uno.UI/UI/ViewManagement/InputPane/InputPane.cs
@@ -84,7 +84,11 @@ namespace Windows.UI.ViewManagement
 
 		internal void OnOccludedRectChanged()
 		{
+#if __ANDROID__
+			var args = new InputPaneVisibilityEventArgs(KeyboardRect);
+#else
 			var args = new InputPaneVisibilityEventArgs(OccludedRect);
+#endif
 
 			if (Visible)
 			{


### PR DESCRIPTION
GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
On Android, Keyboard measurement can be negative when it's hidden

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
Keyboard measurement is limited to positive values only

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://nventive.visualstudio.com/Umbrella/_workitems/edit/145363
https://nventive.visualstudio.com/Umbrella/_workitems/edit/145370
https://nventive.visualstudio.com/Umbrella/_workitems/edit/145379