### PR TITLE
Adjust for VS15.8 compatibility

### DIFF
--- a/src/SourceGenerators/System.Xaml/System.Xaml/XamlXmlReader.cs
+++ b/src/SourceGenerators/System.Xaml/System.Xaml/XamlXmlReader.cs
@@ -634,12 +634,12 @@ namespace Uno.Xaml
 
 				if(isFirstElementString)
 				{
-					value = value.TrimStart();
+					value = value.TrimStart(new char[0]);
 				}
 
 				if(r.NodeType == XmlNodeType.EndElement)
 				{
-					value = value.TrimEnd();
+					value = value.TrimEnd(new char[0]);
 				}
 			}
 

--- a/src/Uno.MonoAnalyzers/MonoNotSupportedAPIAnalyzer.cs
+++ b/src/Uno.MonoAnalyzers/MonoNotSupportedAPIAnalyzer.cs
@@ -101,6 +101,15 @@ namespace Uno.Analyzers
 					},
 					new ValidationEntry{
 						Methods = new[] {
+							"TrimStart",
+							"TrimEnd",
+						},
+						Validation = new Func<IMethodSymbol, bool>(
+							m => m.Parameters.Length == 0
+						)
+					},
+					new ValidationEntry{
+						Methods = new[] {
 							"Replace",
 						},
 						Validation = new Func<IMethodSymbol, bool>(


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Used String.TrimStart/TrimEnd overload is incorrect


## What is the new behavior?
Analyzer is updated to avoid the use of those methods


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
