### PR TITLE
Add a missing global:: qualifier in the BindableMetadataGenerator

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -197,6 +197,7 @@
  * #376 iOS project compilation fails: Can't resolve the reference 'System.Void Windows.UI.Xaml.Documents.BlockCollection::Add(Windows.UI.Xaml.Documents.Block)
  * 138099, 138463 [Android] fixed `ListView` scrolls up when tapping an item at the bottom of screen
  * 140548 [iOS] fixed `CommandBar` not rendering until reloaded
+ * [147530] Add a missing `global::` qualifier in the `BindableMetadataGenerator`
 
 ## Release 1.41
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/BindableTypeProviders/BindableTypeProvidersGenerationTask.cs
@@ -358,7 +358,7 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 				using (writer.BlockInvariant("internal static global::Uno.UI.DataBinding.IBindableType Build(global::Uno.UI.DataBinding.BindableType parent)"))
 				{
 					writer.AppendLineInvariant(
-						@"var bindableType = parent ?? new global::Uno.UI.DataBinding.BindableType({0}, typeof(global::{1}));",
+						@"var bindableType = parent ?? new global::Uno.UI.DataBinding.BindableType({0}, typeof({1}));",
 						flattenedProperties
 							.Where(p => !IsStringIndexer(p) && HasPublicGetter(p))
 							.Count()
@@ -370,7 +370,7 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 					{
 						var baseTypeMapped = _typeMap.UnoGetValueOrDefault(baseType);
 
-						writer.AppendLineInvariant(@"MetadataBuilder_{0:000}.Build(bindableType); // {1}", baseTypeMapped.Index, baseType.GetFullName());
+						writer.AppendLineInvariant(@"MetadataBuilder_{0:000}.Build(bindableType); // {1}", baseTypeMapped.Index, ExpandType(baseType));
 					}
 
 					var ctor = ownerType.GetMethods().FirstOrDefault(m => m.MethodKind == MethodKind.Constructor && !m.Parameters.Any() && m.IsLocallyPublic(_currentModule));
@@ -469,7 +469,7 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 							var getter = $"{XamlConstants.Types.DependencyObjectExtensions}.GetValue(instance, {ownerTypeName}.{propertyName}Property, precedence)";
 							var setter = $"{XamlConstants.Types.DependencyObjectExtensions}.SetValue(instance, {ownerTypeName}.{propertyName}Property, value, precedence)";
 
-							var propertyType = SanitizeTypeName(getMethod.ReturnType.ToString());
+							var propertyType = GetGlobalQualifier(getMethod.ReturnType) + SanitizeTypeName(getMethod.ReturnType.ToString());
 
 							writer.AppendLineInvariant($@"bindableType.AddProperty(""{propertyName}"", typeof({propertyType}),  Get{propertyName}, Set{propertyName});");
 
@@ -495,7 +495,7 @@ namespace Uno.UI.SourceGenerators.BindableTypeProviders
 			}
 			else
 			{
-				return ownerType.GetFullName();
+				return GetGlobalQualifier(ownerType) + ownerType.GetFullName();
 			}
 		}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
A recent type addition makes application ending in `Uno` conflict with existing types.

## What is the new behavior?
The `BindableMetadataGenerator` now qualifies property types properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/147530
