### PR TITLE
Fix NRE on some MediaTransportControl controls + MPE Samples

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -34,7 +34,7 @@ phases:
       msbuildLocationMethod: version
       msbuildVersion: latest
       msbuildArchitecture: x86
-      msbuildArguments: /p:CheckExclusions=True "/p:CombinedConfiguration=$(CombinedConfiguration)" /nodeReuse:true /detailedsummary /m:16 /nr:false #/bl:$(build.artifactstagingdirectory)\build.binlog
+      msbuildArguments: /p:CheckExclusions=True "/p:CombinedConfiguration=$(CombinedConfiguration)" /nodeReuse:true /detailedsummary /m:16 /nr:false /bl:$(build.artifactstagingdirectory)\build.binlog
       clean: false
       maximumCpuCount: true
       restoreNugetPackages: false

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -143,6 +143,7 @@
  * [Wasm] Don't fail if the dispatcher queue is empty
  * 146648 [Android] fixed ListView grouped items corruption on scroll
  * [Wasm] Fix `ListView` recycling when the `XamlParent` is not available for `AutoSuggestBox`
+ * 147405 Fix NRE on some MediaTransportControl controls
 
 ## Release 1.42
 

--- a/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+++ b/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
@@ -81,6 +81,10 @@
       <Project>{028f3ee0-d51b-469a-a72c-c272585dcd40}</Project>
       <Name>Uno.UI.RuntimeTests</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Uno.UI.Toolkit\Uno.UI.Toolkit.csproj">
+      <Project>{2eaf39e3-2ac9-457a-a5b2-47d6548799b3}</Project>
+      <Name>Uno.UI.Toolkit</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Uno.UI\Uno.UI.csproj" />
     <ProjectReference Include="..\..\Uno.UWP\Uno.csproj" />
     <ProjectReference Include="..\..\Uno.UI.BindingHelper.Android\Uno.UI.BindingHelper.Android.csproj" />

--- a/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
+++ b/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
@@ -57,6 +57,7 @@
 	<ItemGroup>
 		<ProjectReference Include="..\..\Uno.Foundation\Uno.Foundation.csproj" />
 		<ProjectReference Include="..\..\Uno.UI.RuntimeTests\Uno.UI.RuntimeTests.csproj" />
+		<ProjectReference Include="..\..\Uno.UI.Toolkit\Uno.UI.Toolkit.csproj" />
 		<ProjectReference Include="..\..\Uno.UI.Wasm.Tests\Uno.UI.Wasm.Tests.csproj" />
 		<ProjectReference Include="..\..\Uno.UI\Uno.UI.csproj" />
 		<ProjectReference Include="..\..\Uno.UWP\Uno.csproj" />

--- a/src/SamplesApp/SamplesApp.iOS/Info.plist
+++ b/src/SamplesApp/SamplesApp.iOS/Info.plist
@@ -13,7 +13,7 @@
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>MinimumOSVersion</key>
-	<string></string>
+	<string>9.0</string>
 	<key>UIDeviceFamily</key>
 	<array>
 		<integer>1</integer>

--- a/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
+++ b/src/SamplesApp/SamplesApp.iOS/SamplesApp.iOS.csproj
@@ -129,6 +129,10 @@
   <ItemGroup>
     <ProjectReference Include="..\..\Uno.UI.RuntimeTests\Uno.UI.RuntimeTests.csproj" />
     <ProjectReference Include="..\..\Uno.Foundation\Uno.Foundation.csproj" />
+    <ProjectReference Include="..\..\Uno.UI.Toolkit\Uno.UI.Toolkit.csproj">
+      <Project>{2eaf39e3-2ac9-457a-a5b2-47d6548799b3}</Project>
+      <Name>Uno.UI.Toolkit</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Uno.UI\Uno.UI.csproj" />
     <ProjectReference Include="..\..\Uno.UWP\Uno.csproj" />
   </ItemGroup>

--- a/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
+++ b/src/SamplesApp/SamplesApp.macOS/SamplesApp.macOS.csproj
@@ -42,8 +42,8 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>
-		<DefineConstants>XAMARIN;HAS_UNO</DefineConstants>
-		<ErrorReport>prompt</ErrorReport>
+    <DefineConstants>XAMARIN;HAS_UNO</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <EnableCodeSigning>false</EnableCodeSigning>
     <CreatePackage>true</CreatePackage>
@@ -67,8 +67,8 @@
     <Reference Include="System.Numerics.Vectors" />
   </ItemGroup>
   <ItemGroup>
-		<PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
-		<PackageReference Include="Uno.SourceGenerationTasks">
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
+    <PackageReference Include="Uno.SourceGenerationTasks">
       <Version>1.29.0-dev.241</Version>
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
@@ -84,6 +84,10 @@
       <Project>{028f3ee0-d51b-469a-a72c-c272585dcd40}</Project>
       <Name>Uno.UI.RuntimeTests</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\Uno.UI.Toolkit\Uno.UI.Toolkit.csproj">
+      <Project>{2eaf39e3-2ac9-457a-a5b2-47d6548799b3}</Project>
+      <Name>Uno.UI.Toolkit</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\Uno.UI\Uno.UI.csproj">
       <Project>{C6884723-81DB-43BD-924F-3FA367633E64}</Project>
       <Name>Uno.UI</Name>
@@ -93,10 +97,10 @@
       <Name>Uno</Name>
     </ProjectReference>
   </ItemGroup>
-	<Import Project="..\..\SourceGenerators\sourcegenerators.local.props" />
-	<Import Project="..\SamplesApp.Shared\SamplesApp.Shared.projitems" Label="Shared" Condition="Exists('..\SamplesApp.Shared\SamplesApp.Shared.projitems')" />
-	<Import Project="..\SamplesApp.UnitTests.Shared\SamplesApp.UnitTests.Shared.projitems" Label="Shared" />
-	<ItemGroup>
+  <Import Project="..\..\SourceGenerators\sourcegenerators.local.props" />
+  <Import Project="..\SamplesApp.Shared\SamplesApp.Shared.projitems" Label="Shared" Condition="Exists('..\SamplesApp.Shared\SamplesApp.Shared.projitems')" />
+  <Import Project="..\SamplesApp.UnitTests.Shared\SamplesApp.UnitTests.Shared.projitems" Label="Shared" />
+  <ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-128.png" />
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\AppIcon-128%402x.png" />

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -213,6 +213,14 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Full.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Minimal.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressRing.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1236,6 +1244,12 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Full_Wider.xaml.cs">
       <DependentUpon>Image_Stretch_Full_Wider.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Full.xaml.cs">
+      <DependentUpon>MediaPlayerElement_Full.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Minimal.xaml.cs">
+      <DependentUpon>MediaPlayerElement_Minimal.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\StringKeyTemplateSelector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_ComboBoxItem_Selection.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Full.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Full.xaml
@@ -1,0 +1,162 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement.MediaPlayerElement_Full"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="2*" />
+		</Grid.RowDefinitions>
+
+		<MediaPlayerElement x:Name="Mpe"
+							Source="https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8"
+							PosterSource="https://bitmovin-a.akamaihd.net/content/sintel/poster.png"
+							AreTransportControlsEnabled="{Binding IsChecked, ElementName=AreTransportControlsEnabled}"
+							AutoPlay="{Binding IsChecked, ElementName=AutoPlay}">
+			<MediaPlayerElement.TransportControls>
+				<MediaTransportControls IsCompact="{Binding IsChecked, ElementName=IsCompact}"
+										ShowAndHideAutomatically="{Binding IsChecked, ElementName=ShowAndHideAutomatically}"
+										IsFastForwardButtonVisible="{Binding IsChecked, ElementName=IsFastForwardButtonVisible}"
+										IsFastForwardEnabled="{Binding IsChecked, ElementName=IsFastForwardEnabled}"
+										IsFastRewindButtonVisible="{Binding IsChecked, ElementName=IsFastRewindButtonVisible}"
+										IsFastRewindEnabled="{Binding IsChecked, ElementName=IsFastRewindEnabled}"
+										IsFullWindowButtonVisible="{Binding IsChecked, ElementName=IsFullWindowButtonVisible}"
+										IsFullWindowEnabled="{Binding IsChecked, ElementName=IsFullWindowEnabled}"
+										IsNextTrackButtonVisible="{Binding IsChecked, ElementName=IsNextTrackButtonVisible}"
+										IsPlaybackRateButtonVisible="{Binding IsChecked, ElementName=IsPlaybackRateButtonVisible}"
+										IsPlaybackRateEnabled="{Binding IsChecked, ElementName=IsPlaybackRateEnabled}"
+										IsPreviousTrackButtonVisible="{Binding IsChecked, ElementName=IsPreviousTrackButtonVisible}"
+										IsRepeatButtonVisible="{Binding IsChecked, ElementName=IsRepeatButtonVisible}"
+										IsRepeatEnabled="{Binding IsChecked, ElementName=IsRepeatEnabled}"
+										IsSeekBarVisible="{Binding IsChecked, ElementName=IsSeekBarVisible}"
+										IsSeekEnabled="{Binding IsChecked, ElementName=IsSeekEnabled}"
+										IsSkipBackwardButtonVisible="{Binding IsChecked, ElementName=IsSkipBackwardButtonVisible}"
+										IsSkipBackwardEnabled="{Binding IsChecked, ElementName=IsSkipBackwardEnabled}"
+										IsSkipForwardButtonVisible="{Binding IsChecked, ElementName=IsSkipForwardButtonVisible}"
+										IsSkipForwardEnabled="{Binding IsChecked, ElementName=IsSkipForwardEnabled}"
+										IsStopButtonVisible="{Binding IsChecked, ElementName=IsStopButtonVisible}"
+										IsStopEnabled="{Binding IsChecked, ElementName=IsStopEnabled}"
+										IsVolumeButtonVisible="{Binding IsChecked, ElementName=IsVolumeButtonVisible}"
+										IsVolumeEnabled="{Binding IsChecked, ElementName=IsVolumeEnabled}"
+										IsZoomButtonVisible="{Binding IsChecked, ElementName=IsZoomButtonVisible}"
+										IsZoomEnabled="{Binding IsChecked, ElementName=IsZoomEnabled}" />
+			</MediaPlayerElement.TransportControls>
+		</MediaPlayerElement>
+
+		<ScrollViewer Grid.Row="1"
+					  Margin="10,20">
+			<StackPanel>
+
+				<CheckBox x:Name="AreTransportControlsEnabled"
+						  IsChecked="True"
+						  Content="AreTransportControlsEnabled" />
+
+				<CheckBox x:Name="AutoPlay"
+						  IsChecked="True"
+						  Content="AutoPlay" />
+				
+				<CheckBox x:Name="IsCompact"
+						  IsChecked="False"
+						  Content="IsCompact" />
+				
+				<CheckBox x:Name="ShowAndHideAutomatically"
+						  IsChecked="True"
+						  Content="ShowAndHideAutomatically" />
+				
+				<CheckBox x:Name="IsFastForwardButtonVisible"
+						  IsChecked="False"
+						  Content="IsFastForwardButtonVisible" />
+				
+				<CheckBox x:Name="IsFastForwardEnabled"
+						  IsChecked="False"
+						  Content="IsFastForwardEnabled" />
+				
+				<CheckBox x:Name="IsFastRewindButtonVisible"
+						  IsChecked="False"
+						  Content="IsFastRewindButtonVisible" />
+				
+				<CheckBox x:Name="IsFastRewindEnabled"
+						  IsChecked="False"
+						  Content="IsFastRewindEnabled" />
+				
+				<CheckBox x:Name="IsFullWindowButtonVisible"
+						  IsChecked="True"
+						  Content="IsFullWindowButtonVisible" />
+				
+				<CheckBox x:Name="IsFullWindowEnabled"
+						  IsChecked="True"
+						  Content="IsFullWindowEnabled" />
+				
+				<CheckBox x:Name="IsNextTrackButtonVisible"
+						  IsChecked="False"
+						  Content="IsNextTrackButtonVisible" />
+				
+				<CheckBox x:Name="IsPlaybackRateButtonVisible"
+						  IsChecked="False"
+						  Content="IsPlaybackRateButtonVisible" />
+				
+				<CheckBox x:Name="IsPreviousTrackButtonVisible"
+						  IsChecked="False"
+						  Content="IsPreviousTrackButtonVisible" />
+				
+				<CheckBox x:Name="IsRepeatButtonVisible"
+						  IsChecked="False"
+						  Content="IsRepeatButtonVisible" />
+				
+				<CheckBox x:Name="IsRepeatEnabled"
+						  IsChecked="False"
+						  Content="IsRepeatEnabled" />
+				
+				<CheckBox x:Name="IsSeekBarVisible"
+						  IsChecked="True"
+						  Content="IsSeekBarVisible" />
+				
+				<CheckBox x:Name="IsSeekEnabled"
+						  IsChecked="True"
+						  Content="IsSeekEnabled" />
+				
+				<CheckBox x:Name="IsSkipBackwardButtonVisible"
+						  IsChecked="True"
+						  Content="IsSkipBackwardButtonVisible" />
+				
+				<CheckBox x:Name="IsSkipBackwardEnabled"
+						  IsChecked="True"
+						  Content="IsSkipBackwardEnabled" />
+				
+				<CheckBox x:Name="IsSkipForwardButtonVisible"
+						  IsChecked="True"
+						  Content="IsSkipForwardButtonVisible" />
+				
+				<CheckBox x:Name="IsSkipForwardEnabled"
+						  IsChecked="True"
+						  Content="IsSkipForwardEnabled" />
+				
+				<CheckBox x:Name="IsStopButtonVisible"
+						  IsChecked="True"
+						  Content="IsStopButtonVisible" />
+				
+				<CheckBox x:Name="IsStopEnabled"
+						  IsChecked="True"
+						  Content="IsStopEnabled" />
+				
+				<CheckBox x:Name="IsVolumeButtonVisible"
+						  IsChecked="True"
+						  Content="IsVolumeButtonVisible" />
+				
+				<CheckBox x:Name="IsVolumeEnabled"
+						  IsChecked="True"
+						  Content="IsVolumeEnabled" />
+				
+				<CheckBox x:Name="IsZoomButtonVisible"
+						  IsChecked="True"
+						  Content="IsZoomButtonVisible" />
+				
+				<CheckBox x:Name="IsZoomEnabled"
+						  IsChecked="True"
+						  Content="IsZoomEnabled" />
+
+			</StackPanel>
+		</ScrollViewer>
+		
+    </Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Full.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Full.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement
+{
+	[SampleControlInfo("MediaPlayerElement", "Feature coverage", description: "MediaPlayerElement feature coverage")]
+	public sealed partial class MediaPlayerElement_Full : UserControl
+	{
+		public MediaPlayerElement_Full()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Minimal.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Minimal.xaml
@@ -1,0 +1,141 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement.MediaPlayerElement_Minimal"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+	<UserControl.Resources>
+
+		<Style TargetType="MediaTransportControls"
+			   x:Key="MediaTransportControlsMinimalStyle">
+			<Setter Property="IsTabStop"
+					Value="False" />
+			<Setter Property="Background"
+					Value="Transparent" />
+			<Setter Property="FlowDirection"
+					Value="LeftToRight" />
+			<Setter Property="UseSystemFocusVisuals"
+					Value="True" />
+			<Setter Property="IsTextScaleFactorEnabled"
+					Value="False" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="MediaTransportControls">
+						<Grid x:Name="RootGrid"
+							  Background="Transparent">
+
+							<VisualStateManager.VisualStateGroups>
+								<!-- ControlPanel Visibility states -->
+								<VisualStateGroup x:Name="ControlPanelVisibilityStates">
+									<VisualState x:Name="ControlPanelFadeIn" />
+									<VisualState x:Name="ControlPanelFadeOut" />
+								</VisualStateGroup>
+								<!-- ControlPanel Visibility states -->
+								<!-- Media state visual states -->
+								<VisualStateGroup x:Name="MediaStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="Buffering" />
+									<VisualState x:Name="Loading" />
+									<VisualState x:Name="Error" />
+									<VisualState x:Name="Disabled" />
+								</VisualStateGroup>
+								<!-- Media state visual states -->
+								<!-- Audio Selection Button visibility states -->
+								<VisualStateGroup x:Name="AudioSelectionAvailablityStates">
+									<VisualState x:Name="AudioSelectionAvailable" />
+									<VisualState x:Name="AudioSelectionUnavailable" />
+								</VisualStateGroup>
+								<!-- Video volume visibility states -->
+								<!-- Closed Captioning Selection Button visibility states -->
+								<VisualStateGroup x:Name="CCSelectionAvailablityStates">
+									<VisualState x:Name="CCSelectionAvailable" />
+									<VisualState x:Name="CCSelectionUnavailable" />
+								</VisualStateGroup>
+								<!-- Closed Captioning  visibility states -->
+								<!-- Focus states -->
+								<VisualStateGroup x:Name="FocusStates">
+									<VisualState x:Name="Focused" />
+									<VisualState x:Name="Unfocused" />
+									<VisualState x:Name="PointerFocused" />
+								</VisualStateGroup>
+								<!-- Focus states -->
+								<VisualStateGroup x:Name="MediaTransportControlMode">
+									<VisualState x:Name="NormalMode" />
+									<VisualState x:Name="CompactMode" />
+								</VisualStateGroup>
+								<!-- PlayPause states -->
+								<VisualStateGroup x:Name="PlayPauseStates">
+									<VisualState x:Name="PlayState" />
+									<VisualState x:Name="PauseState">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlayPauseSymbol"
+																		   Storyboard.TargetProperty="Symbol">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Pause" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+								<!-- VolumeMute states -->
+								<VisualStateGroup x:Name="VolumeMuteStates">
+									<VisualState x:Name="VolumeState" />
+									<VisualState x:Name="MuteState" />
+								</VisualStateGroup>
+								<!-- FullWindow states -->
+								<VisualStateGroup x:Name="FullWindowStates">
+									<VisualState x:Name="NonFullWindowState" />
+									<VisualState x:Name="FullWindowState">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetName="FullWindowSymbol"
+																		   Storyboard.TargetProperty="Symbol">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="BackToWindow" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+
+							<Grid VerticalAlignment="Bottom">
+								<Grid.ColumnDefinitions>
+									<ColumnDefinition Width="Auto" />
+									<ColumnDefinition Width="*" />
+									<ColumnDefinition Width="Auto" />
+								</Grid.ColumnDefinitions>
+
+								<Button x:Name='PlayPauseButton'>
+									<SymbolIcon x:Name='PlayPauseSymbol'
+												Symbol='Play'
+												Foreground="White" />
+								</Button>
+
+								<Slider x:Name="ProgressSlider"
+										IsThumbToolTipEnabled="False"
+										Grid.Column="1"
+										Background="LightGray"
+										Foreground="OrangeRed" />
+
+								<Button x:Name='FullWindowButton'
+										Grid.Column="2">
+									<SymbolIcon x:Name='FullWindowSymbol'
+												Symbol='FullScreen'
+												Foreground="White" />
+								</Button>
+							</Grid>
+						</Grid>
+
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+		
+	</UserControl.Resources>
+
+	<MediaPlayerElement Source="https://bitmovin-a.akamaihd.net/content/sintel/hls/playlist.m3u8"
+						PosterSource="https://bitmovin-a.akamaihd.net/content/sintel/poster.png"
+						AreTransportControlsEnabled="True"
+						AutoPlay="True">
+		<MediaPlayerElement.TransportControls>
+			<MediaTransportControls Style="{StaticResource MediaTransportControlsMinimalStyle}" />
+		</MediaPlayerElement.TransportControls>
+	</MediaPlayerElement>
+	
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Minimal.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/MediaPlayerElement/MediaPlayerElement_Minimal.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.MediaPlayerElement
+{
+	[SampleControlInfo("MediaPlayerElement", "Mini player", description: "MediaPlayerElement with minimal controls")]
+	public sealed partial class MediaPlayerElement_Minimal : UserControl
+    {
+        public MediaPlayerElement_Minimal()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControls.MediaPlayer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControls.MediaPlayer.cs
@@ -117,10 +117,7 @@ namespace Windows.UI.Xaml.Controls
 
 			Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 			{
-				if (_downloadProgressIndicator != null)
-				{
-					_downloadProgressIndicator.Value = (double)args;
-				}
+				_downloadProgressIndicator.Maybe(p => p.Value = (double)args);
 			});
 		}
 
@@ -129,12 +126,12 @@ namespace Windows.UI.Xaml.Controls
 			Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 			{
 				var duration = args as TimeSpan? ?? TimeSpan.Zero;
-				_progressSlider.Minimum = 0;
-				_progressSlider.Maximum = duration.TotalSeconds;
+				_progressSlider.Maybe(p => p.Minimum = 0);
+				_progressSlider.Maybe(p => p.Maximum = duration.TotalSeconds);
 
 				if (_mediaPlayer.PlaybackSession.PlaybackState != MediaPlaybackState.Playing && _mediaPlayer.PlaybackSession.PlaybackState != MediaPlaybackState.Paused)
 				{
-					_timeRemainingElement.Text = $"{duration.TotalHours:0}:{duration.Minutes:00}:{duration.Seconds:00}";
+					_timeRemainingElement.Maybe(p => p.Text = $"{duration.TotalHours:0}:{duration.Minutes:00}:{duration.Seconds:00}");
 				}
 			});
 		}
@@ -144,11 +141,11 @@ namespace Windows.UI.Xaml.Controls
 			Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
 			{
 				var elapsed = args as TimeSpan? ?? TimeSpan.Zero;
-				_timeElapsedElement.Text = $"{elapsed.TotalHours:0}:{elapsed.Minutes:00}:{elapsed.Seconds:00}";
-				_progressSlider.Value = elapsed.TotalSeconds;
+				_timeElapsedElement.Maybe(p => p.Text = $"{elapsed.TotalHours:0}:{elapsed.Minutes:00}:{elapsed.Seconds:00}");
+				_progressSlider.Maybe(p => p.Value = elapsed.TotalSeconds);
 
 				var remaining = _mediaPlayer.PlaybackSession.NaturalDuration - elapsed;
-				_timeRemainingElement.Text = $"{remaining.TotalHours:0}:{remaining.Minutes:00}:{remaining.Seconds:00}";
+				_timeRemainingElement.Maybe(p => p.Text = $"{remaining.TotalHours:0}:{remaining.Minutes:00}:{remaining.Seconds:00}");
 			});
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #
None

## PR Type
What kind of change does this PR introduce?
 Bugfix

## What is the current behavior?
Some missing null check on some MediaTransportControl controls, which affect behavior if control is removed from style

## What is the new behavior?
MediaTransportControl controls can now be properly removed from style if unused

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

## Other information
None

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/147405
