### PR TITLE
Fix potential Scrollviewer add self view in its own children

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -29,7 +29,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-	<Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\Arrange_Performance01.xaml">
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\Arrange_Performance01.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -213,7 +213,11 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-	<Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressRing.xaml">
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressRing.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\Hosted_ScrollViewer.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -1083,7 +1087,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\FrameworkElementTests\XamlEvent_Leak_UserControl.xaml.cs">
       <DependentUpon>XamlEvent_Leak_UserControl.xaml</DependentUpon>
     </Compile>
-	<Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\Arrange_Performance01.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\Arrange_Performance01.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\TransformToVisual_Simple.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml\ViusalStateTests\VisualState_AdaptiveTrigger_UsingOneStateOnly.xaml.cs">
       <DependentUpon>VisualState_AdaptiveTrigger_UsingOneStateOnly.xaml</DependentUpon>
@@ -1296,9 +1300,10 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Models\ImageWithLateSourceViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\TimePickerViewModel.cs" />
-	    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressRing.xaml.cs">
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressRing.xaml.cs">
       <DependentUpon>ProgressRing.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\Hosted_ScrollViewer.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Slider\SliderViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Slider\Slider_Features.xaml.cs">
       <DependentUpon>Slider_Features.xaml</DependentUpon>
@@ -1886,6 +1891,9 @@
     </Compile>
     <Compile Update="C:\s\nv.github\uno-2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\ListView\ListView_OwnContainer_Virtualized.xaml.cs">
       <DependentUpon>ListView_OwnContainer_Virtualized.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\s\nv.github\uno-2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\ScrollViewerTests\Hosted_ScrollViewer.xaml.cs">
+      <DependentUpon>Hosted_ScrollViewer.xaml</DependentUpon>
     </Compile>
     <Compile Update="C:\s\nv.github\uno-2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\ToggleSwitchControl\Native_ToggleSwitch.xaml.cs">
       <DependentUpon>Native_ToggleSwitch.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/Hosted_ScrollViewer.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/Hosted_ScrollViewer.xaml
@@ -1,0 +1,26 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ScrollViewerTests.Hosted_ScrollViewer"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ScrollViewerTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock Text="Should show [OuterContentPresenter Tag]" />
+		<ContentControl Tag="OuterContentPresenter Tag">
+			<ContentControl.Template>
+				<ControlTemplate TargetType="ContentControl">
+					<Border>
+						<ScrollViewer Tag="ScrollViewer Tag">
+							<ContentPresenter Content="{TemplateBinding Tag}" />
+						</ScrollViewer>
+					</Border>
+				</ControlTemplate>
+			</ContentControl.Template>
+		</ContentControl>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/Hosted_ScrollViewer.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/Hosted_ScrollViewer.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ScrollViewerTests
+{
+	[SampleControlInfoAttribute("ScrollViewer", nameof(Hosted_ScrollViewer), description: "Test the ability of a ScrollViewer's content in have a proper TemplatedParent)")]
+	public sealed partial class Hosted_ScrollViewer : UserControl
+	{
+		public Hosted_ScrollViewer()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.xaml
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.xaml
@@ -237,7 +237,8 @@
 										<Button.Flyout>
 											<Flyout Placement="Bottom">
 												<Flyout.FlyoutPresenterStyle>
-													<Style TargetType="FlyoutPresenter">
+													<!-- Based on is required until https://github.com/nventive/Uno/issues/119 is fixed -->
+													<Style TargetType="FlyoutPresenter" BasedOn="{StaticResource DefaultFlyoutPresenter}">
 														<Setter Property="Padding" Value="0,8" />
 														<!-- Set negative top margin to make the flyout align exactly with the button -->
 														<Setter Property="Margin" Value="0,-4,0,0" />

--- a/src/Uno.UI/UI/Xaml/Style/Generic/FlyoutPresenter.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/FlyoutPresenter.xaml
@@ -24,7 +24,7 @@
 	<x:Double x:Key="FlyoutThemeTouchMinWidth">240</x:Double>
 
 	<!-- Default style for Windows.UI.Xaml.Controls.FlyoutPresenter -->
-	<Style TargetType="FlyoutPresenter">
+	<Style x:Key="DefaultFlyoutPresenter"  TargetType="FlyoutPresenter">
 		<Setter Property="HorizontalContentAlignment" Value="Stretch" />
 		<Setter Property="VerticalContentAlignment" Value="Stretch" />
 		<Setter Property="IsTabStop" Value="False" />
@@ -71,6 +71,8 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
+
+	<Style TargetType="FlyoutPresenter" BasedOn="{StaticResource DefaultFlyoutPresenter}"/>
 
 
 </ResourceDictionary>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
Ensure ScrollViewer clears the Content's TemplatedParent before adding it to its ScrollContentPresenter. This ensure that the Content of the ScrollViewer does not add Tempate binding to itself in case it is using the Content property (such as a ContentPresenter).

Also updates `NavigationViewItem` flyout presenter, to add a name to the default style to it can be referenced in the context of #119.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146075/