### PR TITLE
Fix end of animations

### DIFF
--- a/src/Uno.UI.Tests/BinderTests/Given_BindingPath.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_BindingPath.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Uno.UI.DataBinding;
+
+namespace Uno.UI.Tests.BinderTests
+{
+	[TestClass]
+	public partial class Given_BindingPath
+	{
+		[TestMethod]
+		public void When_SetValue_Then_TargetUpdated()
+		{
+			var (target, sut) = Arrange();
+
+			sut.Value = "42";
+
+			Assert.AreEqual("42", target.Value);
+		}
+
+		[TestMethod]
+		public void When_WithHigherPrecedence_SetValue_Then_ValueUpdated()
+		{
+			var (target, sut) = Arrange(DependencyPropertyValuePrecedences.Animations);
+
+			sut.Value = "Animations"; // Animations
+
+			Assert.AreEqual("Animations", target.Value);
+
+			Assert.AreEqual("Animations", target.GetPrecedenceSpecificValue(MyTarget.ValueProperty, DependencyPropertyValuePrecedences.Animations));
+		}
+
+		[TestMethod]
+		public void When_WithHigherPrecedence_SetValueAndLocalValue_Then_ValueUpdated()
+		{
+			var (target, sut) = Arrange(DependencyPropertyValuePrecedences.Animations);
+
+			sut.Value = "Animations";
+			sut.SetLocalValue("Local");
+
+			Assert.AreEqual("Animations", target.Value);
+
+			Assert.AreEqual("Animations", target.GetPrecedenceSpecificValue(MyTarget.ValueProperty, DependencyPropertyValuePrecedences.Animations));
+			Assert.AreEqual("Local", target.GetPrecedenceSpecificValue(MyTarget.ValueProperty, DependencyPropertyValuePrecedences.Local));
+		}
+
+		[TestMethod]
+		public void When_WithHigherPrecedence_SetValueAndLocalValueAndClear_Then_ValueUpdated()
+		{
+			var (target, sut) = Arrange(DependencyPropertyValuePrecedences.Animations);
+
+			sut.Value = "Animations";
+			sut.SetLocalValue("Local");
+			sut.ClearValue();
+
+			Assert.AreEqual("Local", target.Value);
+
+			Assert.AreEqual(DependencyProperty.UnsetValue, target.GetPrecedenceSpecificValue(MyTarget.ValueProperty, DependencyPropertyValuePrecedences.Animations));
+			Assert.AreEqual("Local", target.GetPrecedenceSpecificValue(MyTarget.ValueProperty, DependencyPropertyValuePrecedences.Local));
+		}
+
+		[TestMethod]
+		public void When_WithHigherPrecedence_SetValueAndClear_SetTargetValue_Then_ValueUpdated()
+		{
+			var (target, sut) = Arrange(DependencyPropertyValuePrecedences.Animations);
+
+			sut.Value = "Animations";
+			sut.ClearValue();
+
+			target.Value = "TargetLocalValue";
+
+			Assert.AreEqual("TargetLocalValue", target.Value);
+
+			Assert.AreEqual(DependencyProperty.UnsetValue, target.GetPrecedenceSpecificValue(MyTarget.ValueProperty, DependencyPropertyValuePrecedences.Animations));
+			Assert.AreEqual("TargetLocalValue", target.GetPrecedenceSpecificValue(MyTarget.ValueProperty, DependencyPropertyValuePrecedences.Local));
+		}
+
+		[TestMethod]
+		public void When_WithLowerPrecedence_SetValue_Then_ValueUpdated()
+		{
+			var (target, sut) = Arrange(DependencyPropertyValuePrecedences.Inheritance);
+			target.Value = "CustomDefaultLocalValue";
+
+			sut.Value = "Inherit";
+
+			Assert.AreEqual("CustomDefaultLocalValue", target.Value);
+
+			Assert.AreEqual("Inherit", target.GetPrecedenceSpecificValue(MyTarget.ValueProperty, DependencyPropertyValuePrecedences.Inheritance));
+		}
+
+		[TestMethod]
+		public void When_WithLowerPrecedence_SetValueAndLocalValue_Then_ValueUpdated()
+		{
+			var (target, sut) = Arrange(DependencyPropertyValuePrecedences.Inheritance);
+
+			sut.Value = "Inherit";
+			sut.SetLocalValue("Local");
+
+			Assert.AreEqual("Local", target.Value);
+
+			Assert.AreEqual("Local", target.GetPrecedenceSpecificValue(MyTarget.ValueProperty, DependencyPropertyValuePrecedences.Local));
+			Assert.AreEqual("Inherit", target.GetPrecedenceSpecificValue(MyTarget.ValueProperty, DependencyPropertyValuePrecedences.Inheritance));
+		}
+
+		[TestMethod]
+		public void When_WithLowerPrecedence_SetValueAndLocalValueAndClear_Then_ValueUpdated()
+		{
+			var (target, sut) = Arrange(DependencyPropertyValuePrecedences.Inheritance);
+
+			sut.Value = "Inherit";
+			sut.SetLocalValue("Local");
+			sut.ClearValue();
+
+			Assert.AreEqual("Local", target.Value);
+
+			Assert.AreEqual(DependencyProperty.UnsetValue, target.GetPrecedenceSpecificValue(MyTarget.ValueProperty, DependencyPropertyValuePrecedences.Animations));
+			Assert.AreEqual("Local", target.GetPrecedenceSpecificValue(MyTarget.ValueProperty, DependencyPropertyValuePrecedences.Local));
+		}
+
+		[TestMethod]
+		public void When_WithLowerPrecedence_SetValueAndClear_SetTargetValue_Then_ValueUpdated()
+		{
+			var (target, sut) = Arrange(DependencyPropertyValuePrecedences.Inheritance);
+
+			sut.Value = "Inherit";
+			sut.ClearValue();
+
+			target.Value = "TargetLocalValue";
+
+			Assert.AreEqual("TargetLocalValue", target.Value);
+
+			Assert.AreEqual(DependencyProperty.UnsetValue, target.GetPrecedenceSpecificValue(MyTarget.ValueProperty, DependencyPropertyValuePrecedences.Animations));
+			Assert.AreEqual("TargetLocalValue", target.GetPrecedenceSpecificValue(MyTarget.ValueProperty, DependencyPropertyValuePrecedences.Local));
+		}
+
+		private static (MyTarget target, BindingPath binding) Arrange(DependencyPropertyValuePrecedences? precedence = null)
+		{
+			var target = new MyTarget();
+			var binding = new BindingPath(nameof(MyTarget.Value), MyTarget.FallbackValue, precedence, false)
+			{
+				DataContext = target
+			};
+
+			return (target, binding);
+		}
+
+		public partial class MyTarget : DependencyObject
+		{
+			public const string DefaultValue = "__default__";
+			public const string FallbackValue = "__fallback__";
+
+			public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(
+				"Value", typeof(string), typeof(MyTarget), new PropertyMetadata(DefaultValue));
+
+			public string Value
+			{
+				get => (string) this.GetValue(ValueProperty);
+				set => this.SetValue(ValueProperty, value);
+			}
+		}
+	}
+}

--- a/src/Uno.UI/Controls/Window.iOS.cs
+++ b/src/Uno.UI/Controls/Window.iOS.cs
@@ -124,7 +124,7 @@ namespace Uno.UI.Controls
 						// As soon as we are in a WebView the NeedsKeyboard will always returns false. So here we will complete
 						// edition as soon as the user touch anywhere on the screen. This is acceptable since there are dedicated
 						// buttons on the keyboard to focus the next/previous fields of a form.
-						previouslyFocusedView.EndEditing(true);
+						previouslyFocusedView?.EndEditing(true);
 					}
 					else if (previouslyFocusedView != null && IsFocusable(_focusedView))
 					{

--- a/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
+++ b/src/Uno.UI/DataBinding/BindingPropertyHelper.cs
@@ -753,9 +753,6 @@ namespace Uno.UI.DataBinding
 				}
 			}
 
-			var propertyInfo = Uno.Funcs.CreateMemoized(() => GetPropertyInfo(type, property, allowPrivateMembers: false));
-			var propertyType = Uno.Funcs.CreateMemoized(() => GetPropertyOrDependencyPropertyType(type, property));
-
 			// Start by using the provider, to avoid reflection
 			if (BindableMetadataProvider != null)
 			{
@@ -799,12 +796,14 @@ namespace Uno.UI.DataBinding
 					return (instance, value) => DependencyObjectExtensions.SetValue((DependencyObject)instance, dp, convertSelector(() => dp.Type, value), precedence);
 				}
 
-				if (propertyInfo() != null)
+				var propertyInfo = GetPropertyInfo(type, property, allowPrivateMembers: false);
+				if (propertyInfo != null)
 				{
-					var setMethod = propertyInfo().GetSetMethod();
+					var setMethod = propertyInfo.GetSetMethod();
 
 					if (setMethod != null)
 					{
+						var propertyType = Uno.Funcs.CreateMemoized(() => GetPropertyOrDependencyPropertyType(type, property));
 						var handler = MethodInvokerBuilder(setMethod);
 
 						return (instance, value) => handler(instance, new object[] { convertSelector(propertyType, value) });

--- a/src/Uno.UI/UI/Xaml/Media/Animation/DoubleAnimation.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/DoubleAnimation.cs
@@ -342,14 +342,18 @@ namespace Windows.UI.Xaml.Media.Animation
 
 			if (FillBehavior == FillBehavior.HoldEnd)//Two types of fill behaviors : HoldEnd - Keep displaying the last frame
 			{
-				HoldValue();
+				// We set the final value using the "Local" precedence
+				PropertyInfo.SetLocalValue(ComputeToValue());
+
 				State = TimelineState.Filling;
 			}
-			else// HoldEnd -Put back the inital state
+			else // Stop -Put back the inital state
 			{
 				State = TimelineState.Stopped;
-				ClearValue();
 			}
+
+			// Make sure to reset the value with the "Animations" precedence (no matter the fill behavior)
+			ClearValue();
 
 			OnCompleted();
 		}


### PR DESCRIPTION
- Make sure to set the final value of an animated property, so if a frame is missing at the end (which may happend on iOS) we are sure to complete the animation
- Ensure to reset the value set using the `Animations` precendence, so are able to change it later from code

## PR Type
What kind of change does this PR introduce?
 - Bugfix 

## What is the current behavior?
At the end of a `DoubleAnimation` we rely on the fact that the property was altered by the native animation.

## What is the new behavior?
Now we ensure to set the **expected** final value, using the `Local` precedence

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/147416
https://nventive.visualstudio.com/Umbrella/_workitems/edit/147515