### PR TITLE
Fix SplashScreen image loading

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -15,6 +15,8 @@
     <PackageReference Update="xamarin.build.download" Version="0.4.11" />
     <PackageReference Update="Uno.MonoAnalyzers" Version="1.0.0-dev.2" PrivateAssets="all" />
     <DotNetCliToolReference Update="Uno.Wasm.Bootstrap.Cli" Version="1.0.0-dev.217" />
+    <PackageReference Update="Microsoft.TypeScript.Compiler" Version="3.1.5" />
+    <PackageReference Update="Microsoft.TypeScript.MSBuild" Version="3.1.5" />
   </ItemGroup>
 
 </Project>

--- a/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
+++ b/src/SamplesApp/SamplesApp.Wasm/SamplesApp.Wasm.csproj
@@ -40,8 +40,8 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Microsoft.TypeScript.Compiler" Version="2.8.3" />
-		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="2.8.3" />
+		<PackageReference Include="Microsoft.TypeScript.Compiler" />
+		<PackageReference Include="Microsoft.TypeScript.MSBuild" />
 		<PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
 		<PackageReference Include="Uno.SourceGenerationTasks" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="1.1.1" />

--- a/src/Uno.UI.Wasm.Tests/Uno.UI.Wasm.Tests.csproj
+++ b/src/Uno.UI.Wasm.Tests/Uno.UI.Wasm.Tests.csproj
@@ -16,8 +16,8 @@
   </ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.TypeScript.Compiler" Version="2.8.3" />
-		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="2.8.3" />
+		<PackageReference Include="Microsoft.TypeScript.Compiler" />
+		<PackageReference Include="Microsoft.TypeScript.MSBuild" />
 		<PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
 		<PackageReference Include="Uno.SourceGenerationTasks"/>
 	</ItemGroup>

--- a/src/Uno.UI.Wasm/Uno.UI.Wasm.csproj
+++ b/src/Uno.UI.Wasm/Uno.UI.Wasm.csproj
@@ -34,8 +34,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Uno.Core" />
-		<PackageReference Include="Microsoft.TypeScript.Compiler" Version="3.1.5" />
-		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="3.1.3" />
+		<PackageReference Include="Microsoft.TypeScript.Compiler" />
+		<PackageReference Include="Microsoft.TypeScript.MSBuild" />
 		<PackageReference Include="Uno.SourceGenerationTasks" />
 	</ItemGroup>
 

--- a/src/Uno.UI.Wasm/Uno.UI.Wasm.csproj
+++ b/src/Uno.UI.Wasm/Uno.UI.Wasm.csproj
@@ -33,10 +33,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.Core"/>
-		<PackageReference Include="Microsoft.TypeScript.Compiler" Version="2.8.3" />
-		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="2.8.3" />
-		<PackageReference Include="Uno.SourceGenerationTasks"/>
+		<PackageReference Include="Uno.Core" />
+		<PackageReference Include="Microsoft.TypeScript.Compiler" Version="3.1.5" />
+		<PackageReference Include="Microsoft.TypeScript.MSBuild" Version="3.1.3" />
+		<PackageReference Include="Uno.SourceGenerationTasks" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -11,13 +11,16 @@ declare namespace Windows.UI.Core {
         static _coreDispatcherCallback: any;
         static _isIOS: boolean;
         static _isFirstCall: boolean;
-        static init(): void;
+        static _isReady: Promise<boolean>;
+        static _isWaitingReady: boolean;
+        static init(isReady: Promise<boolean>): void;
         /**
          * Enqueues a core dispatcher callback on the javascript's event loop
          *
          * */
         static WakeUp(): boolean;
-        private static initMethods();
+        private static InnerWakeUp;
+        private static initMethods;
     }
 }
 declare namespace Uno.UI {
@@ -26,7 +29,7 @@ declare namespace Uno.UI {
          * Initialize various polyfills used by Uno
          */
         static initPolyfills(): void;
-        private static isConnectedPolyfill();
+        private static isConnectedPolyfill;
     }
 }
 declare namespace Uno.Http {
@@ -41,13 +44,13 @@ declare namespace Uno.Http {
     }
     class HttpClient {
         static send(config: IHttpClientConfig): Promise<void>;
-        private static blobFromBase64(base64, contentType);
-        private static base64FromBlob(blob);
-        private static dispatchResponse(requestId, status, headers, payload);
-        private static dispatchError(requestId, error);
+        private static blobFromBase64;
+        private static base64FromBlob;
+        private static dispatchResponse;
+        private static dispatchError;
         private static dispatchResponseMethod;
         private static dispatchErrorMethod;
-        private static initMethods();
+        private static initMethods;
     }
 }
 declare module Uno.UI {
@@ -82,13 +85,13 @@ declare namespace MonoSupport {
          * Parses the method identifier
          * @param identifier
          */
-        private static parseIdentifier(identifier);
+        private static parseIdentifier;
         /**
          * Adds the a resolved method for a given identifier
          * @param identifier the findJSFunction identifier
          * @param boundMethod the method to call
          */
-        private static cacheMethod(identifier, boundMethod);
+        private static cacheMethod;
     }
 }
 declare namespace Uno.UI {
@@ -119,6 +122,15 @@ declare namespace Uno.UI {
             */
         static init(localStoragePath: string, isHosted: boolean, isLoadEventsEnabled: boolean, containerElementId?: string, loadingElementId?: string): string;
         /**
+         * Builds a promise that will signal the ability for the dispatcher
+         * to initiate work.
+         * */
+        private static buildReadyPromise;
+        /**
+         * Build the splashscreen image eagerly
+         * */
+        private static buildSplashScreen;
+        /**
             * Initialize the WindowManager
             * @param containerElementId The ID of the container element for the Xaml UI
             * @param loadingElementId The ID of the loading element to remove once ready
@@ -147,7 +159,7 @@ declare namespace Uno.UI {
             * Creates the UWP-compatible splash screen
             *
             */
-        static setupSplashScreen(): void;
+        static setupSplashScreen(splashImage: HTMLImageElement): void;
         /**
             * Reads the window's search parameters
             *
@@ -165,7 +177,7 @@ declare namespace Uno.UI {
             * You need to call addView to connect it to the DOM.
             */
         createContentNative(pParams: number): boolean;
-        private createContentInternal(contentDefinition);
+        private createContentInternal;
         /**
             * Set a name for an element.
             *
@@ -178,7 +190,7 @@ declare namespace Uno.UI {
             * This is mostly for diagnostic purposes.
             */
         setNameNative(pParam: number): boolean;
-        private setNameInternal(elementId, name);
+        private setNameInternal;
         /**
             * Set an attribute for an element.
             */
@@ -242,7 +254,7 @@ declare namespace Uno.UI {
             * @param styles A dictionary of styles to apply on html element.
             */
         resetStyleNative(pParams: number): boolean;
-        private resetStyleInternal(elementId, names);
+        private resetStyleInternal;
         /**
         * Arrange and clips a native elements
         *
@@ -293,48 +305,48 @@ declare namespace Uno.UI {
             * @param eventName The name of the event
             * @param onCapturePhase true means "on trickle down", false means "on bubble up". Default is false.
             */
-        private registerEventOnViewInternal(elementId, eventName, onCapturePhase?, eventFilterName?, eventExtractorName?);
+        private registerEventOnViewInternal;
         /**
          * left pointer event filter to be used with registerEventOnView
          * @param evt
          */
-        private leftPointerEventFilter(evt);
+        private leftPointerEventFilter;
         /**
          * default event filter to be used with registerEventOnView to
          * use for most routed events
          * @param evt
          */
-        private defaultEventFilter(evt);
+        private defaultEventFilter;
         /**
          * Gets the event filter function. See UIElement.HtmlEventFilter
          * @param eventFilterName an event filter name.
          */
-        private getEventFilter(eventFilterName);
+        private getEventFilter;
         /**
          * pointer event extractor to be used with registerEventOnView
          * @param evt
          */
-        private pointerEventExtractor(evt);
+        private pointerEventExtractor;
         /**
          * keyboard event extractor to be used with registerEventOnView
          * @param evt
          */
-        private keyboardEventExtractor(evt);
+        private keyboardEventExtractor;
         /**
          * tapped (mouse clicked / double clicked) event extractor to be used with registerEventOnView
          * @param evt
          */
-        private tappedEventExtractor(evt);
+        private tappedEventExtractor;
         /**
          * tapped (mouse clicked / double clicked) event extractor to be used with registerEventOnView
          * @param evt
          */
-        private focusEventExtractor(evt);
+        private focusEventExtractor;
         /**
          * Gets the event extractor function. See UIElement.HtmlEventExtractor
          * @param eventExtractorName an event extractor name.
          */
-        private getEventExtractor(eventExtractorName);
+        private getEventExtractor;
         /**
             * Set or replace the root content element.
             */
@@ -368,7 +380,7 @@ declare namespace Uno.UI {
             * "Unloading" & "Unloaded" events will be raised if necessary.
             */
         removeViewNative(pParams: number): boolean;
-        private removeViewInternal(parentId, childId);
+        private removeViewInternal;
         /**
             * Destroy a html element.
             *
@@ -383,11 +395,11 @@ declare namespace Uno.UI {
             * version has been scavenged by the GC.
             */
         destroyViewNative(pParams: number): boolean;
-        private destroyViewInternal(viewId);
+        private destroyViewInternal;
         getBoundingClientRect(elementId: string): string;
         getBBox(elementId: number): string;
         getBBoxNative(pParams: number, pReturn: number): boolean;
-        private getBBoxInternal(elementId);
+        private getBBoxInternal;
         /**
             * Use the Html engine to measure the element using specified constraints.
             *
@@ -402,7 +414,7 @@ declare namespace Uno.UI {
             * @param maxHeight string containing height in pixels. Empty string means infinite.
             */
         measureViewNative(pParams: number, pReturn: number): boolean;
-        private measureViewInternal(viewId, maxWidth, maxHeight);
+        private measureViewInternal;
         setImageRawData(viewId: string, dataPtr: number, width: number, height: number): string;
         /**
          * Sets the provided image with a mono-chrome version of the provided url.
@@ -428,20 +440,20 @@ declare namespace Uno.UI {
             * WARNING: you should avoid mixing this and `addView` for the same element.
             */
         setHtmlContentNative(pParams: number): boolean;
-        private setHtmlContentInternal(viewId, html);
+        private setHtmlContentInternal;
         /**
             * Remove the loading indicator.
             *
             * In a future version it will also handle the splashscreen.
             */
         activate(): string;
-        private init();
-        private static initMethods();
-        private initDom();
-        private removeLoading();
-        private resize();
-        private dispatchEvent(element, eventName, eventPayload?);
-        private getIsConnectedToRootElement(element);
+        private init;
+        private static initMethods;
+        private initDom;
+        private removeLoading;
+        private resize;
+        private dispatchEvent;
+        private getIsConnectedToRootElement;
     }
 }
 declare class WindowManagerAddViewParams {
@@ -620,14 +632,14 @@ declare namespace Uno.Foundation.Interop {
     class ManagedObject {
         private static assembly;
         private static dispatchMethod;
-        private static init();
+        private static init;
         static dispatch(handle: string, method: string, parameters: string): void;
     }
 }
 declare namespace Uno.UI.Interop {
     class Runtime {
         static readonly engine: any;
-        private static init();
+        private static init;
     }
 }
 declare namespace Uno.UI.Interop {

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -328,6 +328,7 @@ var Uno;
                     let loaded = false;
                     let loadingDone = () => {
                         if (!loaded) {
+                            loaded = true;
                             if (img.width !== 0 && img.height !== 0) {
                                 // Materialize the image content so it shows immediately
                                 // even if the dispatcher is blocked thereafter by all
@@ -358,8 +359,8 @@ var Uno;
                     img.onload = loadingDone;
                     img.onerror = loadingDone;
                     img.src = String(UnoAppManifest.splashScreenImage);
-                    // If there's no response, skip the 
-                    setTimeout(loadingDone, 2);
+                    // If there's no response, skip the loading
+                    setTimeout(loadingDone, 2000);
                 });
             }
             /**

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -34,9 +34,10 @@ var Windows;
              * Support file for the Windows.UI.Core
              * */
             class CoreDispatcher {
-                static init() {
+                static init(isReady) {
                     MonoSupport.jsCallDispatcher.registerScope("CoreDispatcher", Windows.UI.Core.CoreDispatcher);
                     CoreDispatcher.initMethods();
+                    CoreDispatcher._isReady = isReady;
                     CoreDispatcher._isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
                 }
                 /**
@@ -44,6 +45,24 @@ var Windows;
                  *
                  * */
                 static WakeUp() {
+                    // Is there a Ready promise ?
+                    if (CoreDispatcher._isReady) {
+                        // Are we already waiting for a Ready promise ?
+                        if (!CoreDispatcher._isWaitingReady) {
+                            CoreDispatcher._isReady
+                                .then(() => {
+                                CoreDispatcher.InnerWakeUp();
+                                CoreDispatcher._isReady = null;
+                            });
+                            CoreDispatcher._isWaitingReady = true;
+                        }
+                    }
+                    else {
+                        CoreDispatcher.InnerWakeUp();
+                    }
+                    return true;
+                }
+                static InnerWakeUp() {
                     if (CoreDispatcher._isIOS && CoreDispatcher._isFirstCall) {
                         //
                         // This is a workaround for the available call stack during the first 5 (?) seconds
@@ -55,7 +74,6 @@ var Windows;
                         window.setTimeout(() => this.WakeUp(), 5000);
                     }
                     else {
-                        window.setImmediate(() => CoreDispatcher._coreDispatcherCallback());
                         window.setImmediate(() => {
                             try {
                                 CoreDispatcher._coreDispatcherCallback();
@@ -66,7 +84,6 @@ var Windows;
                             }
                         });
                     }
-                    return true;
                 }
                 static initMethods() {
                     if (Uno.UI.WindowManager.isHosted) {
@@ -286,12 +303,64 @@ var Uno;
             static init(localStoragePath, isHosted, isLoadEventsEnabled, containerElementId = "uno-body", loadingElementId = "uno-loading") {
                 WindowManager._isHosted = isHosted;
                 WindowManager._isLoadEventsEnabled = isLoadEventsEnabled;
-                Windows.UI.Core.CoreDispatcher.init();
+                Windows.UI.Core.CoreDispatcher.init(WindowManager.buildReadyPromise());
                 WindowManager.setupStorage(localStoragePath);
                 this.current = new WindowManager(containerElementId, loadingElementId);
                 MonoSupport.jsCallDispatcher.registerScope("Uno", this.current);
                 this.current.init();
                 return "ok";
+            }
+            /**
+             * Builds a promise that will signal the ability for the dispatcher
+             * to initiate work.
+             * */
+            static buildReadyPromise() {
+                return new Promise(resolve => {
+                    Promise.all([WindowManager.buildSplashScreen()]).then(() => resolve(true));
+                });
+            }
+            /**
+             * Build the splashscreen image eagerly
+             * */
+            static buildSplashScreen() {
+                return new Promise(resolve => {
+                    const img = new Image();
+                    let loaded = false;
+                    let loadingDone = () => {
+                        if (!loaded) {
+                            if (img.width !== 0 && img.height !== 0) {
+                                // Materialize the image content so it shows immediately
+                                // even if the dispatcher is blocked thereafter by all
+                                // the Uno initialization work. The resulting canvas is not used.
+                                //
+                                // If the image fails to load, setup the splashScreen anyways with the
+                                // proper sample.
+                                let canvas = document.createElement('canvas');
+                                canvas.width = img.width;
+                                canvas.height = img.height;
+                                let ctx = canvas.getContext("2d");
+                                ctx.drawImage(img, 0, 0);
+                            }
+                            if (document.readyState === "loading") {
+                                document.addEventListener("DOMContentLoaded", () => {
+                                    WindowManager.setupSplashScreen(img);
+                                    resolve(true);
+                                });
+                            }
+                            else {
+                                WindowManager.setupSplashScreen(img);
+                                resolve(true);
+                            }
+                        }
+                    };
+                    // Preload the splash screen so the image element
+                    // created later on 
+                    img.onload = loadingDone;
+                    img.onerror = loadingDone;
+                    img.src = String(UnoAppManifest.splashScreenImage);
+                    // If there's no response, skip the 
+                    setTimeout(loadingDone, 2);
+                });
             }
             /**
                 * Initialize the WindowManager
@@ -355,7 +424,7 @@ var Uno;
                 * Creates the UWP-compatible splash screen
                 *
                 */
-            static setupSplashScreen() {
+            static setupSplashScreen(splashImage) {
                 if (UnoAppManifest && UnoAppManifest.splashScreenImage) {
                     const loading = document.getElementById("loading");
                     if (loading) {
@@ -369,11 +438,9 @@ var Uno;
                             const body = document.getElementsByTagName("body")[0];
                             body.style.backgroundColor = UnoAppManifest.splashScreenColor;
                         }
-                        const unoLoadingSplash = document.createElement("div");
-                        unoLoadingSplash.id = "uno-loading-splash";
-                        unoLoadingSplash.classList.add("uno-splash");
-                        unoLoadingSplash.style.backgroundImage = `url('${UnoAppManifest.splashScreenImage}')`;
-                        unoLoading.appendChild(unoLoadingSplash);
+                        splashImage.id = "uno-loading-splash";
+                        splashImage.classList.add("uno-splash");
+                        unoLoading.appendChild(splashImage);
                         unoBody.appendChild(unoLoading);
                     }
                 }
@@ -971,6 +1038,9 @@ var Uno;
                 const shouldRaiseLoadEvents = WindowManager.isLoadEventsEnabled
                     && this.getIsConnectedToRootElement(childElement);
                 parentElement.removeChild(childElement);
+                // Mark the element as unarranged, so if it gets measured while being
+                // disconnected from the root element, it won't be visible.
+                childElement.classList.add(WindowManager.unoUnarrangedClassName);
                 if (shouldRaiseLoadEvents) {
                     this.dispatchEvent(childElement, "unloaded");
                 }
@@ -1003,8 +1073,8 @@ var Uno;
                 }
                 if (element.parentElement) {
                     element.parentElement.removeChild(element);
-                    delete this.allActiveElementsById[viewId];
                 }
+                delete this.allActiveElementsById[viewId];
             }
             getBoundingClientRect(elementId) {
                 const htmlElement = this.allActiveElementsById[elementId];
@@ -1312,12 +1382,6 @@ var Uno;
         UI.WindowManager = WindowManager;
         if (typeof define === "function") {
             define(["AppManifest"], () => {
-                if (document.readyState === "loading") {
-                    document.addEventListener("DOMContentLoaded", () => WindowManager.setupSplashScreen());
-                }
-                else {
-                    WindowManager.setupSplashScreen();
-                }
             });
         }
         else {

--- a/src/Uno.UI.Wasm/ts/CoreDispatcher.ts
+++ b/src/Uno.UI.Wasm/ts/CoreDispatcher.ts
@@ -55,9 +55,7 @@
 				console.debug("Detected iOS, delaying first CoreDispatched dispatch for 5s (see https://github.com/mono/mono/issues/12357)");
 				window.setTimeout(() => this.WakeUp(), 5000);
 			} else {
-				(<any>window).setImmediate(() => CoreDispatcher._coreDispatcherCallback());
-
-				window.setImmediate(() => {
+				(<any>window).setImmediate(() => {
 					try {
 						CoreDispatcher._coreDispatcherCallback();
 					}

--- a/src/Uno.UI.Wasm/tsconfig.json
+++ b/src/Uno.UI.Wasm/tsconfig.json
@@ -7,7 +7,7 @@
 			"outFile": "WasmScripts/Uno.UI.js",
 			//"inlineSourceMap": true,
 			"locale": "en-US",
-			"target": "es2015"
+			"target": "es6"
 	},
   "include": [
     "ts/**/*",


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix


## What is the current behavior?
The Uno.UI splash screen image is not appearing, it's only using the AppManifest background color.


## What is the new behavior?
The SplashScreen image is eagerly materialized to it appears even if the dispatcher loop is busy.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
