### PR TITLE
Enhance animation for WASM

### DIFF
--- a/doc/articles/working-with-animations.md
+++ b/doc/articles/working-with-animations.md
@@ -1,0 +1,10 @@
+# Animations
+
+## General guidelines
+As of 1.43.1: 
+1. It is only possible to run GPU bound animations that are animating:
+	* `Opacity`
+	* `RenderTransform` of type `TranslateTransform`, `RotateTransform`, `ScaleTransform`, or `CompositeTransform`. Transforms cannot be part of a TransformGroup.
+1. When animating a `Transform`, you can animate only one property at a time (i.e. `CompositeTransform.TranslateX` *or* `CompositeTransform.TranslateY`),
+1. You cannot reuse a `Transform` or an `Animation` declared in resources on multiple controls (instead you have to put your animation in a `Template`)
+1. By default on iOS, Android and WASM, controls are clipped by their parent. On iOS ou can set the flag `Uno.UI.FeatureConfiguration.UIElement.UseLegacyClipping = false` to get the Windows behavior.

--- a/src/Uno.UI/UI/Xaml/Media/Animation/DoubleAnimationUsingKeyFrames.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/DoubleAnimationUsingKeyFrames.cs
@@ -341,7 +341,7 @@ namespace Windows.UI.Xaml.Media.Animation
 		partial void UseHardware();
 		partial void HoldValue();
 
-#if NET461 || __WASM__ || __MACOS__
+#if NET461 || __MACOS__
 		private bool ReportEachFrame() => true;
 #endif
 	}

--- a/src/Uno.UI/UI/Xaml/Media/Animation/DoubleAnimationUsingKeyFrames.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Animation/DoubleAnimationUsingKeyFrames.wasm.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.UI.Xaml.Media.Animation
+{
+	public partial class DoubleAnimationUsingKeyFrames
+	{
+		private bool ReportEachFrame() => true;
+
+		partial void OnFrame(IValueAnimator currentAnimator)
+		{
+			SetValue(currentAnimator.AnimatedValue);
+		}
+	}
+}


### PR DESCRIPTION
* Enabled `DoubleAnimationUsingKeyFrames`
* Fix support of `BeginTime`

## PR Type
- Bugfix
- Feature

## What is the current behavior?
* `DoubleAnimationUsingKeyFrames` does nothing
* An animation with a `BeginTime` will remove this delay from the `Duration` when starting the animation. So if `Duration < BeginTime`, the animation will reach its final state immediately at the end of the wait delay (a.k.a. `BeginTime`).

## What is the new behavior?
* `DoubleAnimationUsingKeyFrames` are now supported on WASM
* Animation will wait for the 'BeginTime` and then animate properly using the right `Duration`.

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
