### PR TITLE
Misc fixes for events support

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -31,6 +31,9 @@
 * Add support for x:Name late binding support to adds proper support for CollectionViewSource in Resources (#696)
 * `PointerRelease` events are now marked as handled by the `TextBox`
 * `KeyDown` events that are changing the cursor position (left/right/top/bottom/home/end) are now marked as handled by the `TextBox`
+* `RoutedEventArgs.IsGenerated` returns `false` as generating events with Uno is not yet supported
+* `AutomationPeer.ListenerExists` returns `false` as we cannot generating events with Uno is not yet supported
+* `KeyUp` event properly sends `KeyEventArgs` to the controls
 
 ### Breaking changes
 * Make `UIElement.IsPointerPressed` and `IsPointerOver` internal

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/AutomationPeer.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Automation.Peers/AutomationPeer.cs
@@ -607,12 +607,6 @@ namespace Windows.UI.Xaml.Automation.Peers
 			throw new global::System.NotImplementedException("The member RawElementProviderRuntimeId AutomationPeer.GenerateRawElementProviderRuntimeId() is not implemented in Uno.");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static bool ListenerExists( global::Windows.UI.Xaml.Automation.Peers.AutomationEvents eventId)
-		{
-			throw new global::System.NotImplementedException("The member bool AutomationPeer.ListenerExists(AutomationEvents eventId) is not implemented in Uno.");
-		}
-		#endif
+		// Skipping already declared method Windows.UI.Xaml.Automation.Peers.AutomationPeer.ListenerExists()
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/PointerRoutedEventArgs.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Input/PointerRoutedEventArgs.cs
@@ -10,22 +10,14 @@ namespace Windows.UI.Xaml.Input
 		// Skipping already declared property Handled
 		// Skipping already declared property KeyModifiers
 		// Skipping already declared property Pointer
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  bool IsGenerated
-		{
-			get
-			{
-				throw new global::System.NotImplementedException("The member bool PointerRoutedEventArgs.IsGenerated is not implemented in Uno.");
-			}
-		}
-		#endif
+		// Skipping already declared property IsGenerated
+
 		// Forced skipping of method Windows.UI.Xaml.Input.PointerRoutedEventArgs.Pointer.get
 		// Forced skipping of method Windows.UI.Xaml.Input.PointerRoutedEventArgs.KeyModifiers.get
 		// Forced skipping of method Windows.UI.Xaml.Input.PointerRoutedEventArgs.Handled.get
 		// Forced skipping of method Windows.UI.Xaml.Input.PointerRoutedEventArgs.Handled.set
 		// Skipping already declared method Windows.UI.Xaml.Input.PointerRoutedEventArgs.GetCurrentPoint(Windows.UI.Xaml.UIElement)
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::System.Collections.Generic.IList<global::Windows.UI.Input.PointerPoint> GetIntermediatePoints( global::Windows.UI.Xaml.UIElement relativeTo)
 		{

--- a/src/Uno.UI/UI/Xaml/Automation/Peers/AutomationPeer.cs
+++ b/src/Uno.UI/UI/Xaml/Automation/Peers/AutomationPeer.cs
@@ -6,6 +6,12 @@ namespace Windows.UI.Xaml.Automation.Peers
 {
 	public partial class AutomationPeer : DependencyObject
 	{
+		[global::Uno.NotImplemented]
+		public static bool ListenerExists(global::Windows.UI.Xaml.Automation.Peers.AutomationEvents eventId)
+		{
+			return false;
+		}
+
 		#region Public
 
 		public bool IsContentElement()

--- a/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/Input/PointerRoutedEventArgs.cs
@@ -30,6 +30,8 @@ namespace Windows.UI.Xaml.Input
 			throw new NotImplementedException();
 		}
 
+		public bool IsGenerated { get; } = false; // Generated events are not supported by UNO
+
 		public bool Handled { get; set; }
 
 		public VirtualKeyModifiers KeyModifiers { get; internal set; }

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -869,6 +869,7 @@ namespace Windows.UI.Xaml
 							break;
 
 						case nameof(KeyDownEvent):
+						case nameof(KeyUpEvent):
 							eventFilter = null;
 							eventExtractor = HtmlEventExtractor.KeyboardEventExtractor;
 							payloadConverter = PayloadToKeyArgs;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix
- Feature

## What is the current behavior?
* `RoutedEventArgs.IsGenerated` throws `NotImplementedException`
* `AutomationPeer.ListenerExists` throws `NotImplementedException`
* `KeyUp` event throws `InvalidCastException`

## What is the new behavior?
* `RoutedEventArgs.IsGenerated` returns `false` as we cannot generate events with Uno
* `AutomationPeer.ListenerExists` returns `false` as we cannot generate events with Uno
* `KeyUp` event properly sends `KeyEventArgs` to the controls

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/149028