### PR TITLE
Restore original SymbolIcon.SymbolProperty as a C# property

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -70,6 +70,7 @@
 * Add support for `Selector.SelectedValuePath` (e.g. useful for ComboBox)
 * Add support for JS unhandled exception logging for CoreDispatcher (support for Mixed mode troubleshooting)
 * [WASM] Improve element arrange and transform performance
+* Restore original SymbolIcon.SymbolProperty as a C# property
 
 ### Breaking changes
 * Refactored ToggleSwitch Default Native XAML Styles. (cf. 'NativeDefaultToggleSwitch' styles in Generic.Native.xaml)

--- a/src/Uno.UI/UI/Xaml/Controls/SymbolIcon/SymbolIcon.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/SymbolIcon/SymbolIcon.cs
@@ -30,8 +30,7 @@ namespace Windows.UI.Xaml.Controls
 			set => SetValue(SymbolProperty, value);
 		}
 
-		// Using a DependencyProperty as the backing store for Symbol.  This enables animation, styling, binding, etc...
-		public static readonly DependencyProperty SymbolProperty =
+		public static DependencyProperty SymbolProperty { get; } =
 			DependencyProperty.Register("Symbol", typeof(Symbol), typeof(SymbolIcon), new PropertyMetadata(Symbol.Home, OnSymbolChanged));
 
 		private static void OnSymbolChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs args)


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
```
6> Fatal error in Mono CIL Linker
6> Mono.Linker.MarkException: Error processing method: 'System.Void Microsoft.Toolkit.Uwp.UI.Controls.__Resources._SlidableListItem_1d281c723c2c9317e7ef2ea0816c3828_SlidableListItemRDSC0/<>c::<Build>b__0_4(Windows.UI.Xaml.Controls.SymbolIcon)' in assembly: 'Microsoft.Toolkit.Uwp.UI.Controls.dll'
---> Mono.Cecil.ResolutionException: Failed to resolve Windows.UI.Xaml.DependencyProperty Windows.UI.Xaml.Controls.SymbolIcon::get_SymbolProperty()
```

## What is the new behavior?
The original `SymbolIcon.SymbolProperty` definition is restored as a property, not a field.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
