### PR TITLE
Restore original NavigationView Settings events registrations

### DIFF
--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -249,7 +249,7 @@ declare namespace Uno.UI {
         */
         arrangeElementNative(pParams: number): boolean;
         /**
-        * Arrange and clips a native elements
+        * Sets the transform matrix of an element
         *
         */
         setElementTransformNative(pParams: number): boolean;

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -666,7 +666,7 @@ var Uno;
                 return true;
             }
             /**
-            * Arrange and clips a native elements
+            * Sets the transform matrix of an element
             *
             */
             setElementTransformNative(pParams) {

--- a/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/NavigationView/NavigationView.cs
@@ -390,13 +390,9 @@ namespace Windows.UI.Xaml.Controls
 				var d = new CompositeDisposable();
 
 				m_settingsItem = settingsItem;
-#if IS_UNO
-				settingsItem.PointerPressed += OnSettingsTapped;
-				d.Add(() => settingsItem.PointerPressed -= OnSettingsTapped);
-#else
+
 				settingsItem.Tapped += OnSettingsTapped;
 				d.Add(() => settingsItem.Tapped -= OnSettingsTapped);
-#endif
 
 				settingsItem.KeyDown += OnSettingsKeyDown;
 				d.Add(() => settingsItem.KeyDown -= OnSettingsKeyDown);
@@ -884,11 +880,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-#if IS_UNO
-		void OnSettingsTapped(object sender, PointerRoutedEventArgs args)
-#else
 		void OnSettingsTapped(object sender, TappedRoutedEventArgs args)
-#endif
 		{
 			OnSettingsInvoked();
 		}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The Settings item in the navigation is not properly reacting to clicks.


## What is the new behavior?
The RoutedEvents PR added the Tap event support, the NavigationView is now using it.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
