### PR TITLE
[WASM] Add workaround for mono linker issue in AOT mode

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -210,6 +210,7 @@
  * 138099, 138463 [Android] fixed `ListView` scrolls up when tapping an item at the bottom of screen
  * 140548 [iOS] fixed `CommandBar` not rendering until reloaded
  * [147530] Add a missing `global::` qualifier in the `BindableMetadataGenerator`
+ * [WASM] Add workaround for mono linker issue in AOT mode in `ObservableVectorWrapper`
 
 ## Release 1.41
 

--- a/src/Uno.UI/LinkerDefinition.Wasm.xml
+++ b/src/Uno.UI/LinkerDefinition.Wasm.xml
@@ -9,6 +9,7 @@
     <type fullname="Windows.UI.Xaml.Media.CornerRadiusConverter" />
     <type fullname="Uno.Media.GeometryConverter" />
     <type fullname="Windows.UI.Xaml.ThicknessConverter" />
+    <type fullname="Windows.UI.Xaml.ObservableVectorWrapper" />
   </assembly>
   
   <assembly fullname="Uno">


### PR DESCRIPTION


## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
ListView implementation may fail with this error:
```
"System.ExecutionEngineException: Attempting to JIT compile method 
'Windows.Foundation.Collections.IObservableVector`1<object> Windows.UI.Xaml.ObservableVectorWrapper:Create (object)' while running 
in aot-only mode. See https://docs.microsoft.com/xamarin/ios/internals/limitations for more information." but maybe just a warning
```

## What is the new behavior?
Added a linker exclusion to works around https://github.com/mono/mono/issues/12987

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
