### PR TITLE
Disabling font scaling on Android now works properly

### DIFF
--- a/doc/articles/feature-flags.md
+++ b/doc/articles/feature-flags.md
@@ -18,6 +18,6 @@ This can be changed using `Uno.UI.FeatureConfiguration.UIElement.UseUWPDefaultSt
 
 ##Disabling accessibility text scaling
 
-By default, Uno automatically enables accessibility text scaling on iOS and Android devices however to have more control an option has been added to disable text scaling on Text based controls. 
+By default, Uno automatically enables accessibility text scaling on iOS and Android devices however to have more control an option has been added to disable text scaling. 
 
 Use `Uno.UI.FeatureConfiguration.Font.IgnoreTextScaleFactor` to control this. 

--- a/src/Uno.UI/Extensions/ViewHelper.Android.cs
+++ b/src/Uno.UI/Extensions/ViewHelper.Android.cs
@@ -68,6 +68,13 @@ namespace Uno.UI
 				// WARNING: The Density value is not completely based on the DPI of the device.
 				// On two 8" devices, the Density may not be consistent.
 				_cachedDensity = displayMetrics.Density;
+				if (FeatureConfiguration.Font.IgnoreTextScaleFactor)
+				{
+					// To disable text scaling, we put the Density value in ScaledDensity so that the ratio between them is 1.
+					// This ensures it's disabled for everything using ScaledDensity (e.g. TextBlock, TextBox, AppBarButton, etc.)
+					// https://developer.xamarin.com/api/property/Android.Util.DisplayMetrics.ScaledDensity/
+					displayMetrics.ScaledDensity = displayMetrics.Density;
+				}
 				_cachedScaledDensity = displayMetrics.ScaledDensity;
 				_cachedScaledXDpi = displayMetrics.Xdpi;
 			}

--- a/src/Uno.UI/UI/Xaml/Extensions/FontHelper.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Extensions/FontHelper.Android.cs
@@ -149,10 +149,6 @@ namespace Windows.UI.Xaml
 		/// <returns></returns>
 		public static double GetFontRatio()
 		{
-			if (FeatureConfiguration.Font.IgnoreTextScaleFactor)
-			{
-				return 1.0;
-			}
 			return ViewHelper.FontScale / ViewHelper.Scale;	
 		}
 	}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Setting FeatureConfiguration.Font.IgnoreTextScaleFactor on Android doesn't disable font scaling on some controls like TextBox and AppBarButton.

## What is the new behavior?
Setting FeatureConfiguration.Font.IgnoreTextScaleFactor on Android disables font scaling everywhere.

## PR Checklist

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/147422
