### PR TITLE
Fix touch events not dispatched to UIElement that have a RenderTransform

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -213,6 +213,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_TransformsOnList.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Full.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -226,6 +230,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\Hosted_ScrollViewer.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Transforms.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -1249,6 +1257,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Full_Wider.xaml.cs">
       <DependentUpon>Image_Stretch_Full_Wider.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_TransformsOnList.xaml.cs">
+      <DependentUpon>ListView_TransformsOnList.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Full.xaml.cs">
       <DependentUpon>MediaPlayerElement_Full.xaml</DependentUpon>
     </Compile>
@@ -1321,7 +1332,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressRing.xaml.cs">
       <DependentUpon>ProgressRing.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\Hosted_ScrollViewer.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\Hosted_ScrollViewer.xaml.cs">
+      <DependentUpon>Hosted_ScrollViewer.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Transforms.xaml.cs">
+      <DependentUpon>ScrollViewer_Transforms.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Slider\SliderViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Slider\Slider_Features.xaml.cs">
       <DependentUpon>Slider_Features.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_TransformsOnList.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_TransformsOnList.xaml
@@ -1,0 +1,53 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ListView.ListView_TransformsOnList"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:uno="using:Uno.UI.Samples.Controls"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+
+		<Grid.Resources>
+			<DataTemplate x:Key="LstTpl">
+				<Grid RenderTransformOrigin="0.5,0.5">
+					<Grid.RenderTransform>
+						<RotateTransform Angle="180" />
+					</Grid.RenderTransform>
+
+					<ContentControl Content="{Binding}" />
+				</Grid>
+			</DataTemplate>
+		</Grid.Resources>
+
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<uno:StarStackPanel Orientation="Horizontal" Sizes="*,30">
+			<Slider x:Name="angle" Minimum="-180.0" Maximum="180.0" Value="0.0" />
+			<TextBlock Text="{Binding Value, ElementName=angle}" />
+		</uno:StarStackPanel>
+
+
+		<ListView
+			x:Name="lst"
+			Grid.Row="1"
+			Margin="50"
+			Background="FloralWhite"
+			RenderTransformOrigin="0.5,0.5"
+			ItemTemplate="{StaticResource LstTpl}"
+			SelectionMode="None">
+
+			<ListView.RenderTransform>
+				<RotateTransform Angle="{Binding Value, ElementName=angle}" />
+			</ListView.RenderTransform>
+
+		</ListView>
+
+	</Grid>
+</Page>
+

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_TransformsOnList.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_TransformsOnList.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System.Linq;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ListView
+{
+	[SampleControlInfo("ListView", "ListView_TransformsOnList", description: "Rotate the list and it should continue to scroll smoothly.")]
+	public sealed partial class ListView_TransformsOnList : Page
+	{
+		public ListView_TransformsOnList()
+		{
+			InitializeComponent();
+
+			lst.ItemsSource = Enumerable
+				.Range(0, 60)
+				.Reverse()
+				.Select(i => $"Items #{i}");
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Transforms.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Transforms.xaml
@@ -1,0 +1,69 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ScrollViewerTests.ScrollViewer_Transforms"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:uno="using:Uno.UI.Samples.Controls"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+
+		<ScrollViewer
+			Grid.Row="2"
+			Margin="70"
+			HorizontalScrollMode="Enabled"
+			VerticalScrollMode="Enabled"
+			RenderTransformOrigin="0.5,0.5">
+
+			<ItemsControl ItemsSource="{Binding}">
+				<ItemsControl.ItemTemplate>
+					<DataTemplate>
+						<ItemsControl ItemsSource="{Binding}">
+							<ItemsControl.ItemsPanel>
+								<ItemsPanelTemplate>
+									<StackPanel Orientation="Horizontal"/>
+								</ItemsPanelTemplate>
+							</ItemsControl.ItemsPanel>
+							<ItemsControl.ItemTemplate>
+								<DataTemplate>
+									<ToggleButton
+										Width="45"
+										Height="40"
+										Content="{Binding}" />
+								</DataTemplate>
+							</ItemsControl.ItemTemplate>
+						</ItemsControl>
+					</DataTemplate>
+				</ItemsControl.ItemTemplate>
+			</ItemsControl>
+
+			<ScrollViewer.RenderTransform>
+				<TransformGroup>
+					<RotateTransform Angle="{Binding Value, ElementName=angle}" />
+					<ScaleTransform
+						ScaleX="{Binding Value, ElementName=scale}"
+						ScaleY="{Binding Value, ElementName=scale}"/>
+				</TransformGroup>
+			</ScrollViewer.RenderTransform>
+		</ScrollViewer>
+
+		<uno:StarStackPanel Orientation="Horizontal" Sizes="*,30">
+			<Slider x:Name="angle" Minimum="-180.0" Maximum="180.0" Value="0.0" />
+			<TextBlock Text="{Binding Value, ElementName=angle}" />
+		</uno:StarStackPanel>
+
+		<uno:StarStackPanel Orientation="Horizontal" Sizes="*,30" Grid.Row="1">
+			<Slider x:Name="scale" Minimum="0.2" Maximum="1.75" Value="1.0" StepFrequency="0.1" SnapsTo="StepValues" />
+			<TextBlock Text="{Binding Value, ElementName=scale}" />
+		</uno:StarStackPanel>
+
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Transforms.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ScrollViewerTests/ScrollViewer_Transforms.xaml.cs
@@ -1,0 +1,22 @@
+﻿using System.Linq;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ScrollViewerTests
+{
+	[SampleControlInfo("ScrollViewer", "ScrollViewer_Transforms", description: "Apply transforms and ensure manipulations are still working smoothly.")]
+	public sealed partial class ScrollViewer_Transforms : Page
+	{
+		public ScrollViewer_Transforms()
+		{
+			this.InitializeComponent();
+
+			var atoz = Enumerable
+				.Range(65, 26)
+				.Select(i => ((char)i).ToString())
+				.ToArray();
+
+			DataContext = atoz.Select(x => atoz.Select(y => $"{x}:{y}").ToArray()).ToArray();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Media/Transform.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Transform.cs
@@ -54,6 +54,7 @@ namespace Windows.UI.Xaml.Media
 		/// <summary>
 		/// The matrix used by this transformation
 		/// </summary>
+		/// <remarks>This matrix does not include any center point</remarks>
 		internal Matrix3x2 MatrixCore { get; private set; } = Matrix3x2.Identity;
 
 		/// <summary>


### PR DESCRIPTION
## PR Type
- Bugfix

## What is the current behavior?
Touch events are not dispatched to `UIElement` which has a `RenderTransform`

## What is the new behavior?
We can also tap on the part of a `UIElement`  which does not overlap it original location

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
This is only a partial fix, cf. https://github.com/nventive/Uno/issues/649

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/147978
https://nventive.visualstudio.com/Umbrella/_workitems/edit/148298
https://nventive.visualstudio.com/Umbrella/_workitems/edit/148300
https://nventive.visualstudio.com/Umbrella/_workitems/edit/148303
https://nventive.visualstudio.com/Umbrella/_workitems/edit/148375
https://nventive.visualstudio.com/Umbrella/_workitems/edit/148521
