### PR TITLE
[Wasm] Fix unarranged measuring, destroy items leak

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -162,6 +162,8 @@
  * 147405 Fix NRE on some MediaTransportControl controls
  * #139 Update Uno.SourceGenerationTasks to improve build performance
  * Update `Uno.UI.Toolkit` base UWP sdk to 17763
+ * [Wasm] Fixes items measured after being removed from their parent appear in the visual tree, on top of every other items.
+ * [Wasm] Fixes lements may not be removed form the global active DOM elements tracking map
 
 ## Release 1.42
 

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -923,6 +923,10 @@
 
 			parentElement.removeChild(childElement);
 
+			// Mark the element as unarranged, so if it gets measured while being
+			// disconnected from the root element, it won't be visible.
+			childElement.classList.add(WindowManager.unoUnarrangedClassName);
+
 			if (shouldRaiseLoadEvents) {
 				this.dispatchEvent(childElement, "unloaded");
 			}
@@ -959,8 +963,9 @@
 
 			if (element.parentElement) {
 				element.parentElement.removeChild(element);
-				delete this.allActiveElementsById[viewId];
 			}
+
+			delete this.allActiveElementsById[viewId];
 		}
 
 		public getBoundingClientRect(elementId: string): string {


### PR DESCRIPTION
GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
- Fixes an issue where items measured after being removed from their parent appear in the visual tree, on top of every other items.
- Fixes an issue where elements may not be removed form the global active DOM elements tracking map

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
