### PR TITLE
Add workaround for Mono issue #12981

### DIFF
--- a/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.RoutedEvents.cs
@@ -392,8 +392,13 @@ namespace Windows.UI.Xaml
 			}
 
 			// [13] Raise on parent
-			return parent.RaiseEvent(routedEvent, args);
+			return RaiseOnParent(routedEvent, args, parent);
 		}
+
+		// This method is a workaround for https://github.com/mono/mono/issues/12981
+		// It can be inlined in RaiseEvent when fixed.
+		private static bool RaiseOnParent(RoutedEvent routedEvent, RoutedEventArgs args, UIElement parent)
+			=> parent.RaiseEvent(routedEvent, args);
 
 		private static bool IsHandled(RoutedEventArgs args)
 		{


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The runtime crashes when using Uno from a nuget package:
```
* Assertion at /mnt/jenkins/workspace/test-mono-mainline-wasm/label/ubuntu-1804-amd64/mono/mini/interp/transform.c:2856, condition `<disabled>' not met
```

## What is the new behavior?
Fixes #614 by adding a workaround for https://github.com/mono/mono/issues/12981


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
