### PR TITLE
Replace an exception with a warning message

### DIFF
--- a/src/Uno.UWP/ContextHelper.cs
+++ b/src/Uno.UWP/ContextHelper.cs
@@ -10,6 +10,8 @@ using Android.OS;
 using Android.Runtime;
 using Android.Views;
 using Android.Widget;
+using Uno.Extensions;
+using Uno.Logging;
 
 namespace Uno.UI
 {
@@ -26,10 +28,12 @@ namespace Uno.UI
 			{
 				if (_current == null)
 				{
-					throw new InvalidOperationException(
-						"ContextHelper.Current not defined. " +
-						"For compatibility with Uno, you should ensure your `MainActivity` " +
-						"is deriving from Windows.UI.Xaml.ApplicationActivity.");
+					typeof(ContextHelper)
+						.Log()
+						.Warn(
+							"ContextHelper.Current not defined. " +
+							"For compatibility with Uno, you should ensure your `MainActivity` " +
+							"is deriving from Windows.UI.Xaml.ApplicationActivity.");
 				}
 				return _current;
 			}


### PR DESCRIPTION
## Bugfix

## What is the current behavior?
`ContextHelper.Current` was throwing an exception when called before it's initialized.

The exception is: `System.InvalidOperationException: ContextHelper.Current not defined. For compatibility with Uno, you should ensure your 'MainActivity' is deriving from Windows.UI.Xaml.ApplicationActivity.`

## What is the new behavior?
The exception is replaced by a warning in the log.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)~~
- ~~[ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [X] Contains **NO** breaking changes --> **It actually a fix to a breaking change in PR #160**
- ~~[ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)~~
- [X] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
* <https://nventive.visualstudio.com/Umbrella/_workitems/edit/147083> BUG 147083 [Android] Apps crash at launch