### PR TITLE
[Wasm] Fix support for GotFocus routed event

### DIFF
--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -732,6 +732,27 @@
 		}
 
 		/**
+		 * tapped (mouse clicked / double clicked) event extractor to be used with registerEventOnView
+		 * @param evt
+		 */
+		private focusEventExtractor(evt: FocusEvent): string {
+
+			if (evt) {
+				const targetElement: HTMLElement | SVGElement = <any>evt.target;
+
+				if (targetElement) {
+					const targetXamlHandle = targetElement.getAttribute("XamlHandle");
+
+					if (targetXamlHandle) {
+						return `${targetXamlHandle}`;
+					}
+				}
+			}
+
+			return "";
+		}
+
+		/**
 		 * Gets the event extractor function. See UIElement.HtmlEventExtractor
 		 * @param eventExtractorName an event extractor name.
 		 */
@@ -747,6 +768,9 @@
 
 					case "TappedEventExtractor":
 						return this.tappedEventExtractor;
+
+					case "FocusEventExtractor":
+						return this.focusEventExtractor;
 				}
 
 				throw `Event filter ${eventExtractorName} is not supported`;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?
The `UIElement.GotFocus` event receives a null `RoutedEventArgs`.

## What is the new behavior?
The `UIElement.GotFocus` event now has a proper `RoutedEventArgs` instance.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)