### PR TITLE
Patch SplitView opening issue

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/SplitView/SplitView.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/SplitView/SplitView.cs
@@ -384,6 +384,9 @@ namespace Windows.UI.Xaml.Controls
 				PaneOpening?.Invoke(this, null);
 			}
 
+#if __IOS__
+			PatchInvalidFinalState(stateName);
+#endif
 			VisualStateManager.GoToState(this, stateName, useTransitons);
 
 			if (!IsPaneOpen)

--- a/src/Uno.UI/UI/Xaml/Controls/SplitView/SplitView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/SplitView/SplitView.iOS.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Animation;
+
+namespace Windows.UI.Xaml.Controls
+{
+	partial class SplitView
+	{
+		/*
+
+			About the PatchInvalidFinalState:
+				On iOS for some strange reasons, the burger menu may not complete its open/close animation,
+				but instead either does not appear at all (when opened), either stays partialy visible (when closed).
+				This seems to be related to the fact that  animations of SplitView are altering the Grid.Column and the Visibility 
+				of some controls.
+				Usually it will become fully visible/hidden when a rendering cycle occurs, but this causes
+				a delay for the users which seems aukward.
+				The patch here only ensure to invalidate the view to force a layouting cycle.
+			
+		*/
+		
+		private VisualStateGroup _patchDisplayModeStatesGroup;
+		
+		private void PatchInvalidFinalState(string targetStateName)
+		{
+			// Get the DisplayModeStates visual state group from the root element of the template
+			if (_patchDisplayModeStatesGroup == null)
+			{
+				var rootElement = TemplatedRoot as FrameworkElement;
+				if (rootElement == null && VisualTreeHelper.GetChildrenCount(this) > 0)
+				{
+					rootElement = VisualTreeHelper.GetChild(this, 0) as FrameworkElement;
+				}
+
+				if (rootElement != null)
+				{
+					_patchDisplayModeStatesGroup = VisualStateManager
+						.GetVisualStateGroups(rootElement)
+						.FirstOrDefault(g => g.Name == "DisplayModeStates");
+				}
+			}
+
+			var current = _patchDisplayModeStatesGroup?.CurrentState;
+			if (current == null)
+			{
+				return;
+			}
+
+			// As completion are not properly handled by visual states/Storyboard, we have to dig to find the transition
+			// and subscribe to its longest Storyboard's timeline
+			var timeline = _patchDisplayModeStatesGroup
+				.Transitions
+				.FirstOrDefault(t => t.From == current.Name && t.To == targetStateName)
+				?.Storyboard?.Children
+				.Where(t => t.Duration.HasTimeSpan)
+				.OrderBy(t => (t.BeginTime ?? TimeSpan.Zero) + t.Duration.TimeSpan)
+				.LastOrDefault();
+
+			if (timeline != null)
+			{
+				timeline.Completed += PatchInvalidFinalStateHandler;
+			}
+		}
+
+		private void PatchInvalidFinalStateHandler(object sender, object o)
+		{
+			if (sender is Timeline timeline)
+			{
+				timeline.Completed -= PatchInvalidFinalStateHandler;
+			}
+
+			Dispatcher.RunIdleAsync(_ => InvalidateMeasure());
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/SplitView/SplitView.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/SplitView/SplitView.iOS.cs
@@ -17,7 +17,7 @@ namespace Windows.UI.Xaml.Controls
 				This seems to be related to the fact that  animations of SplitView are altering the Grid.Column and the Visibility 
 				of some controls.
 				Usually it will become fully visible/hidden when a rendering cycle occurs, but this causes
-				a delay for the users which seems aukward.
+				a delay for the users which seems awkward.
 				The patch here only ensure to invalidate the view to force a layouting cycle.
 			
 		*/


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Other: Patch

## What is the current behavior?
In some applications it may occurs that the menu stay partially visible when closed

## What is the new behavior?
The menu is fully opened / closed

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/146335