### PR TITLE
Add feature flag (enabled by default) to allow negative width and height in Rect

### DIFF
--- a/src/Uno.Foundation/FoundationFeatureConfiguration.cs
+++ b/src/Uno.Foundation/FoundationFeatureConfiguration.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Text;
+
+namespace Uno
+{
+	public static class FoundationFeatureConfiguration
+	{
+		/// <summary>
+		/// Used by tests cleanup to restore the default configuration for other tests!
+		/// </summary>
+		internal static void RestoreDefaults()
+		{
+			Rect.RestoreDefaults();
+		}
+
+		public static class Rect
+		{
+			internal static void RestoreDefaults()
+			{
+				AllowNegativeWidthHeight = _defaultAllowNegativeWidthHeight;
+			}
+
+			private const bool _defaultAllowNegativeWidthHeight = true;
+			/// <summary>
+			/// If this flag is set to true, the <see cref="Windows.Foundation.Rect"/> won't throw an exception
+			/// if it's been created with a negative width / height.
+			/// This should be kept to `true` until https://github.com/nventive/Uno/issues/606 get fixed.
+			/// </summary>
+			/// <remarks>This hides some errors from invalid measure/arrange which have to be fixed!</remarks>
+			[DefaultValue(_defaultAllowNegativeWidthHeight)]
+			public static bool AllowNegativeWidthHeight { get; set; } = _defaultAllowNegativeWidthHeight;
+		}
+	}
+}

--- a/src/Uno.Foundation/Rect.cs
+++ b/src/Uno.Foundation/Rect.cs
@@ -24,13 +24,17 @@ namespace Windows.Foundation
 
 		public Rect(double x, double y, double width, double height)
 		{
-			if (width < 0)
+			if (!Uno.FoundationFeatureConfiguration.Rect.AllowNegativeWidthHeight)
 			{
-				throw new ArgumentOutOfRangeException(nameof(width), _negativeErrorMessage);
-			}
-			if (height < 0)
-			{
-				throw new ArgumentOutOfRangeException(nameof(width), _negativeErrorMessage);
+				if (width < 0)
+				{
+					throw new ArgumentOutOfRangeException(nameof(width), _negativeErrorMessage);
+				}
+
+				if (height < 0)
+				{
+					throw new ArgumentOutOfRangeException(nameof(width), _negativeErrorMessage);
+				}
 			}
 
 			X = x;

--- a/src/Uno.UI.Tests/Foundation/Given_Rect.cs
+++ b/src/Uno.UI.Tests/Foundation/Given_Rect.cs
@@ -11,6 +11,32 @@ namespace Uno.UI.Tests.Foundation
 	[TestClass]
 	public class Given_Rect
 	{
+		[TestInitialize]
+		public void Init() => Uno.FoundationFeatureConfiguration.Rect.AllowNegativeWidthHeight = false;
+
+		[TestCleanup]
+		public void Cleanup() => Uno.FoundationFeatureConfiguration.Rect.RestoreDefaults();
+
+		[TestMethod]
+		public void When_Create_WithNegativeWidth_With_FeatureFlagEnabled()
+		{
+			Uno.FoundationFeatureConfiguration.Rect.AllowNegativeWidthHeight = true;
+
+			var sut = new Rect(0, 0, -42, 0);
+
+			Assert.AreEqual(-42, sut.Width);
+		}
+
+		[TestMethod]
+		public void When_Create_WithNegativeHeight_With_FeatureFlagEnabled()
+		{
+			Uno.FoundationFeatureConfiguration.Rect.AllowNegativeWidthHeight = true;
+
+			var sut = new Rect(0, 0, 0, -42);
+
+			Assert.AreEqual(-42, sut.Height);
+		}
+
 		[TestMethod]
 		[ExpectedException(typeof(ArgumentOutOfRangeException))]
 		public void When_Create_WithNegativeWidth()


### PR DESCRIPTION
## PR Type
- Bugfix

## What is the current behavior?
`Rect` constructor will throw if built with a negative width or height ... which unfortunately seems to still be quite common in Uno layouting

## What is the new behavior?
It won't throw by default

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
