### PR TITLE
[iOS] Fix transform animations which uses 'BeginTime'

### DIFF
--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media_Animation/DoubleAnimation_BeginTime.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media_Animation/DoubleAnimation_BeginTime.xaml
@@ -1,78 +1,60 @@
 <UserControl
 	x:Class="Uno.UI.Samples.Content.UITests.Animations.DoubleAnimation_BeginTime"
-	xmlns:controls="using:Uno.UI.Samples.Controls"
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-	xmlns:xamarin="http://uno.ui/xamarin"
-	mc:Ignorable="d xamarin"
+	mc:Ignorable="d"
 	d:DesignHeight="2000"
 	d:DesignWidth="400">
 
-	<UserControl.Resources>
-		<ResourceDictionary>
-			<Style TargetType="Button" x:Key="ButtonSlowAnimationStyle">
-				<Setter Property="Template">
-					<Setter.Value>
-						<ControlTemplate TargetType="Button">
-							<Grid BorderBrush="Black" BorderThickness="2">
-								<VisualStateManager.VisualStateGroups>
-									<VisualStateGroup x:Name="CommonStates">
-										<VisualState x:Name="Normal">
-											<Storyboard>
-												<DoubleAnimation
-													Storyboard.TargetName="Inner"
-													Storyboard.TargetProperty="Opacity"
-													To="0"
-													Duration="0:0:0.3" />
-											</Storyboard>
-										</VisualState>
-										<VisualState x:Name="Pressed">
-											<Storyboard>
-												<DoubleAnimation
-													Storyboard.TargetName="Inner"
-													Storyboard.TargetProperty="Opacity"
-													To="1"
-													BeginTime="0:0:.5"
-													Duration="0:0:.5" />
-											</Storyboard>
-										</VisualState>
-									</VisualStateGroup>
-								</VisualStateManager.VisualStateGroups>
-								<Border
-									x:Name="Inner"
-									Background="Green"
-									HorizontalAlignment="Stretch"
-									VerticalAlignment="Stretch" />
+	<Grid VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
+		<StackPanel>
+			<Button Content="Animate" Tapped="StartAnimation" />
+			<Button Content="Reset" Tapped="ResetAnimation" />
+		</StackPanel>
 
-								<ContentPresenter
-									x:Name="Content"
-									Content="{TemplateBinding Content}"
-									xamarin:ContentTemplate="{TemplateBinding ContentTemplate}"
-									ContentTemplateSelector="{TemplateBinding ContentTemplateSelector}"
-									HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-									VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-									VerticalAlignment="Center" />
-							</Grid>
-						</ControlTemplate>
-					</Setter.Value>
-				</Setter>
-			</Style>
-		</ResourceDictionary>
-	</UserControl.Resources>
+		<Border
+			Background="Orange"
+			Width="100"
+			Height="100"
+			VerticalAlignment="Center"
+			HorizontalAlignment="Center">
+			<Border.RenderTransform>
+				<TranslateTransform x:Name="_transform" Y="150" />
+			</Border.RenderTransform>
+		</Border>
 
-	<controls:SampleControl SampleDescription="Button with BeginTime on pressed state animation">
-		<controls:SampleControl.SampleContent>
-			<DataTemplate>
-				<Button
-					Style="{StaticResource ButtonSlowAnimationStyle}"
-					x:Uid="button_slow_animation"
-					Content="Sloow"
-					Margin="10"
-					Width="100"
-					Height="60"/>
-			</DataTemplate>
-		</controls:SampleControl.SampleContent>
-	</controls:SampleControl>
+		<Border
+			BorderThickness="5"
+			BorderBrush="DeepPink"
+			Width="200"
+			Height="200"
+			VerticalAlignment="Center"
+			HorizontalAlignment="Center">
+			<TextBlock Text="150" Foreground="DeepPink" />
+		</Border>
+
+		<Border
+			BorderThickness="5"
+			BorderBrush="DeepSkyBlue"
+			Width="100"
+			Height="100"
+			VerticalAlignment="Center"
+			HorizontalAlignment="Center">
+			<TextBlock Text="50" Foreground="DeepSkyBlue" />
+		</Border>
+
+		<Border
+			Background="Red"
+			Width="4"
+			Height="4"
+			VerticalAlignment="Center"
+			HorizontalAlignment="Center" />
+
+		<TextBlock VerticalAlignment="Bottom" HorizontalAlignment="Stretch" TextWrapping="Wrap">
+			When you click on button, after a delay of 3 sec, the orange square will move up by 150 px to came back to the center (red dot) of the view
+			(it should start with an Y offset of 150 from the center)
+		</TextBlock>
+	</Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media_Animation/DoubleAnimation_BeginTime.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Media_Animation/DoubleAnimation_BeginTime.xaml.cs
@@ -2,18 +2,42 @@ using System;
 using System.Linq;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 using Uno.UI.Samples.Controls;
 
 
 namespace Uno.UI.Samples.Content.UITests.Animations
 {
-	[SampleControlInfoAttribute("Animations", "DoubleAnimation_BeginTime")]
+	[SampleControlInfo("Animations", "DoubleAnimation_BeginTime")]
 	public sealed partial class DoubleAnimation_BeginTime : UserControl
 	{
 		public DoubleAnimation_BeginTime()
 		{
 			this.InitializeComponent();
+		}
+
+		private void StartAnimation(object sender, TappedRoutedEventArgs e)
+		{
+			var animation = new DoubleAnimation
+			{
+				To = 0,
+				BeginTime = TimeSpan.FromSeconds(3),
+				Duration = new Duration(TimeSpan.FromSeconds(3))
+			};
+			Storyboard.SetTargetProperty(animation, nameof(TranslateTransform.Y));
+			Storyboard.SetTarget(animation, _transform);
+
+			new Storyboard
+			{
+				Children = { animation }
+			}.Begin();
+		}
+
+		private void ResetAnimation(object sender, TappedRoutedEventArgs e)
+		{
+			_transform.Y = 150;
 		}
 	}
 }

--- a/src/Uno.UWP/UI/Composition/CoreAnimation.iOS.cs
+++ b/src/Uno.UWP/UI/Composition/CoreAnimation.iOS.cs
@@ -152,6 +152,11 @@ namespace Windows.UI.Composition
 
 			_onAnimationStarted = (s, e) =>
 			{
+				// This will disable the transform while the native animation handles it
+				// It must be the first thing we do when the animation starts
+				// (However we have to wait for the first frame in order to not remove the transform while waiting for the BeginTime)
+				_prepare?.Invoke();
+
 				var anim = s as CAAnimation;
 
 				if (anim == null)
@@ -210,7 +215,6 @@ namespace Windows.UI.Composition
 
 			_animation.AnimationStarted += _onAnimationStarted;
 
-			_prepare?.Invoke();
 			layer.AddAnimation(_animation, _key);
 		}
 


### PR DESCRIPTION
[iOS] Fix transform animations which uses 'BeginTime' will wait the delay without any transform

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
On iOS, when animating a `Transform` with a `BeginTime != TimeSpan.Zero` and the target property is not 0 (e.g. `TranslateTransform.Y == 150`), then while waiting for the delay, the current transform is not applied on the view (i.e. the view goes back to its original position like if `TranslateTransform.Y = 0`)

## What is the new behavior?
We wait for the first frame of the animation to disable the managed transform (cf. `RenderTransformAdapter.iOS.cs`)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/147309