### PR TITLE
VSIX updates for logging and iOS Assets

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -84,6 +84,7 @@
 * Add some missing default UWP styles
 * The `FrameworkElement.IsLoaded` property is now public
 * Improve XAML generation error messages for unknown symbols
+* Added default console logging for all platforms
 
 ### Breaking changes
 * Refactored ToggleSwitch Default Native XAML Styles. (cf. 'NativeDefaultToggleSwitch' styles in Generic.Native.xaml)
@@ -165,6 +166,7 @@
  * [Wasm] Fixes items measured after being removed from their parent appear in the visual tree, on top of every other items.
  * [Wasm] Fixes lements may not be removed form the global active DOM elements tracking map
  * [Wasm] Disable the root element scrolling (bounce) on touch devices
+ * Fixed invalid iOS assets folder. `ImageAsset` nodes must not be `<Visible>false</Visible>` to be copied to the generated project.
 
 ## Release 1.42
 

--- a/src/SolutionTemplate/UnoSolutionTemplate/Droid/Properties/AssemblyInfo.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Droid/Properties/AssemblyInfo.cs
@@ -6,12 +6,12 @@ using Android.App;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("UnoQuickStart.Droid")]
+[assembly: AssemblyTitle("$projectname$")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("UnoQuickStart.Droid")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCompany("$registeredorganization$")]
+[assembly: AssemblyProduct("$projectname$")]
+[assembly: AssemblyCopyright("Copyright © $registeredorganization$ $year$")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: ComVisible(false)]

--- a/src/SolutionTemplate/UnoSolutionTemplate/Droid/UnoQuickStart.Droid.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Droid/UnoQuickStart.Droid.csproj
@@ -1,91 +1,93 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>$guid1$</ProjectGuid>
-    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>$ext_safeprojectname$.Droid</RootNamespace>
-    <AssemblyName>$ext_safeprojectname$.Droid</AssemblyName>
-    <FileAlignment>512</FileAlignment>
-    <AndroidApplication>true</AndroidApplication>
-    <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
-    <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
-    <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
-    <ResourcesDirectory>..\$ext_safeprojectname$.Shared\Strings</ResourcesDirectory>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>portable</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
-    <AndroidLinkMode>None</AndroidLinkMode>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>portable</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-    <AndroidManagedSymbols>true</AndroidManagedSymbols>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
-    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+		<ProductVersion>8.0.30703</ProductVersion>
+		<SchemaVersion>2.0</SchemaVersion>
+		<ProjectGuid>$guid1$</ProjectGuid>
+		<ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+		<OutputType>Library</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<RootNamespace>$ext_safeprojectname$.Droid</RootNamespace>
+		<AssemblyName>$ext_safeprojectname$.Droid</AssemblyName>
+		<FileAlignment>512</FileAlignment>
+		<AndroidApplication>true</AndroidApplication>
+		<AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
+		<GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+		<AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
+		<TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
+		<AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
+		<ResourcesDirectory>..\$ext_safeprojectname$.Shared\Strings</ResourcesDirectory>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+		<DebugSymbols>true</DebugSymbols>
+		<DebugType>portable</DebugType>
+		<Optimize>false</Optimize>
+		<OutputPath>bin\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+		<AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
+		<AndroidLinkMode>None</AndroidLinkMode>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+		<DebugType>portable</DebugType>
+		<DebugSymbols>true</DebugSymbols>
+		<AndroidManagedSymbols>true</AndroidManagedSymbols>
+		<Optimize>true</Optimize>
+		<OutputPath>bin\Release\</OutputPath>
+		<DefineConstants>TRACE</DefineConstants>
+		<ErrorReport>prompt</ErrorReport>
+		<WarningLevel>4</WarningLevel>
+		<AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
+		<AndroidLinkMode>SdkOnly</AndroidLinkMode>
 		<AndroidCreatePackagePerAbi>true</AndroidCreatePackagePerAbi>
 		<EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
 		<AotAssemblies>true</AotAssemblies>
 		<EnableLLVM>true</EnableLLVM>
 		<AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
 	</PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Mono.Android" />
-    <Reference Include="Mono.Android.Export" />
-    <Reference Include="mscorlib" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Uno.UI" Version="1.43.0-dev.965" />
-	<PackageReference Include="Uno.UniversalImageLoader" Version="1.9.32" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="MainActivity.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Main.cs" />
-  </ItemGroup>
-  <ItemGroup>
+	<ItemGroup>
+		<Reference Include="Mono.Android" />
+		<Reference Include="Mono.Android.Export" />
+		<Reference Include="mscorlib" />
+		<Reference Include="System" />
+		<Reference Include="System.Core" />
+		<Reference Include="System.Xml.Linq" />
+		<Reference Include="System.Xml" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Uno.UI" Version="1.43.0-dev.965" />
+		<PackageReference Include="Uno.UniversalImageLoader" Version="1.9.32" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="MainActivity.cs" />
+		<Compile Include="Properties\AssemblyInfo.cs" />
+		<Compile Include="Main.cs" />
+	</ItemGroup>
+	<ItemGroup>
 		<AndroidAsset Include="Assets\Fonts\winjs-symbols.ttf" />
-    <None Include="Resources\AboutResources.txt" />
-    <None Include="Assets\AboutAssets.txt" />
-  </ItemGroup>
-  <ItemGroup>
-    <AndroidResource Include="Resources\values\Strings.xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <AndroidResource Include="Resources\drawable\Icon.png" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="Properties\AndroidManifest.xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <AndroidResource Include="Resources\values\Styles.xml" />
-  </ItemGroup>	
-  <Import Project="..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems" Label="Shared" Condition="Exists('..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems')" />
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
+		<None Include="Resources\AboutResources.txt" />
+		<None Include="Assets\AboutAssets.txt" />
+	</ItemGroup>
+	<ItemGroup>
+		<AndroidResource Include="Resources\values\Strings.xml" />
+	</ItemGroup>
+	<ItemGroup>
+		<AndroidResource Include="Resources\drawable\Icon.png" />
+	</ItemGroup>
+	<ItemGroup>
+		<None Include="Properties\AndroidManifest.xml" />
+	</ItemGroup>
+	<ItemGroup>
+		<AndroidResource Include="Resources\values\Styles.xml" />
+	</ItemGroup>
+	<Import Project="..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems" Label="Shared" Condition="Exists('..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems')" />
+	<Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 
 	<!-- This will force the generation of the APK when not buildig inside visual studio -->
 	<Target Name="GenerateBuild" DependsOnTargets="SignAndroidPackage" AfterTargets="Build" Condition="'$(BuildingInsideVisualStudio)'==''" />

--- a/src/SolutionTemplate/UnoSolutionTemplate/Shared/App.xaml.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Shared/App.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -21,86 +22,130 @@ namespace $ext_safeprojectname$
     /// Provides application-specific behavior to supplement the default Application class.
     /// </summary>
     sealed partial class App : Application
-    {
-        /// <summary>
-        /// Initializes the singleton application object.  This is the first line of authored code
-        /// executed, and as such is the logical equivalent of main() or WinMain().
-        /// </summary>
-        public App()
-        {
-            this.InitializeComponent();
-            this.Suspending += OnSuspending;
-        }
+	{
+		/// <summary>
+		/// Initializes the singleton application object.  This is the first line of authored code
+		/// executed, and as such is the logical equivalent of main() or WinMain().
+		/// </summary>
+		public App()
+		{
+			ConfigureFilters(Uno.Extensions.LogExtensionPoint.AmbientLoggerFactory);
 
-        /// <summary>
-        /// Invoked when the application is launched normally by the end user.  Other entry points
-        /// will be used such as when the application is launched to open a specific file.
-        /// </summary>
-        /// <param name="e">Details about the launch request and process.</param>
-        protected override void OnLaunched(LaunchActivatedEventArgs e)
-        {
+			this.InitializeComponent();
+			this.Suspending += OnSuspending;
+		}
+
+		/// <summary>
+		/// Invoked when the application is launched normally by the end user.  Other entry points
+		/// will be used such as when the application is launched to open a specific file.
+		/// </summary>
+		/// <param name="e">Details about the launch request and process.</param>
+		protected override void OnLaunched(LaunchActivatedEventArgs e)
+		{
 #if DEBUG
-            if (System.Diagnostics.Debugger.IsAttached)
-            {
-               // this.DebugSettings.EnableFrameRateCounter = true;
-            }
+			if (System.Diagnostics.Debugger.IsAttached)
+			{
+				// this.DebugSettings.EnableFrameRateCounter = true;
+			}
 #endif
-            Frame rootFrame = Windows.UI.Xaml.Window.Current.Content as Frame;
+			Frame rootFrame = Windows.UI.Xaml.Window.Current.Content as Frame;
 
-            // Do not repeat app initialization when the Window already has content,
-            // just ensure that the window is active
-            if (rootFrame == null)
-            {
-                // Create a Frame to act as the navigation context and navigate to the first page
-                rootFrame = new Frame();
+			// Do not repeat app initialization when the Window already has content,
+			// just ensure that the window is active
+			if (rootFrame == null)
+			{
+				// Create a Frame to act as the navigation context and navigate to the first page
+				rootFrame = new Frame();
 
-                rootFrame.NavigationFailed += OnNavigationFailed;
+				rootFrame.NavigationFailed += OnNavigationFailed;
 
-                if (e.PreviousExecutionState == ApplicationExecutionState.Terminated)
-                {
-                    //TODO: Load state from previously suspended application
-                }
+				if (e.PreviousExecutionState == ApplicationExecutionState.Terminated)
+				{
+					//TODO: Load state from previously suspended application
+				}
 
-                // Place the frame in the current Window
-                Windows.UI.Xaml.Window.Current.Content = rootFrame;
-            }
+				// Place the frame in the current Window
+				Windows.UI.Xaml.Window.Current.Content = rootFrame;
+			}
 
-            if (e.PrelaunchActivated == false)
-            {
-                if (rootFrame.Content == null)
-                {
-                    // When the navigation stack isn't restored navigate to the first page,
-                    // configuring the new page by passing required information as a navigation
-                    // parameter
-                    rootFrame.Navigate(typeof(MainPage), e.Arguments);
-                }
-                // Ensure the current window is active
-                Windows.UI.Xaml.Window.Current.Activate();
-            }
-        }
+			if (e.PrelaunchActivated == false)
+			{
+				if (rootFrame.Content == null)
+				{
+					// When the navigation stack isn't restored navigate to the first page,
+					// configuring the new page by passing required information as a navigation
+					// parameter
+					rootFrame.Navigate(typeof(MainPage), e.Arguments);
+				}
+				// Ensure the current window is active
+				Windows.UI.Xaml.Window.Current.Activate();
+			}
+		}
 
-        /// <summary>
-        /// Invoked when Navigation to a certain page fails
+		/// <summary>
+		/// Invoked when Navigation to a certain page fails
+		/// </summary>
+		/// <param name="sender">The Frame which failed navigation</param>
+		/// <param name="e">Details about the navigation failure</param>
+		void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
+		{
+			throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
+		}
+
+		/// <summary>
+		/// Invoked when application execution is being suspended.  Application state is saved
+		/// without knowing whether the application will be terminated or resumed with the contents
+		/// of memory still intact.
+		/// </summary>
+		/// <param name="sender">The source of the suspend request.</param>
+		/// <param name="e">Details about the suspend request.</param>
+		private void OnSuspending(object sender, SuspendingEventArgs e)
+		{
+			var deferral = e.SuspendingOperation.GetDeferral();
+			//TODO: Save application state and stop any background activity
+			deferral.Complete();
+		}
+
+
+		/// <summary>
+        /// Configures global logging
         /// </summary>
-        /// <param name="sender">The Frame which failed navigation</param>
-        /// <param name="e">Details about the navigation failure</param>
-        void OnNavigationFailed(object sender, NavigationFailedEventArgs e)
-        {
-            throw new Exception("Failed to load Page " + e.SourcePageType.FullName);
-        }
+        /// <param name="factory"></param>
+		static void ConfigureFilters(ILoggerFactory factory)
+		{
+			factory
+				.WithFilter(new FilterLoggerSettings
+					{
+						{ "Uno", LogLevel.Warning },
+						{ "Windows", LogLevel.Warning },
 
-        /// <summary>
-        /// Invoked when application execution is being suspended.  Application state is saved
-        /// without knowing whether the application will be terminated or resumed with the contents
-        /// of memory still intact.
-        /// </summary>
-        /// <param name="sender">The source of the suspend request.</param>
-        /// <param name="e">Details about the suspend request.</param>
-        private void OnSuspending(object sender, SuspendingEventArgs e)
-        {
-            var deferral = e.SuspendingOperation.GetDeferral();
-            //TODO: Save application state and stop any background activity
-            deferral.Complete();
-        }
+						// Debug JS interop
+						// { "Uno.Foundation.WebAssemblyRuntime", LogLevel.Debug },
+
+						// Generic Xaml events
+						// { "Windows.UI.Xaml", LogLevel.Debug },
+						// { "Windows.UI.Xaml.VisualStateGroup", LogLevel.Debug },
+						// { "Windows.UI.Xaml.StateTriggerBase", LogLevel.Debug },
+						// { "Windows.UI.Xaml.UIElement", LogLevel.Debug },
+
+						// Layouter specific messages
+						// { "Windows.UI.Xaml.Controls", LogLevel.Debug },
+						// { "Windows.UI.Xaml.Controls.Layouter", LogLevel.Debug },
+						// { "Windows.UI.Xaml.Controls.Panel", LogLevel.Debug },
+						// { "Windows.Storage", LogLevel.Debug },
+
+						// Binding related messages
+						// { "Windows.UI.Xaml.Data", LogLevel.Debug },
+
+						// DependencyObject memory references tracking
+						// { "ReferenceHolder", LogLevel.Debug },
+					}
+				)
+#if DEBUG
+				.AddConsole(LogLevel.Debug);
+#else
+				.AddConsole(LogLevel.Information);
+#endif
+		}
     }
 }

--- a/src/SolutionTemplate/UnoSolutionTemplate/UWP/Package.appxmanifest
+++ b/src/SolutionTemplate/UnoSolutionTemplate/UWP/Package.appxmanifest
@@ -30,7 +30,7 @@
   <Applications>
     <Application Id="App"
       Executable="$ext_safeprojectname$.exe"
-      EntryPoint="UnoQuickStart.App">
+      EntryPoint="$ext_safeprojectname$.App">
       <uap:VisualElements
         DisplayName="$ext_safeprojectname$"
         Square150x150Logo="Assets\Square150x150Logo.png"

--- a/src/SolutionTemplate/UnoSolutionTemplate/UWP/Properties/AssemblyInfo.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate/UWP/Properties/AssemblyInfo.cs
@@ -5,12 +5,12 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("UnoQuickStart")]
+[assembly: AssemblyTitle("$projectname$")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("UnoQuickStart")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCompany("$registeredorganization$")]
+[assembly: AssemblyProduct("$projectname$")]
+[assembly: AssemblyCopyright("Copyright © $registeredorganization$ $year$")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/SolutionTemplate/UnoSolutionTemplate/UWP/UnoQuickStart.Uwp.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/UWP/UnoQuickStart.Uwp.csproj
@@ -1,123 +1,126 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
+	<Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
 			<!-- 
 			If, in the same solution, you are referencing a project that uses https://github.com/onovotny/MSBuildSdkExtras,
 			you need to make sure that the version provided here matches https://github.com/onovotny/MSBuildSdkExtras/blob/master/Source/MSBuild.Sdk.Extras/DefaultItems/ImplicitPackages.targets#L11.
 			This is not an issue when libraries are referenced through nuget packages. See https://github.com/nventive/Uno/issues/446 for more details.
 			-->
-      <Version>6.2.2</Version>
-    </PackageReference>
-  </ItemGroup>
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
-    <ProjectGuid>$guid1$</ProjectGuid>
-    <OutputType>AppContainerExe</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>$ext_safeprojectname$</RootNamespace>
-    <AssemblyName>$ext_safeprojectname$</AssemblyName>
-    <DefaultLanguage>en-US</DefaultLanguage>
-    <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
-    <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <PackageCertificateKeyFile>$ext_safeprojectname$.Uwp_TemporaryKey.pfx</PackageCertificateKeyFile>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <NoWarn>;2008</NoWarn>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>true</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <Optimize>true</Optimize>
-    <NoWarn>;2008</NoWarn>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x86</PlatformTarget>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>true</Prefer32Bit>
-    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\ARM\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <NoWarn>;2008</NoWarn>
-    <DebugType>full</DebugType>
-    <PlatformTarget>ARM</PlatformTarget>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>true</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
-    <OutputPath>bin\ARM\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <Optimize>true</Optimize>
-    <NoWarn>;2008</NoWarn>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>ARM</PlatformTarget>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>true</Prefer32Bit>
-    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <NoWarn>;2008</NoWarn>
-    <DebugType>full</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>true</Prefer32Bit>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
-    <Optimize>true</Optimize>
-    <NoWarn>;2008</NoWarn>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-    <ErrorReport>prompt</ErrorReport>
-    <Prefer32Bit>true</Prefer32Bit>
-    <UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
-  </PropertyGroup>
-  <ItemGroup>
-    <!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <AppxManifest Include="Package.appxmanifest">
-      <SubType>Designer</SubType>
-    </AppxManifest>
-    <None Include="$safeprojectname$_TemporaryKey.pfx" />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include="Properties\Default.rd.xml" />
-  </ItemGroup>
-  <Import Project="..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems" Label="Shared" Condition="Exists('..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems')" />
-  <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
-    <VisualStudioVersion>14.0</VisualStudioVersion>
-  </PropertyGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+			<Version>6.2.2</Version>
+		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
+    <PackageReference Include="Uno.Core" Version="1.27.0-dev.68" />
+	</ItemGroup>
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+		<ProjectGuid>$guid1$</ProjectGuid>
+		<OutputType>AppContainerExe</OutputType>
+		<AppDesignerFolder>Properties</AppDesignerFolder>
+		<RootNamespace>$ext_safeprojectname$</RootNamespace>
+		<AssemblyName>$ext_safeprojectname$</AssemblyName>
+		<DefaultLanguage>en-US</DefaultLanguage>
+		<TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
+		<TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
+		<TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
+		<MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
+		<FileAlignment>512</FileAlignment>
+		<ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+		<PackageCertificateKeyFile>$ext_safeprojectname$.Uwp_TemporaryKey.pfx</PackageCertificateKeyFile>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
+		<DebugSymbols>true</DebugSymbols>
+		<OutputPath>bin\x86\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<NoWarn>;2008</NoWarn>
+		<DebugType>full</DebugType>
+		<PlatformTarget>x86</PlatformTarget>
+		<UseVSHostingProcess>false</UseVSHostingProcess>
+		<ErrorReport>prompt</ErrorReport>
+		<Prefer32Bit>true</Prefer32Bit>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+		<OutputPath>bin\x86\Release\</OutputPath>
+		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<Optimize>true</Optimize>
+		<NoWarn>;2008</NoWarn>
+		<DebugType>pdbonly</DebugType>
+		<PlatformTarget>x86</PlatformTarget>
+		<UseVSHostingProcess>false</UseVSHostingProcess>
+		<ErrorReport>prompt</ErrorReport>
+		<Prefer32Bit>true</Prefer32Bit>
+		<UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|ARM'">
+		<DebugSymbols>true</DebugSymbols>
+		<OutputPath>bin\ARM\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<NoWarn>;2008</NoWarn>
+		<DebugType>full</DebugType>
+		<PlatformTarget>ARM</PlatformTarget>
+		<UseVSHostingProcess>false</UseVSHostingProcess>
+		<ErrorReport>prompt</ErrorReport>
+		<Prefer32Bit>true</Prefer32Bit>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|ARM'">
+		<OutputPath>bin\ARM\Release\</OutputPath>
+		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<Optimize>true</Optimize>
+		<NoWarn>;2008</NoWarn>
+		<DebugType>pdbonly</DebugType>
+		<PlatformTarget>ARM</PlatformTarget>
+		<UseVSHostingProcess>false</UseVSHostingProcess>
+		<ErrorReport>prompt</ErrorReport>
+		<Prefer32Bit>true</Prefer32Bit>
+		<UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
+		<DebugSymbols>true</DebugSymbols>
+		<OutputPath>bin\x64\Debug\</OutputPath>
+		<DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<NoWarn>;2008</NoWarn>
+		<DebugType>full</DebugType>
+		<PlatformTarget>x64</PlatformTarget>
+		<UseVSHostingProcess>false</UseVSHostingProcess>
+		<ErrorReport>prompt</ErrorReport>
+		<Prefer32Bit>true</Prefer32Bit>
+	</PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
+		<OutputPath>bin\x64\Release\</OutputPath>
+		<DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
+		<Optimize>true</Optimize>
+		<NoWarn>;2008</NoWarn>
+		<DebugType>pdbonly</DebugType>
+		<PlatformTarget>x64</PlatformTarget>
+		<UseVSHostingProcess>false</UseVSHostingProcess>
+		<ErrorReport>prompt</ErrorReport>
+		<Prefer32Bit>true</Prefer32Bit>
+		<UseDotNetNativeToolchain>true</UseDotNetNativeToolchain>
+	</PropertyGroup>
+	<ItemGroup>
+		<!-- A reference to the entire .Net Framework and Windows SDK are automatically included -->
+	</ItemGroup>
+	<ItemGroup>
+		<Compile Include="Properties\AssemblyInfo.cs" />
+	</ItemGroup>
+	<ItemGroup>
+		<AppxManifest Include="Package.appxmanifest">
+			<SubType>Designer</SubType>
+		</AppxManifest>
+		<None Include="$safeprojectname$_TemporaryKey.pfx" />
+	</ItemGroup>
+	<ItemGroup>
+		<Content Include="Properties\Default.rd.xml" />
+	</ItemGroup>
+	<Import Project="..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems" Label="Shared" Condition="Exists('..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems')" />
+	<PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
+		<VisualStudioVersion>14.0</VisualStudioVersion>
+	</PropertyGroup>
+	<Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
+	<!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/src/SolutionTemplate/UnoSolutionTemplate/UnoSolutionTemplate.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/UnoSolutionTemplate.csproj
@@ -82,8 +82,12 @@
     <None Include="iOS\LaunchScreen.storyboard">
       <SubType>Designer</SubType>
     </None>
-    <None Include="iOS\Media.xcassets\AppIcons.appiconset\Contents.json" />
-    <None Include="iOS\Media.xcassets\LaunchImages.launchimage\Contents.json" />
+    <Content Include="iOS\Media.xcassets\AppIcons.appiconset\Contents.json">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="iOS\Media.xcassets\LaunchImages.launchimage\Contents.json">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <None Include="iOS\Resources\Fonts\winjs-symbols.ttf">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
@@ -116,7 +120,7 @@
       <SubType>Designer</SubType>
     </None>
     <None Include="iOS\iOS.vstemplate" />
-    <None Include="iOS\Resources\Default-568h%402x.png" />
+    <Content Include="iOS\Resources\Default-568h%402x.png" />
     <None Include="iOS\UnoQuickStart.iOS.csproj">
       <SubType>Designer</SubType>
     </None>
@@ -171,13 +175,27 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="iOS\Media.xcassets\AppIcons.appiconset\ios-marketing-1024x1024%401x.png" />
-    <Content Include="iOS\Media.xcassets\AppIcons.appiconset\iPad-76x76%402x.png" />
-    <Content Include="iOS\Media.xcassets\AppIcons.appiconset\iPad-84x84%402x.png" />
-    <Content Include="iOS\Media.xcassets\AppIcons.appiconset\iPhone-20x20%402x.png" />
-    <Content Include="iOS\Media.xcassets\AppIcons.appiconset\iPhone-20x20%403x.png" />
-    <Content Include="iOS\Media.xcassets\AppIcons.appiconset\iPhone-40x40%403x.png" />
-    <Content Include="iOS\Media.xcassets\AppIcons.appiconset\iPhone-60x60%402x.png" />
+    <Content Include="iOS\Media.xcassets\AppIcons.appiconset\ios-marketing-1024x1024%401x.png">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="iOS\Media.xcassets\AppIcons.appiconset\iPad-76x76%402x.png">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="iOS\Media.xcassets\AppIcons.appiconset\iPad-84x84%402x.png">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="iOS\Media.xcassets\AppIcons.appiconset\iPhone-20x20%402x.png">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="iOS\Media.xcassets\AppIcons.appiconset\iPhone-20x20%403x.png">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="iOS\Media.xcassets\AppIcons.appiconset\iPhone-40x40%403x.png">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
+    <Content Include="iOS\Media.xcassets\AppIcons.appiconset\iPhone-60x60%402x.png">
+      <IncludeInVSIX>true</IncludeInVSIX>
+    </Content>
     <Content Include="iOS\Resources\SplashScreen%402x.png" />
     <Content Include="iOS\Resources\SplashScreen%403x.png" />
     <Content Include="Wasm\LinkerConfig.xml" />

--- a/src/SolutionTemplate/UnoSolutionTemplate/Wasm/UnoQuickStart.Wasm.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Wasm/UnoQuickStart.Wasm.csproj
@@ -34,6 +34,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<!-- Note that for WebAssembly version 1.1.1 of the console logger required -->
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
 		<PackageReference Include="Uno.UI" Version="1.43.0-dev.965" />
 		<PackageReference Include="Uno.Wasm.Bootstrap" Version="1.0.0-dev.217" />
 		<DotNetCliToolReference Include="Uno.Wasm.Bootstrap.Cli" Version="1.0.0-dev.217" />

--- a/src/SolutionTemplate/UnoSolutionTemplate/iOS/Info.plist
+++ b/src/SolutionTemplate/UnoSolutionTemplate/iOS/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
   <dict>
 	<key>CFBundleDisplayName</key>
-	<string>UnoQuickStart.iOS</string>
+	<string>$ext_safeprojectname$</string>
 	<key>CFBundleIdentifier</key>
 	<string>com.companyname.$ext_safeprojectname$</string>
 	<key>CFBundleShortVersionString</key>

--- a/src/SolutionTemplate/UnoSolutionTemplate/iOS/Properties/AssemblyInfo.cs
+++ b/src/SolutionTemplate/UnoSolutionTemplate/iOS/Properties/AssemblyInfo.cs
@@ -5,12 +5,12 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("UnoQuickStart.iOS")]
+[assembly: AssemblyTitle("$projectname$")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("UnoQuickStart.iOS")]
-[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyCompany("$registeredorganization$")]
+[assembly: AssemblyProduct("$projectname$")]
+[assembly: AssemblyCopyright("Copyright © $registeredorganization$ $year$")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/src/SolutionTemplate/UnoSolutionTemplate/iOS/UnoQuickStart.iOS.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/iOS/UnoQuickStart.iOS.csproj
@@ -103,6 +103,7 @@
 		<Content Include="Entitlements.plist" />
 		<BundleResource Include="Resources\SplashScreen%402x.png" />
 		<BundleResource Include="Resources\SplashScreen%403x.png" />
+		<BundleResource Include="Resources\Default-568h%402x.png" />
 	</ItemGroup>
 	<ItemGroup>
 		<Reference Include="System" />
@@ -115,35 +116,33 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="Uno.UI" Version="1.43.0-dev.965" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Filter" Version="1.1.1" />
 	</ItemGroup>
 	<ItemGroup>
 		<ImageAsset Include="Media.xcassets\AppIcons.appiconset\Contents.json">
-			<Visible>false</Visible>
 		</ImageAsset>
-		<ImageAsset Include="Media.xcassets\AppIcons.appiconset\ios-marketing-1024x1024@1x.png">
-			<Visible>false</Visible>
+		<ImageAsset Include="Media.xcassets\AppIcons.appiconset\ios-marketing-1024x1024%401x.png">
 		</ImageAsset>
-		<ImageAsset Include="Media.xcassets\AppIcons.appiconset\iPad-76x76@2x.png">
-			<Visible>false</Visible>
+		<ImageAsset Include="Media.xcassets\AppIcons.appiconset\iPad-76x76%402x.png">
 		</ImageAsset>
-		<ImageAsset Include="Media.xcassets\AppIcons.appiconset\iPad-84x84@2x.png">
-			<Visible>false</Visible>
+		<ImageAsset Include="Media.xcassets\AppIcons.appiconset\iPad-84x84%402x.png">
 		</ImageAsset>
-		<ImageAsset Include="Media.xcassets\AppIcons.appiconset\iPhone-20x20@2x.png">
-			<Visible>false</Visible>
+		<ImageAsset Include="Media.xcassets\AppIcons.appiconset\iPhone-20x20%402x.png">
 		</ImageAsset>
-		<ImageAsset Include="Media.xcassets\AppIcons.appiconset\iPhone-20x20@3x.png">
-			<Visible>false</Visible>
+		<ImageAsset Include="Media.xcassets\AppIcons.appiconset\iPhone-20x20%403x.png">
 		</ImageAsset>
-		<ImageAsset Include="Media.xcassets\AppIcons.appiconset\iPhone-40x40@3x.png">
-			<Visible>false</Visible>
+		<ImageAsset Include="Media.xcassets\AppIcons.appiconset\iPhone-40x40%403x.png">
 		</ImageAsset>
-		<ImageAsset Include="Media.xcassets\AppIcons.appiconset\iPhone-60x60@2x.png">
-			<Visible>false</Visible>
+		<ImageAsset Include="Media.xcassets\AppIcons.appiconset\iPhone-60x60%402x.png">
 		</ImageAsset>
 		<ImageAsset Include="Media.xcassets\LaunchImages.launchimage\Contents.json">
-			<Visible>false</Visible>
 		</ImageAsset>
+	</ItemGroup>
+	<ItemGroup>
+		<Folder Include="Media" Visible="false" />
+		<Folder Include="Media\AppIcons" Visible="false" />
+		<Folder Include="Media\LaunchImages" Visible="false" />
 	</ItemGroup>
 	<Import Project="..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems" Label="Shared" Condition="Exists('..\$ext_safeprojectname$.Shared\$ext_safeprojectname$.Shared.projitems')" />
 	<Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/src/SolutionTemplate/UnoSolutionTemplate/iOS/iOS.vstemplate
+++ b/src/SolutionTemplate/UnoSolutionTemplate/iOS/iOS.vstemplate
@@ -19,25 +19,24 @@
 	<Project TargetFileName="$ext_safeprojectname$.iOS.csproj" File="UnoQuickStart.iOS.csproj" ReplaceParameters="true">
 	  <ProjectItem ReplaceParameters="true" TargetFileName="Entitlements.plist">Entitlements.plist</ProjectItem>
 	  <ProjectItem ReplaceParameters="true" TargetFileName="Info.plist">Info.plist</ProjectItem>
-	  <ProjectItem ReplaceParameters="true" TargetFileName="Main.cs">Main.cs</ProjectItem>
+	  <ProjectItem ReplaceParameters="true" TargetFileName="Main.cs">Main.cs</ProjectItem> 
 	  <ProjectItem ReplaceParameters="true" TargetFileName="LaunchScreen.storyboard">LaunchScreen.storyboard</ProjectItem>
 	  <Folder Name="Properties" TargetFolderName="Properties">
 		<ProjectItem ReplaceParameters="true" TargetFileName="AssemblyInfo.cs">AssemblyInfo.cs</ProjectItem>
 	  </Folder>
 	  <Folder Name="Media.xcassets" TargetFolderName="Media.xcassets">
 		<Folder Name="AppIcons.appiconset" TargetFolderName="AppIcons.appiconset">
-		  <ProjectItem ReplaceParameters="false" TargetFileName="Contents.json">Contents.json</ProjectItem>
-
-		  <ProjectItem ReplaceParameters="false" TargetFileName="ios-marketing-1024x1024@1x.png">ios-marketing-1024x1024@1x.png</ProjectItem>
-		  <ProjectItem ReplaceParameters="false" TargetFileName="iPad-76x76@2x.png">iPad-76x76@2x.png</ProjectItem>
-		  <ProjectItem ReplaceParameters="false" TargetFileName="iPad-84x84@2x.png">iPad-84x84@2x.png</ProjectItem>
-		  <ProjectItem ReplaceParameters="false" TargetFileName="iPhone-20x20@2x.png">iPhone-20x20@2x.png</ProjectItem>
-		  <ProjectItem ReplaceParameters="false" TargetFileName="iPhone-20x20@3x.png">iPhone-20x20@3x.png</ProjectItem>
-		  <ProjectItem ReplaceParameters="false" TargetFileName="iPhone-40x40@3x.png">iPhone-40x40@3x.png</ProjectItem>
-		  <ProjectItem ReplaceParameters="false" TargetFileName="iPhone-60x60@2x.png">iPhone-60x60@2x.png</ProjectItem>
+		  <ProjectItem ReplaceParameters="false" ItemType="ImageAsset" TargetFileName="Contents.json">Contents.json</ProjectItem>
+		  <ProjectItem ReplaceParameters="false" ItemType="ImageAsset" TargetFileName="ios-marketing-1024x1024@1x.png">ios-marketing-1024x1024@1x.png</ProjectItem>
+		  <ProjectItem ReplaceParameters="false" ItemType="ImageAsset" TargetFileName="iPad-76x76@2x.png">iPad-76x76@2x.png</ProjectItem>
+		  <ProjectItem ReplaceParameters="false" ItemType="ImageAsset" TargetFileName="iPad-84x84@2x.png">iPad-84x84@2x.png</ProjectItem>
+		  <ProjectItem ReplaceParameters="false" ItemType="ImageAsset" TargetFileName="iPhone-20x20@2x.png">iPhone-20x20@2x.png</ProjectItem>
+		  <ProjectItem ReplaceParameters="false" ItemType="ImageAsset" TargetFileName="iPhone-20x20@3x.png">iPhone-20x20@3x.png</ProjectItem>
+		  <ProjectItem ReplaceParameters="false" ItemType="ImageAsset" TargetFileName="iPhone-40x40@3x.png">iPhone-40x40@3x.png</ProjectItem>
+		  <ProjectItem ReplaceParameters="false" ItemType="ImageAsset" TargetFileName="iPhone-60x60@2x.png">iPhone-60x60@2x.png</ProjectItem>
 		</Folder>
 		<Folder Name="LaunchImages.launchimage" TargetFolderName="LaunchImages.launchimage">
-		  <ProjectItem ReplaceParameters="false" TargetFileName="Contents.json">Contents.json</ProjectItem>
+		  <ProjectItem ReplaceParameters="false" ItemType="ImageAsset" TargetFileName="Contents.json">Contents.json</ProjectItem>
 		</Folder>
 	  </Folder>
 	  <Folder Name="Resources" TargetFolderName="Resources">


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #668 

## PR Type
What kind of change does this PR introduce?
- Bugfix 
- Feature

## What is the new behavior?
- Added default console logging for all platforms
- Fixed invalid iOS assets folder. `ImageAsset` nodes must not be `<Visible>false</Visible>` to be copied to the generated project.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->

https://nventive.visualstudio.com/Umbrella/_workitems/edit/149207