### PR TITLE
Support for x:Bind and x:Name late binding in Resources

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -27,6 +27,8 @@
 * Add support for `Application.OnWindowCreated`
 * Added non-throwing stubs for `AutomationProperty`
 * Add missing system resources
+* Add support for x:Bind in StaticResources (#696)
+* Add support for x:Name late binding support to adds proper support for CollectionViewSource in Resources (#696)
 
 ### Breaking changes
 * Make `UIElement.IsPointerPressed` and `IsPointerOver` internal

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -836,6 +836,18 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				BuildChild(writer, null, namedResource.Value);
 				writer.AppendLineInvariant(0, ";", namedResource.Value.Type);
 			}
+
+			if (namedResources.Any())
+			{
+				using (writer.BlockInvariant("Loading += (s, e) =>"))
+				{
+					foreach (var namedResource in namedResources)
+					{
+						writer.AppendFormatInvariant($"{namedResource.Key}.ApplyCompiledBindings();");
+					}
+				}
+				writer.AppendLineInvariant(0, ";");
+			}
 		}
 
 		private bool IsSingleTimeInitializable(XamlType type)
@@ -2667,7 +2679,9 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					}
 					else if (_namedResources.ContainsKey(resourceName))
 					{
-						return resourceName;
+						// Skip the literal value, use the elementNameSubject instead
+						// so the source can be updated when the subject is set.
+						return "_" + resourceName + "Subject";
 					}
 					else
 					{

--- a/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_Binder.cs
@@ -674,6 +674,67 @@ namespace Uno.UI.Tests.BinderTests
 			Assert.AreEqual("Alice", sut.Text);
 		}
 
+		[TestMethod]
+		public void When_Source_Complex()
+		{
+			var SUT = new Windows.UI.Xaml.Controls.Grid();
+			var subject = new ElementNameSubject();
+
+			SUT.SetBinding(
+				Windows.UI.Xaml.Controls.Grid.TagProperty,
+				new Binding()
+				{
+					Path = "MyProperty",
+					Source = new { MyProperty = 42 }
+				}
+			);
+
+			Assert.AreEqual(42, SUT.Tag);
+		}
+
+		[TestMethod]
+		public void When_Subject_Source_Complex()
+		{
+			var SUT = new Windows.UI.Xaml.Controls.Grid();
+			var subject = new ElementNameSubject();
+
+			SUT.SetBinding(
+				Windows.UI.Xaml.Controls.Grid.TagProperty,
+				new Binding()
+				{
+					Path = "MyProperty",
+					Source = subject
+				}
+			);
+
+			Assert.IsNull(SUT.Tag);
+
+			subject.ElementInstance = new { MyProperty = 42 };
+
+			Assert.AreEqual(42, SUT.Tag);
+		}
+
+		[TestMethod]
+		public void When_Subject_Source()
+		{
+			var SUT = new Windows.UI.Xaml.Controls.Grid();
+			var subject = new ElementNameSubject();
+
+			SUT.SetBinding(
+				Windows.UI.Xaml.Controls.Grid.TagProperty,
+				new Binding()
+				{
+					Source = subject
+				}
+			);
+
+			Assert.IsNull(SUT.Tag);
+
+			subject.ElementInstance = 42;
+
+			Assert.AreEqual(42, SUT.Tag);
+		}
+
 		public partial class BaseTarget : DependencyObject
 		{
 			private List<object> _dataContextChangedList = new List<object>();

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -46,8 +46,8 @@
     <PackageReference Include="System.Collections.Immutable">
       <Version>1.3.1</Version>
     </PackageReference>
-    <PackageReference Include="Uno.SourceGenerationTasks"/>
-    <PackageReference Include="Uno.Core"/>
+    <PackageReference Include="Uno.SourceGenerationTasks" />
+    <PackageReference Include="Uno.Core" />
   </ItemGroup>
 
 	<ItemGroup>
@@ -58,6 +58,7 @@
 		<Reference Include="System.Net.Http" />
 		<Reference Include="System.Numerics" />
 		<Reference Include="System.Numerics.Vectors" />
+		<Reference Include="System.Windows.Forms" />
 		<Reference Include="System.Xaml" />
 		<Reference Include="System.Xml" />
 		<Reference Include="System.Xml.Linq" />
@@ -74,6 +75,7 @@
 		<None Remove="ResourceLoader\When_ResourceFile-en.upri" />
 		<None Remove="ResourceLoader\When_ResourceFile_Neutral_Both-en.upri" />
 		<None Remove="ResourceLoader\When_ResourceFile_Neutral_Both-fr.upri" />
+		<None Remove="Windows_UI_Xaml_Data\xBindTests\Given_StaticResource_Control.xaml" />
 		<None Remove="XamlReaderTests\When_AttachedProperty_Binding.xamltest" />
 		<None Remove="XamlReaderTests\When_AttachedProperty_Different_Target.xamltest" />
 		<None Remove="XamlReaderTests\When_AttachedProperty_Same_Target.xamltest" />
@@ -128,6 +130,15 @@
 
 	<ItemGroup>
 		<PRIResource Include="**\*.resw" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="Windows_UI_Xaml_Data\xBindTests\Given_StaticResource_Control.xaml">
+		  <Generator>MSBuild:Compile</Generator>
+		</None>
+	</ItemGroup>
+	<ItemGroup Condition="'$(BuildingInsideUnoSourceGenerator)'!=''">
+		<Page Include="Windows_UI_Xaml_Data\xBindTests\Given_StaticResource_Control.xaml" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_StaticResource.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_StaticResource.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
+{
+	[TestClass]
+	public class Given_StaticResource
+	{
+		[TestMethod]
+		public void When_xBind_Resource()
+		{
+			var SUT = new Given_StaticResource_Control();
+
+			Assert.IsNull(SUT.mySource.Source);
+
+			SUT.MyProperty = 42;
+
+			SUT.ForceLoaded();
+
+			Assert.AreEqual(42, SUT.mySource.Source);
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_StaticResource_Control.xaml
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_StaticResource_Control.xaml
@@ -1,0 +1,13 @@
+﻿<Page
+    x:Class="Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests.Given_StaticResource_Control"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+	<Page.Resources>
+		<CollectionViewSource x:Name="mySource" x:FieldModifier="public" Source="{x:Bind MyProperty}" />
+	</Page.Resources>
+</Page>

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_StaticResource_Control.xaml.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/xBindTests/Given_StaticResource_Control.xaml.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.xBindTests
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class Given_StaticResource_Control : Page
+	{
+		public Given_StaticResource_Control()
+		{
+			this.InitializeComponent();
+		}
+
+		public object MyProperty { get; set; }
+	}
+}

--- a/src/Uno.UI/DataBinding/BindingExpression.cs
+++ b/src/Uno.UI/DataBinding/BindingExpression.cs
@@ -279,7 +279,7 @@ namespace Windows.UI.Xaml.Data
 			);
 			_boundPropertyType = targetPropertyDetails.Property.Type;
 
-			ExplicitSource = binding.Source;
+			TryGetSource(binding);
 
 			if (ParentBinding.CompiledSource != null)
 			{
@@ -296,6 +296,34 @@ namespace Windows.UI.Xaml.Data
 			ApplyFallbackValue();
 			ApplyExplicitSource();
 			ApplyElementName();
+		}
+
+		private void TryGetSource(Binding binding)
+		{
+			if (binding.Source is ElementNameSubject sourceSubject)
+			{
+				void applySource()
+				{
+					ExplicitSource = sourceSubject.ElementInstance;
+					ApplyExplicitSource();
+				}
+
+				// The element name instance may already have been
+				// set, in relation to the declaration order in the xaml file.
+				if (sourceSubject.ElementInstance == null)
+				{
+					sourceSubject
+						.ElementInstanceChanged += (s, elementNameInstance) => applySource();
+				}
+				else
+				{
+					applySource();
+				}
+			}
+			else
+			{
+				ExplicitSource = binding.Source;
+			}
 		}
 
 		private void SetTargetValue(object value)

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/FrameworkElement.cs
@@ -670,7 +670,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
-		#if false || false || NET461 || false || false
+		#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.UI.Xaml.RoutedEventHandler Loaded
 		{
@@ -702,7 +702,7 @@ namespace Windows.UI.Xaml
 			}
 		}
 		#endif
-		#if false || false || NET461 || false || false
+		#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.UI.Xaml.RoutedEventHandler Unloaded
 		{
@@ -719,7 +719,7 @@ namespace Windows.UI.Xaml
 		}
 		#endif
 		// Skipping already declared event Windows.UI.Xaml.FrameworkElement.DataContextChanged
-		#if false || false || NET461 || false || false
+		#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public  event global::Windows.Foundation.TypedEventHandler<global::Windows.UI.Xaml.FrameworkElement, object> Loading
 		{

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.net.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Interface.net.cs
@@ -34,15 +34,24 @@ namespace Windows.UI.Xaml
 			Initialize();
 		}
 
+		protected virtual void OnLoading()
+		{
+			Loading?.Invoke(this, null);
+		}
+
 		protected virtual void OnLoaded()
 		{
-
+			Loaded?.Invoke(this, RoutedEventArgs.Empty);
 		}
 
 		protected virtual void OnUnloaded()
 		{
-
+			Unloaded?.Invoke(this, RoutedEventArgs.Empty);
 		}
+
+		public event RoutedEventHandler Loaded;
+		public event RoutedEventHandler Unloaded;
+		public event TypedEventHandler<FrameworkElement, object> Loading;
 
 		public TransitionCollection Transitions { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.net.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.net.cs
@@ -80,6 +80,7 @@ namespace Windows.UI.Xaml
 		public void ForceLoaded()
 		{
 			IsLoaded = true;
+			OnLoading();
 			OnLoaded();
 		}
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Feature

## What is the new behavior?
It is now possible to use the following construct:

```xaml
<Page.Resources>
   <CollectionViewSource x:Name="mySource" Source="{x:Bind MyProperty}" />
</Page.Resources>
<ListView ItemsSource="{StaticResource mySource}" />
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)