### PR TITLE
[Wasm] Fixed popups only appear once

### DIFF
--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -671,7 +671,10 @@ namespace Windows.UI.Xaml
 
 			OnChildAdded(child);
 
-			InvalidateMeasure();
+			child.InvalidateMeasure();
+
+			// Arrange is required to unset the uno-unarranged CSS class
+			child.InvalidateArrange();
 		}
 
 		public void ClearChildren()


### PR DESCRIPTION


## PR Type
- Bugfix

## What is the new behavior?
This changes forces an arrange pass to ensure the uno-unarranged CSS class is removed, so the element is displayed properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
