### PR TITLE
Use the `IsAnimating` flag instead of the DP precedence to udpate matrix

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -29,7 +29,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\Arrange_Performance01.xaml">
+	<Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\Arrange_Performance01.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -213,7 +213,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressRing.xaml">
+	<Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressRing.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -897,6 +897,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media_Animation\DoubleAnimation_Cumulative.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media_Animation\DoubleAnimation_Opacity_TextBlock.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1079,7 +1083,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\XamlEvent_Leak_UserControl.xaml.cs">
       <DependentUpon>XamlEvent_Leak_UserControl.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\Arrange_Performance01.xaml.cs" />
+	<Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\Arrange_Performance01.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\TransformToVisual_Simple.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\ViusalStateTests\VisualState_AdaptiveTrigger_UsingOneStateOnly.xaml.cs">
       <DependentUpon>VisualState_AdaptiveTrigger_UsingOneStateOnly.xaml</DependentUpon>
@@ -1292,7 +1296,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Models\ImageWithLateSourceViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\TimePickerViewModel.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressRing.xaml.cs">
+	    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressRing.xaml.cs">
       <DependentUpon>ProgressRing.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Slider\SliderViewModel.cs" />
@@ -1716,6 +1720,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media_Animation\DoubleAnimation_BeginTime.xaml.cs">
       <DependentUpon>DoubleAnimation_BeginTime.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media_Animation\DoubleAnimation_Cumulative.cs">
+      <DependentUpon>DoubleAnimation_Cumulative.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Media_Animation\DoubleAnimation_Opacity_TextBlock.xaml.cs">
       <DependentUpon>DoubleAnimation_Opacity_TextBlock.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Cumulative.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Cumulative.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Animation;
+using Uno.UI.Samples.Controls;
+
+
+namespace Uno.UI.Samples.Content.UITests.Animations
+{
+	[SampleControlInfoAttribute("Animations", "DoubleAnimation_Cumulative")]
+	public sealed partial class DoubleAnimation_Cumulative : UserControl
+	{
+		public DoubleAnimation_Cumulative()
+		{
+			this.InitializeComponent();
+		}
+
+		private void LaunchAnimation1(object sender, TappedRoutedEventArgs e)
+		{
+			var animation = new DoubleAnimation
+			{
+				To = 50,
+				Duration = new Duration(TimeSpan.FromSeconds(10))
+			};
+			Storyboard.SetTargetProperty(animation, nameof(TranslateTransform.Y));
+			Storyboard.SetTarget(animation, _transform);
+
+			new Storyboard
+			{
+				Children = { animation}
+			}.Begin();
+		}
+
+		private void LaunchAnimation2(object sender, TappedRoutedEventArgs e)
+		{
+			var animation = new DoubleAnimation
+			{
+				To = 0,
+				Duration = new Duration(TimeSpan.FromSeconds(10))
+			};
+			Storyboard.SetTargetProperty(animation, nameof(TranslateTransform.Y));
+			Storyboard.SetTarget(animation, _transform);
+
+			new Storyboard
+			{
+				Children = { animation }
+			}.Begin();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Cumulative.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media_Animation/DoubleAnimation_Cumulative.xaml
@@ -1,0 +1,44 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.Animations.DoubleAnimation_Cumulative"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d xamarin"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<Grid>
+		<StackPanel>
+			<Button
+ 				HorizontalAlignment="Left"
+				VerticalAlignment="Top"
+				Tapped="LaunchAnimation1"
+				Content="Move to Y = 50"/>
+			<Button
+				HorizontalAlignment="Left"
+				VerticalAlignment="Top"
+				Tapped="LaunchAnimation2"
+				Content="Move to Y = 0"/>
+		</StackPanel>
+
+		<Border
+			Background="Red"
+			Width="100"
+			Height="100"
+			HorizontalAlignment="Center"
+			VerticalAlignment="Center">
+			<Border.RenderTransform>
+				<TranslateTransform x:Name="_transform" Y="0" />
+			</Border.RenderTransform>
+		</Border>
+		<Border
+			Background="Black"
+			Width="100"
+			Height="1"
+			HorizontalAlignment="Center"
+			VerticalAlignment="Center" />
+	</Grid>
+</UserControl>

--- a/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/Animators/AnimatorFactory.Android.cs
@@ -136,6 +136,11 @@ namespace Windows.UI.Xaml.Media.Animation
 					scale.View.PivotX = ViewHelper.LogicalToPhysicalPivotPixels(pivotX + scale.CenterX);
 					scale.View.PivotY = ViewHelper.LogicalToPhysicalPivotPixels(pivotY + scale.CenterY);
 					break;
+
+				case CompositeTransform composite:
+					composite.View.PivotX = ViewHelper.LogicalToPhysicalPivotPixels(pivotX + composite.CenterX);
+					composite.View.PivotY = ViewHelper.LogicalToPhysicalPivotPixels(pivotY + composite.CenterY);
+					break;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Media/Transform.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Transform.Android.cs
@@ -1,5 +1,4 @@
-﻿using Android.Graphics;
-using System;
+﻿using System;
 using System.Numerics;
 using Windows.Foundation;
 
@@ -28,6 +27,8 @@ namespace Windows.UI.Xaml.Media
 				if (_isAnimating != value)
 				{
 					_isAnimating = value;
+
+					MatrixCore = ToMatrix(new Point(0, 0));
 					NotifyChanged();
 				}
 			}

--- a/src/Uno.UI/UI/Xaml/Media/Transform.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Transform.cs
@@ -33,9 +33,8 @@ namespace Windows.UI.Xaml.Media
 			// The value is being animated by the platform itself.
 
 			if (snd is Transform transform
-#if !__WASM__ // On WASM currently we supports only CPU bound animations, so we have to let the transform be updated on each frame
-				&& args.NewPrecedence != DependencyPropertyValuePrecedences.Animations
-				&& !args.BypassesPropagation
+#if __ANDROID__ || __IOS__ || __MACOS__ // On WASM currently we supports only CPU bound animations, so we have to let the transform be updated on each frame
+				&& !transform.IsAnimating
 #endif
 				)
 			{


### PR DESCRIPTION
Use the `IsAnimating` flag instead of the DP precedence to determine when update the matrix of a transform. This ensure that the final value published by the animator (which is also published with the animation's precedence) effectively updates the matrix and is then properly applied by the render transform adapter

## PR Type
What kind of change does this PR introduce?
 - Bugfix

## What is the current behavior?
When an animation completes, the animated property goes back to its original value until the transform is modified again.

## What is the new behavior?
The updated value is properly applied in the UI

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146942 (TBD, not accessible)
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146935
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146936
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146941
https://nventive.visualstudio.com/Umbrella/_workitems/edit/147024
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146987
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146991