### PR TITLE
PR fix Time picker initial time when using time increment is using initial time seconds when rounding.. it should ignore seconds.. and [iOS] TimePicker is clipped off screen when ios:FlyoutPlacement isnt set

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -214,3 +214,5 @@
  * 148228 [Android] Right theme (clock or spinner) is selected for specific time increments 
  * 148229 [Android] Right time is picked and rounded to nearest time increment in clock mode 
  * 148241 [Android] won't open if `MinuteIncrement` is not set
+ * 148582 Time picker initial time when using time increment is using initial time seconds when rounding.. it should ignore seconds.. 
+ * 148285 [iOS] TimePicker is clipped off screen when ios:FlyoutPlacement isnt set

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample1.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TimePicker/Sample1.xaml
@@ -17,7 +17,6 @@
 				<Grid Background="White">
 					<TimePicker Grid.Row="1"
                                 Margin="15,10"
-                                ios:FlyoutPlacement="Full"
                                 HorizontalAlignment="Center"
                                 VerticalAlignment="Top"
                                 MinuteIncrement="1"

--- a/src/Uno.UI/Extensions/TimeSpanExtensions.cs
+++ b/src/Uno.UI/Extensions/TimeSpanExtensions.cs
@@ -4,8 +4,8 @@ using System.Text;
 
 namespace Uno.UI.Extensions
 {
-    public static class TimeSpanExtensions
-    {
+	public static class TimeSpanExtensions
+	{
 		public static string ToXamlString(this TimeSpan timeSpan, IFormatProvider provider)
 		{
 			var builder = new StringBuilder();
@@ -27,6 +27,7 @@ namespace Uno.UI.Extensions
 
 		/// <summary>
 		/// Round timespan to previous minute interval
+		/// input time seconds are ignored
 		/// </summary>
 		/// <param name="interval">minute interval</param>
 		/// <returns>Rounded timespan</returns>
@@ -34,7 +35,7 @@ namespace Uno.UI.Extensions
 		{
 			if (interval > 0 && time != TimeSpan.Zero)
 			{
-				var roundedMinutes = Math.Floor(time.TotalMinutes / interval) * interval;
+				var roundedMinutes = Math.Floor(Math.Truncate(time.TotalMinutes) / interval) * interval;
 				return TimeSpan.FromMinutes(roundedMinutes);
 			}
 
@@ -43,6 +44,7 @@ namespace Uno.UI.Extensions
 
 		/// <summary>
 		/// Round timespan to next minute interval
+		// input time seconds are ignored
 		/// </summary>
 		/// <param name="interval">minute interval</param>
 		/// <returns>Rounded timespan</returns>
@@ -50,7 +52,7 @@ namespace Uno.UI.Extensions
 		{
 			if (interval > 0 && time != TimeSpan.Zero)
 			{
-				var roundedMinutes = Math.Ceiling(time.TotalMinutes / interval) * interval;
+				var roundedMinutes = Math.Ceiling(Math.Truncate(time.TotalMinutes) / interval) * interval;
 				return TimeSpan.FromMinutes(roundedMinutes);
 			}
 
@@ -59,6 +61,7 @@ namespace Uno.UI.Extensions
 
 		/// <summary>
 		/// Round timespan to minute interval
+		/// input time seconds are ignored
 		/// </summary>
 		/// <param name="interval">minute interval</param>
 		/// <returns>Rounded timespan</returns>
@@ -66,7 +69,7 @@ namespace Uno.UI.Extensions
 		{
 			if (interval > 0 && time != TimeSpan.Zero)
 			{
-				var roundedMinutes = Math.Round(time.TotalMinutes / interval) * interval;
+				var roundedMinutes = Math.Round(Math.Truncate(time.TotalMinutes) / interval) * interval;
 				return TimeSpan.FromMinutes(roundedMinutes);
 			}
 

--- a/src/Uno.UI/Extensions/TimeSpanExtensions.cs
+++ b/src/Uno.UI/Extensions/TimeSpanExtensions.cs
@@ -44,7 +44,7 @@ namespace Uno.UI.Extensions
 
 		/// <summary>
 		/// Round timespan to next minute interval
-		// input time seconds are ignored
+		/// input time seconds are ignored
 		/// </summary>
 		/// <param name="interval">minute interval</param>
 		/// <returns>Rounded timespan</returns>

--- a/src/Uno.UI/Mixins/DependencyPropertyMixins.tt
+++ b/src/Uno.UI/Mixins/DependencyPropertyMixins.tt
@@ -93,7 +93,6 @@
 				.Property("MinuteIncrement", "int", "1")
 				.Property("ClockIdentifier", "string", "Windows.Globalization.ClockIdentifiers.TwelveHour")
 			.Class("TimePicker")
-			    .Property("Time", "TimeSpan", "DateTime.Now.TimeOfDay")
 				.Property("ClockIdentifier", "string", "Windows.Globalization.ClockIdentifiers.TwelveHour")
 
 		.Namespace("Windows.UI.Xaml.Controls.Primitives")

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
@@ -30,6 +30,32 @@ namespace Windows.UI.Xaml.Controls
 
 		public TimePicker() { }
 
+		#region Time DependencyProperty
+
+		public TimeSpan Time
+		{
+			get { return (TimeSpan)this.GetValue(TimeProperty); }
+			set { this.SetValue(TimeProperty, value); }
+		}
+
+		public static readonly DependencyProperty TimeProperty =
+			DependencyProperty.Register(
+				"Time",
+				typeof(TimeSpan),
+				typeof(TimePicker),
+				new FrameworkPropertyMetadata(
+					defaultValue: DateTime.Now.TimeOfDay,
+					options: FrameworkPropertyMetadataOptions.None,
+					propertyChangedCallback: (s, e) => ((TimePicker)s)?.OnTimeChangedPartial((TimeSpan)e.OldValue, (TimeSpan)e.NewValue),
+					coerceValueCallback: (s, e) =>
+					{
+						var ts = (TimeSpan)e;
+						return new TimeSpan(ts.Hours, ts.Minutes, 0);
+					})
+				);
+
+		#endregion
+
 		#region MinuteIncrement DependencyProperty
 
 		public int MinuteIncrement
@@ -123,7 +149,7 @@ namespace Windows.UI.Xaml.Controls
 			UpdateDisplayedDate();
 		}
 
-		partial void OnTimeChangedPartial(TimeSpan oldTime, TimeSpan newTime)
+		void OnTimeChangedPartial(TimeSpan oldTime, TimeSpan newTime)
 		{
 			UpdateDisplayedDate();
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
@@ -50,7 +50,7 @@ namespace Windows.UI.Xaml.Controls
 					coerceValueCallback: (s, e) =>
 					{
 						var ts = (TimeSpan)e;
-						return new TimeSpan(ts.Hours, ts.Minutes, 0);
+						return new TimeSpan(ts.Days, ts.Hours, ts.Minutes, 0);
 					})
 				);
 
@@ -89,11 +89,22 @@ namespace Windows.UI.Xaml.Controls
 
 		#endregion
 
-		/// <summary>
-		/// Property that allows apps to specify any flyout placement 
-		/// (especially FlyoutPlacementMode.Full, which is commonly used on iPhone)
-		/// </summary>
-		public FlyoutPlacementMode FlyoutPlacement { get; set; }
+		#region FlyoutPlacement DependencyProperty
+
+		public FlyoutPlacementMode FlyoutPlacement
+		{
+			get { return (FlyoutPlacementMode)this.GetValue(FlyoutPlacementProperty); }
+			set { this.SetValue(FlyoutPlacementProperty, value); }
+		}
+
+		public static readonly DependencyProperty FlyoutPlacementProperty =
+			DependencyProperty.Register(
+				"FlyoutPlacement",
+				typeof(FlyoutPlacementMode),
+				typeof(TimePicker),
+				new FrameworkPropertyMetadata(FlyoutPlacementMode.Full));
+
+		#endregion
 
 		protected override void OnApplyTemplate()
 		{
@@ -204,6 +215,4 @@ namespace Windows.UI.Xaml.Controls
 		}
 	}
 }
-
-
 #endif

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.md
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.md
@@ -36,7 +36,8 @@ In case clock mode still appear for some reason picked value will be rounded to 
 
 #### iOS
 Native time picker is wrapped in the flyout.
-Timepicker flyout appear at bottom of the screen.
+Set 'ios:FlyoutPlacement' property to change flyout docking placement
+Default 'ios:FlyoutPlacement' is 'Full' and will dock of the flyout at the bottom of the screen
 You can change the flyout button by copying and modifying TimePickerFlyoutButtonStyle.
 You can change the flyout button by copying and modifying TimePickerFlyoutPresenterStyle.
 

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.md
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.md
@@ -6,6 +6,7 @@ TimePicker is use to select a specific time of the day in hour and minute (AM/PM
 
 Button showing time open the time picker popup. 
 Bind to the Time property of the control to set initial time.
+days, seconds and milliseconds of input timespan are ignored
 By default minute increment is set to 1
 if you assign a negative value or 0, it will use 1 minute increment
 if you assign a value over 30, it will use 30 minute increment

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
@@ -48,10 +48,10 @@ namespace Windows.UI.Xaml.Controls
 
 		public void Initialize()
 		{
-			SaveInitialTime();
 			SetPickerClockIdentifier(ClockIdentifier);
 			SetPickerMinuteIncrement(MinuteIncrement);
 			SetPickerTime(Time.RoundToNextMinuteInterval(MinuteIncrement));
+			SaveInitialTime();
 		}
 
 		private void SetPickerMinuteIncrement(int minuteIncrement)

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
@@ -74,7 +74,7 @@ namespace Windows.UI.Xaml.Controls
 
 					if (Time.Hours != time.Hours || Time.Minutes != time.Minutes)
 					{
-						Time = new TimeSpan(Time.Days, time.Hours, time.Minutes, Time.Seconds, Time.Milliseconds);
+						Time = new TimeSpan(Time.Days, time.Hours, time.Minutes, 0, 0);
 						SaveInitialTime();
 					}
 				}

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -1949,7 +1949,10 @@
 				Value="Left" />
 		<Setter Property="VerticalAlignment"
 				Value="Center" />
-		<Setter Property="Template">
+        <!-- Uno specific property use only in ios, set placement to "Full" to dock of the flyout at the bottom of the screen -->
+        <ios:Setter Property="FlyoutPlacement"
+				Value="Full" />
+        <Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="TimePicker">
 					<StackPanel x:Name="LayoutRoot"


### PR DESCRIPTION
PR fix Time picker initial time when using time increment is using initial time seconds when rounding.. it should ignore seconds.. and [iOS] TimePicker is clipped off screen when ios:FlyoutPlacement isnt set