### PR TITLE
Align TextBox events handling behavior with Windows

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -29,6 +29,8 @@
 * Add missing system resources
 * Add support for x:Bind in StaticResources (#696)
 * Add support for x:Name late binding support to adds proper support for CollectionViewSource in Resources (#696)
+* `PointerRelease` events are now marked as handled by the `TextBox`
+* `KeyDown` events that are changing the cursor position (left/right/top/bottom/home/end) are now marked as handled by the `TextBox`
 
 ### Breaking changes
 * Make `UIElement.IsPointerPressed` and `IsPointerOver` internal

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -788,9 +788,6 @@ var Uno;
                     var handled = this.dispatchEvent(htmlElement, eventName, eventPayload);
                     if (handled) {
                         event.stopPropagation();
-                        if (event instanceof KeyboardEvent) {
-                            event.preventDefault();
-                        }
                     }
                 };
                 htmlElement.addEventListener(eventName, eventHandler, onCapturePhase);

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -671,9 +671,6 @@
 				var handled = this.dispatchEvent(htmlElement, eventName, eventPayload);
 				if (handled) {
 					event.stopPropagation();
-					if (event instanceof KeyboardEvent) {
-						event.preventDefault();
-					}
 				}
 			};
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.cs
@@ -8,6 +8,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Windows.Input;
+using Windows.System;
 using Uno.Extensions;
 using Uno.UI.Common;
 using Windows.UI.Text;
@@ -518,6 +519,34 @@ namespace Windows.UI.Xaml.Controls
 #endif
 		}
 
+		/// <inheritdoc />
+		protected override void OnPointerReleased(PointerRoutedEventArgs args)
+		{
+			base.OnPointerReleased(args);
+
+			args.Handled = true;
+		}
+
+		/// <inheritdoc />
+		protected override void OnKeyDown(KeyRoutedEventArgs args)
+		{
+			base.OnKeyDown(args);
+
+			// Note: On windows only keys that are "moving the cursor" are handled
+			//		 AND ** only KeyDown ** is handled (not KeyUp)
+			switch (args.Key)
+			{
+				case VirtualKey.Left:
+				case VirtualKey.Right:
+				case VirtualKey.Up:
+				case VirtualKey.Down:
+				case VirtualKey.Home:
+				case VirtualKey.End:
+					args.Handled = true;
+					break;
+			}
+		}
+
 		private void UpdateCommonStates()
 		{
 			var commonState = "Normal";
@@ -540,10 +569,12 @@ namespace Windows.UI.Xaml.Controls
 		private void UpdateButtonStates()
 		{
 			if (Text.HasValue() 
-			&& FocusState != FocusState.Unfocused 
-			&& !IsReadOnly
-			&& !AcceptsReturn
-			&& TextWrapping == TextWrapping.NoWrap)
+				&& FocusState != FocusState.Unfocused 
+				&& !IsReadOnly
+				&& !AcceptsReturn
+				&& TextWrapping == TextWrapping.NoWrap
+				// TODO (https://github.com/nventive/Uno/issues/683): && ActualWidth >= TDB / Note: We also have to invoke this method on SizeChanged
+			)
 			{
 				VisualStateManager.GoToState(this, ButtonVisibleStateName, true);
 			}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Feature

## What is the current behavior?
Touch and key events are not handled as windows does

## What is the new behavior?
* `PointerRelease` events are now marked as handled by the `TextBox`
* `KeyDown` events that are changing the cursor position (left/right/top/bottom/home/end) are now marked as handled by the `TextBox`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/149028