### PR TITLE
Add support for `BindingExpression.UpdateSource()`

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -37,6 +37,7 @@
 * Add ItemsSource CollectionViewSource update support (#697)
 * Add support for the `CollectionViewSource.ItemsPath` property
 * Fixed support for dots in resource names (#700)
+* Add support for `BindingExpression.UpdateSource()`
 
 ### Breaking changes
 * Make `UIElement.IsPointerPressed` and `IsPointerOver` internal

--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
@@ -735,6 +735,41 @@ namespace Uno.UI.Tests.BinderTests
 			Assert.AreEqual(42, SUT.Tag);
 		}
 
+		[TestMethod]
+		public void When_ExplicitUpdateSourceTrigger()
+		{
+			var source = new MyBindingSource {IntValue = 42};
+			var target = new MyControl();
+			target.SetBinding(MyControl.MyPropertyProperty, new Binding {Source = source, Path = nameof(MyBindingSource.IntValue), Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.Explicit});
+
+			Assert.AreEqual(42, source.IntValue);
+			Assert.AreEqual(42, target.MyProperty);
+
+			target.MyProperty = -42;
+
+			Assert.AreEqual(42, source.IntValue);
+			Assert.AreEqual(-42, target.MyProperty);
+		}
+
+		[TestMethod]
+		public void When_ExplicitUpdateSourceTrigger_UpdateSource()
+		{
+			var source = new MyBindingSource {IntValue = 42};
+			var target = new MyControl();
+			target.SetBinding(MyControl.MyPropertyProperty, new Binding { Source = source, Path = nameof(MyBindingSource.IntValue), Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.Explicit });
+
+			var sut = target.GetBindingExpression(MyControl.MyPropertyProperty);
+
+			Assert.AreEqual(42, source.IntValue);
+			Assert.AreEqual(42, target.MyProperty);
+
+			target.MyProperty = -42;
+			sut.UpdateSource();
+
+			Assert.AreEqual(-42, source.IntValue);
+			Assert.AreEqual(-42, target.MyProperty);
+		}
+
 		public partial class BaseTarget : DependencyObject
 		{
 			private List<object> _dataContextChangedList = new List<object>();
@@ -862,6 +897,26 @@ namespace Uno.UI.Tests.BinderTests
 			#endregion
 
 			public int objectSetCount { get; set; }
+		}
+
+		public class MyBindingSource : INotifyPropertyChanged
+		{
+			private int _intValue;
+
+			public int IntValue
+			{
+				get => _intValue;
+				set
+				{
+					_intValue = value;
+					OnPropertyChanged();
+				}
+			}
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+				=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}
 
 		public class MySource : INotifyPropertyChanged

--- a/src/Uno.UI/DataBinding/BindingExpression.cs
+++ b/src/Uno.UI/DataBinding/BindingExpression.cs
@@ -26,8 +26,6 @@ namespace Windows.UI.Xaml.Data
 {
 	public partial class BindingExpression : IDisposable, IValueChangedListener
 	{
-		public Binding ParentBinding { get; private set; }
-
 		private readonly Type _boundPropertyType;
 		private readonly ManagedWeakReference _view;
 		private readonly Type _targetOwnerType;
@@ -40,27 +38,21 @@ namespace Windows.UI.Xaml.Data
 		private ManagedWeakReference _explicitSourceStore;
 		private readonly bool _isCompiledSource;
 		private readonly bool _isElementNameSource;
+		private bool _isBindingSuspended;
+		private ValueGetterHandler _valueGetter;
 		private ValueSetterHandler _valueSetter;
-		private bool _bindingSuspended;
+
+		public Binding ParentBinding { get; }
 
 		internal DependencyPropertyDetails TargetPropertyDetails { get; }
 
 		private object ExplicitSource
 		{
-			get
-			{
-				return _explicitSourceStore?.Target;
-			}
-			set
-			{
-				_explicitSourceStore = WeakReferencePool.RentWeakReference(this, value);
-			}
+			get => _explicitSourceStore?.Target;
+			set => _explicitSourceStore = WeakReferencePool.RentWeakReference(this, value);
 		}
 
-		public string TargetName
-		{
-			get { return TargetPropertyDetails.Property.Name; }
-		}
+		public string TargetName => TargetPropertyDetails.Property.Name;
 
 		public object DataContext
 		{
@@ -88,15 +80,24 @@ namespace Windows.UI.Xaml.Data
 		/// <summary>
 		/// Sends the current binding target value to the binding source property in TwoWay bindings.
 		/// </summary>
-		/// <param name="value"></param>
+		public void UpdateSource()
+		{
+			if (TryGetTargetValue(out var value))
+			{
+				UpdateSource(value);
+			}
+		}
+
+		/// <summary>
+		/// Sends the current binding target value to the binding source property in TwoWay bindings.
+		/// </summary>
+		/// <param name="value">The expected current value of the target</param>
 		public void UpdateSource(object value)
 		{
-			var finalValue = value;
-
 			// Convert if necessary
 			if (ParentBinding.Converter != null)
 			{
-				finalValue = ParentBinding.Converter.ConvertBack(
+				value = ParentBinding.Converter.ConvertBack(
 					value,
 					_bindingPath.ValueType,
 					ParentBinding.ConverterParameter,
@@ -104,7 +105,7 @@ namespace Windows.UI.Xaml.Data
 				);
 			}
 
-			_bindingPath.Value = finalValue;
+			_bindingPath.Value = value;
 		}
 
 		/// <summary>
@@ -121,7 +122,7 @@ namespace Windows.UI.Xaml.Data
 			try
 			{
 				if (ParentBinding.Mode == BindingMode.TwoWay
-				&& ResolveUpdateSourceTrigger() == UpdateSourceTrigger.PropertyChanged)
+					&& ResolveUpdateSourceTrigger() == UpdateSourceTrigger.PropertyChanged)
 				{
 					UpdateSource(value);
 				}
@@ -132,15 +133,14 @@ namespace Windows.UI.Xaml.Data
 			}
 		}
 
-
 		/// <summary>
 		/// Suspends the processing of the binding until <see cref="ResumeBinding"/> is called.
 		/// </summary>
 		internal void SuspendBinding()
 		{
-			if (!_bindingSuspended)
+			if (!_isBindingSuspended)
 			{
-				_bindingSuspended = true;
+				_isBindingSuspended = true;
 				_subscription.Dispose();
 			}
 		}
@@ -150,9 +150,9 @@ namespace Windows.UI.Xaml.Data
 		/// </summary>
 		internal void ResumeBinding()
 		{
-			if (_bindingSuspended)
+			if (_isBindingSuspended)
 			{
-				_bindingSuspended = false;
+				_isBindingSuspended = false;
 				ApplyBinding();
 			}
 		}
@@ -296,7 +296,7 @@ namespace Windows.UI.Xaml.Data
 			ApplyFallbackValue();
 			ApplyExplicitSource();
 			ApplyElementName();
-		}
+		}		
 
 		private void TryGetSource(Binding binding)
 		{
@@ -326,9 +326,27 @@ namespace Windows.UI.Xaml.Data
 			}
 		}
 
+		private bool TryGetTargetValue(out object value)
+		{
+			var viewTarget = _view.Target;
+
+			if (viewTarget != null)
+			{
+				value = GetValueGetter()(viewTarget);
+				return true;
+			}
+			else
+			{
+				Dispose(); // Self dispose if view is no more available
+
+				value = default(object);
+				return false;
+			}
+		}
+
 		private void SetTargetValue(object value)
 		{
-			object viewTarget = _view.Target;
+			var viewTarget = _view.Target;
 
 			if (viewTarget != null)
 			{
@@ -338,6 +356,16 @@ namespace Windows.UI.Xaml.Data
 			{
 				Dispose(); // Self dispose if view is no more available
 			}
+		}
+
+		private ValueGetterHandler GetValueGetter()
+		{
+			if (_valueGetter == null)
+			{
+				_valueGetter = BindingPropertyHelper.GetValueGetter(_targetOwnerType, TargetPropertyDetails.Property.Name);
+			}
+
+			return _valueGetter;
 		}
 
 		private ValueSetterHandler GetValueSetter()

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Data/BindingExpression.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Data/BindingExpression.cs
@@ -20,12 +20,6 @@ namespace Windows.UI.Xaml.Data
 		// Skipping already declared property ParentBinding
 		// Forced skipping of method Windows.UI.Xaml.Data.BindingExpression.DataItem.get
 		// Forced skipping of method Windows.UI.Xaml.Data.BindingExpression.ParentBinding.get
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  void UpdateSource()
-		{
-			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.UI.Xaml.Data.BindingExpression", "void BindingExpression.UpdateSource()");
-		}
-		#endif
+		// Skipping already declared property UpdateSource()
 	}
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Feature

## What is the current behavior?
NotImplemented

## What is the new behavior?
The `BindingExpression.UpdateSource` is implemented

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/149028