### PR TITLE
Add to beta : Fix potential add self view in its own children

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -181,6 +181,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\Hosted_ScrollViewer.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Slider\Slider_Features.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1097,6 +1101,7 @@
       <DependentUpon>Picker_Resizable.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Models\ImageWithLateSourceViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\Hosted_ScrollViewer.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Slider\SliderViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Slider\Slider_Features.xaml.cs">
       <DependentUpon>Slider_Features.xaml</DependentUpon>
@@ -1600,6 +1605,11 @@
     <PRIResource Include="$(MSBuildThisFileDirectory)UITestsStrings\en-US\Resources.resw" />
   </ItemGroup>
   <ItemGroup>
+ 
+    <Compile Update="C:\s\nv.github\uno-2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\ScrollViewerTests\Hosted_ScrollViewer.xaml.cs">
+      <DependentUpon>Hosted_ScrollViewer.xaml</DependentUpon>
+    </Compile>
+
     <Compile Update="C:\s\nv.github\uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml\UIElementTests\TransformToVisual_Simple.xaml.cs">
       <DependentUpon>TransformToVisual_Simple.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/Hosted_ScrollViewer.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/Hosted_ScrollViewer.xaml
@@ -1,0 +1,26 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ScrollViewerTests.Hosted_ScrollViewer"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.ScrollViewerTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock Text="Should show [OuterContentPresenter Tag]" />
+		<ContentControl Tag="OuterContentPresenter Tag">
+			<ContentControl.Template>
+				<ControlTemplate TargetType="ContentControl">
+					<Border>
+						<ScrollViewer Tag="ScrollViewer Tag">
+							<ContentPresenter Content="{TemplateBinding Tag}" />
+						</ScrollViewer>
+					</Border>
+				</ControlTemplate>
+			</ContentControl.Template>
+		</ContentControl>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/Hosted_ScrollViewer.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/Hosted_ScrollViewer.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ScrollViewerTests
+{
+	[SampleControlInfoAttribute("ScrollViewer", nameof(Hosted_ScrollViewer), description: "Test the ability of a ScrollViewer's content in have a proper TemplatedParent)")]
+	public sealed partial class Hosted_ScrollViewer : UserControl
+	{
+		public Hosted_ScrollViewer()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.xaml
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.xaml
@@ -237,7 +237,8 @@
 										<Button.Flyout>
 											<Flyout Placement="Bottom">
 												<Flyout.FlyoutPresenterStyle>
-													<Style TargetType="FlyoutPresenter">
+													<!-- Based on is required until https://github.com/nventive/Uno/issues/119 is fixed -->
+													<Style TargetType="FlyoutPresenter" BasedOn="{StaticResource DefaultFlyoutPresenter}">
 														<Setter Property="Padding" Value="0,8" />
 														<!-- Set negative top margin to make the flyout align exactly with the button -->
 														<Setter Property="Margin" Value="0,-4,0,0" />

--- a/src/Uno.UI/UI/Xaml/Style/Generic/FlyoutPresenter.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/FlyoutPresenter.xaml
@@ -24,7 +24,7 @@
 	<x:Double x:Key="FlyoutThemeTouchMinWidth">240</x:Double>
 
 	<!-- Default style for Windows.UI.Xaml.Controls.FlyoutPresenter -->
-	<Style TargetType="FlyoutPresenter">
+	<Style x:Key="DefaultFlyoutPresenter"  TargetType="FlyoutPresenter">
 		<Setter Property="HorizontalContentAlignment" Value="Stretch" />
 		<Setter Property="VerticalContentAlignment" Value="Stretch" />
 		<Setter Property="IsTabStop" Value="False" />
@@ -71,6 +71,8 @@
 			</Setter.Value>
 		</Setter>
 	</Style>
+
+	<Style TargetType="FlyoutPresenter" BasedOn="{StaticResource DefaultFlyoutPresenter}"/>
 
 
 </ResourceDictionary>


### PR DESCRIPTION
Ensure ScrollViewer clears the Content's TemplatedParent before adding it to its ScrollContentPresenter. This ensure that the Content of the ScrollViewer does not add Tempate binding to itself in case it is using the Content property (such as a ContentPresenter)


Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146075/
