### PR TITLE
CollectionViewSource updates

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -34,6 +34,8 @@
 * `RoutedEventArgs.IsGenerated` returns `false` as generating events with Uno is not yet supported
 * `AutomationPeer.ListenerExists` returns `false` as we cannot generating events with Uno is not yet supported
 * `KeyUp` event properly sends `KeyEventArgs` to the controls
+* Add ItemsSource CollectionViewSource update support (#697)
+* Add support for the `CollectionViewSource.ItemsPath` property
 
 ### Breaking changes
 * Make `UIElement.IsPointerPressed` and `IsPointerOver` internal
@@ -54,6 +56,7 @@
  * [Wasm] Fixes lements may not be removed form the global active DOM elements tracking map
  * [Wasm] Disable the root element scrolling (bounce) on touch devices
  * Fixed invalid iOS assets folder. `ImageAsset` nodes must not be `<Visible>false</Visible>` to be copied to the generated project.
+ * Make CollectionViewSource.View a proper DependencyProperty (#697)
 
 
 ## Release 1.43.1

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ItemsControlTests/Given_ItemsControl.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/ItemsControlTests/Given_ItemsControl.cs
@@ -124,6 +124,33 @@ namespace Uno.UI.Tests.ItemsControlTests
 			
 			Assert.AreEqual(1, count);
 		}
+
+		[TestMethod]
+		public void When_CollectionViewSource()
+		{
+			var count = 0;
+			var panel = new StackPanel();
+
+			var cvs = new CollectionViewSource();
+
+			var SUT = new ItemsControl()
+			{
+				ItemsPanelRoot = panel,
+				InternalItemsPanelRoot = panel,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					count++;
+					return new Border();
+				}),
+				ItemsSource = cvs
+			};
+			
+			Assert.AreEqual(0, count);
+
+			cvs.Source = new [] { 42 };
+
+			Assert.AreEqual(1, count);
+		}
 	}
 
 	public class MyItemsControl : ItemsControl

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/CollectionViewTests/Given_CollectionView.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/CollectionViewTests/Given_CollectionView.cs
@@ -16,7 +16,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.CollectionViewTests
 		public void When_CopyTo()
 		{
 			var originalList = new List<object> { 1, 2, 3 };
-			var SUT = new CollectionView(originalList, false);
+			var SUT = new CollectionView(originalList, false, null);
 
 			var array = new object[3];
 			(SUT as ICollection<object>).CopyTo(array, 0);
@@ -28,7 +28,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.CollectionViewTests
 		public void When_CopyTo_With_Index()
 		{
 			var originalList = new List<object> { 1, 2, 3 };
-			var SUT = new CollectionView(originalList, false);
+			var SUT = new CollectionView(originalList, false, null);
 
 			var array = new object[4];
 			array[0] = 42;
@@ -42,7 +42,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.CollectionViewTests
 		public void When_Array_CopyTo()
 		{
 			var originalList = new object[] { 1, 2, 3 };
-			var SUT = new CollectionView(originalList, false);
+			var SUT = new CollectionView(originalList, false, null);
 
 			var array = new object[3];
 			(SUT as ICollection<object>).CopyTo(array, 0);
@@ -54,7 +54,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.CollectionViewTests
 		public void When_Array_CopyTo_With_Index()
 		{
 			var originalList = new object[]{ 1, 2, 3 };
-			var SUT = new CollectionView(originalList, false);
+			var SUT = new CollectionView(originalList, false, null);
 
 			var array = new object[4];
 			array[0] = 42;

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/CollectionViewTests/Given_CollectionViewSource.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/CollectionViewTests/Given_CollectionViewSource.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Data;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Data.CollectionViewTests
+{
+	[TestClass]
+	public class Given_CollectionViewSource
+	{
+		[TestMethod]
+		public void When_Source_Is_Not_Enumerable()
+		{
+			var SUT = new CollectionViewSource();
+
+			Assert.IsNull(SUT.View);
+
+			SUT.Source = 42;
+
+			Assert.IsNull(SUT.View);
+		}
+
+		[TestMethod]
+		public void When_Source_IsArray()
+		{
+			var SUT = new CollectionViewSource();
+
+			Assert.IsNull(SUT.View);
+
+			SUT.Source = new[] { 42 };
+
+			Assert.IsNotNull(SUT.View);
+			Assert.AreEqual(1, SUT.View.Count);
+		}
+
+		[TestMethod]
+		public void When_Source_Notify()
+		{
+			var SUT = new CollectionViewSource();
+			int viewChanged = 0;
+			SUT.RegisterPropertyChangedCallback(CollectionViewSource.ViewProperty, (s, e) => viewChanged++);
+
+			Assert.IsNull(SUT.View);
+
+			SUT.Source = new[] { 42 };
+
+			Assert.IsNotNull(SUT.View);
+			Assert.AreEqual(1, SUT.View.Count);
+			Assert.AreEqual(1, viewChanged);
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Data/CollectionViewTests/Given_CollectionViewSource.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Data/CollectionViewTests/Given_CollectionViewSource.cs
@@ -52,5 +52,72 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Data.CollectionViewTests
 			Assert.AreEqual(1, SUT.View.Count);
 			Assert.AreEqual(1, viewChanged);
 		}
+
+		[TestMethod]
+		public void When_Valid_ItemsPath()
+		{
+			var SUT = new CollectionViewSource() { IsSourceGrouped = true };
+			SUT.ItemsPath = "MyItems";
+
+			int viewChanged = 0;
+			SUT.RegisterPropertyChangedCallback(CollectionViewSource.ViewProperty, (s, e) => viewChanged++);
+
+			Assert.IsNull(SUT.View);
+
+			var items = new[] {
+				new {
+					Key = 42,
+					MyItems = new [] {
+						21,
+						21
+					}
+				}
+			};
+
+			SUT.Source = items;
+
+			Assert.IsNotNull(SUT.View);
+			Assert.AreEqual(2, SUT.View.Count);
+			Assert.AreEqual(1, viewChanged);
+
+			Assert.AreEqual(1, SUT.View.CollectionGroups.Count);
+
+			var firstGroup = SUT.View.CollectionGroups.First() as ICollectionViewGroup;
+			Assert.AreEqual(items.First(), firstGroup.Group);
+			Assert.AreEqual(2, firstGroup.GroupItems.Count);
+		}
+
+		[TestMethod]
+		public void When_Invalid_ItemsPath()
+		{
+			var SUT = new CollectionViewSource() { IsSourceGrouped = true };
+			SUT.ItemsPath = "Invalid";
+
+			int viewChanged = 0;
+			SUT.RegisterPropertyChangedCallback(CollectionViewSource.ViewProperty, (s, e) => viewChanged++);
+
+			Assert.IsNull(SUT.View);
+
+			var items = new[] {
+				new {
+					Key = 42,
+					MyItems = new [] {
+						21,
+						21
+					}
+				}
+			};
+
+			SUT.Source = items;
+
+			Assert.IsNotNull(SUT.View);
+			Assert.AreEqual(0, SUT.View.Count);
+			Assert.AreEqual(1, viewChanged);
+
+			Assert.AreEqual(1, SUT.View.CollectionGroups.Count);
+
+			var firstGroup = SUT.View.CollectionGroups.First() as ICollectionViewGroup;
+			Assert.AreEqual(0, firstGroup.GroupItems.Count);
+		}
 	}
 }

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Data/CollectionViewSource.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Data/CollectionViewSource.cs
@@ -7,41 +7,6 @@ namespace Windows.UI.Xaml.Data
 	#endif
 	public  partial class CollectionViewSource : global::Windows.UI.Xaml.DependencyObject
 	{
-		// Skipping already declared property Source
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public  global::Windows.UI.Xaml.PropertyPath ItemsPath
-		{
-			get
-			{
-				return (global::Windows.UI.Xaml.PropertyPath)this.GetValue(ItemsPathProperty);
-			}
-			set
-			{
-				this.SetValue(ItemsPathProperty, value);
-			}
-		}
-		#endif
-		// Skipping already declared property IsSourceGrouped
-		// Skipping already declared property View
-		// Skipping already declared property IsSourceGroupedProperty
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty ItemsPathProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			"ItemsPath", typeof(global::Windows.UI.Xaml.PropertyPath), 
-			typeof(global::Windows.UI.Xaml.Data.CollectionViewSource), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.PropertyPath)));
-		#endif
-		// Skipping already declared property SourceProperty
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
-		[global::Uno.NotImplemented]
-		public static global::Windows.UI.Xaml.DependencyProperty ViewProperty { get; } = 
-		Windows.UI.Xaml.DependencyProperty.Register(
-			"View", typeof(global::Windows.UI.Xaml.Data.ICollectionView), 
-			typeof(global::Windows.UI.Xaml.Data.CollectionViewSource), 
-			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.Data.ICollectionView)));
-		#endif
 		// Skipping already declared method Windows.UI.Xaml.Data.CollectionViewSource.CollectionViewSource()
 		// Forced skipping of method Windows.UI.Xaml.Data.CollectionViewSource.CollectionViewSource()
 		// Forced skipping of method Windows.UI.Xaml.Data.CollectionViewSource.Source.get

--- a/src/Uno.UI/UI/Xaml/Data/CollectionView.cs
+++ b/src/Uno.UI/UI/Xaml/Data/CollectionView.cs
@@ -16,18 +16,20 @@ namespace Windows.UI.Xaml.Data
 	{
 		private IEnumerable _collection;
 		private readonly bool _isGrouped;
+		private readonly PropertyPath _itemsPath;
 
-		public CollectionView(IEnumerable collection, bool isGrouped)
+		public CollectionView(IEnumerable collection, bool isGrouped, PropertyPath itemsPath)
 		{
 			_collection = collection;
 			_isGrouped = isGrouped;
+			_itemsPath = itemsPath;
 
 			if (isGrouped)
 			{
 				var collectionGroups = new ObservableVector<object>();
 				foreach (var group in collection)
 				{
-					collectionGroups.Add(new CollectionViewGroup(group));
+					collectionGroups.Add(new CollectionViewGroup(group, _itemsPath));
 				}
 
 				CollectionGroups = collectionGroups;
@@ -48,7 +50,7 @@ namespace Windows.UI.Xaml.Data
 				case NotifyCollectionChangedAction.Add:
 					for (int i = e.NewStartingIndex; i < e.NewStartingIndex + e.NewItems.Count; i++)
 					{
-						CollectionGroups.Insert(i, new CollectionViewGroup(_collection.ElementAt(i)));
+						CollectionGroups.Insert(i, new CollectionViewGroup(_collection.ElementAt(i), _itemsPath));
 					}
 					break;
 				case NotifyCollectionChangedAction.Move:
@@ -70,7 +72,7 @@ namespace Windows.UI.Xaml.Data
 				case NotifyCollectionChangedAction.Replace:
 					for (int i = e.NewStartingIndex; i < e.NewStartingIndex + e.NewItems.Count; i++)
 					{
-						CollectionGroups[i] = new CollectionViewGroup(_collection.ElementAt(i));
+						CollectionGroups[i] = new CollectionViewGroup(_collection.ElementAt(i), _itemsPath);
 					}
 					break;
 				case NotifyCollectionChangedAction.Reset:

--- a/src/Uno.UI/UI/Xaml/Data/CollectionViewGroup.cs
+++ b/src/Uno.UI/UI/Xaml/Data/CollectionViewGroup.cs
@@ -1,19 +1,33 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using Uno.UI.DataBinding;
 using Windows.Foundation.Collections;
 
 namespace Windows.UI.Xaml.Data
 {
 	internal class CollectionViewGroup : ICollectionViewGroup
 	{
-		public CollectionViewGroup(object group)
+		private readonly BindingPath _bindingPath;
+
+		public CollectionViewGroup(object group, PropertyPath itemsPath)
 		{
 			Group = group;
 
-			GroupItems = ObservableVectorWrapper.Create(group);
+			if (itemsPath != null)
+			{
+				_bindingPath = new BindingPath(itemsPath.Path, null);
+				_bindingPath.DataContext = group;
+
+				GroupItems = ObservableVectorWrapper.Create(_bindingPath.Value);
+			}
+			else
+			{
+				GroupItems = ObservableVectorWrapper.Create(group);
+			}
 		}
 		public object Group { get; }
+
 
 		public IObservableVector<object> GroupItems { get; }
 	}

--- a/src/Uno.UI/UI/Xaml/Data/CollectionViewSource.cs
+++ b/src/Uno.UI/UI/Xaml/Data/CollectionViewSource.cs
@@ -22,9 +22,7 @@ namespace Windows.UI.Xaml.Data
 
 		// Using a DependencyProperty as the backing store for IsSourceGrouped.  This enables animation, styling, binding, etc...
 		public static readonly DependencyProperty IsSourceGroupedProperty =
-			DependencyProperty.Register("IsSourceGrouped", typeof(bool), typeof(CollectionViewSource), new PropertyMetadata(false, (o, e) => ((CollectionViewSource)o).UpdateView()));
-
-
+			DependencyProperty.Register(nameof(IsSourceGrouped), typeof(bool), typeof(CollectionViewSource), new PropertyMetadata(false, (o, e) => ((CollectionViewSource)o).UpdateView()));
 
 		public object Source
 		{
@@ -34,13 +32,13 @@ namespace Windows.UI.Xaml.Data
 
 		// Using a DependencyProperty as the backing store for Source.  This enables animation, styling, binding, etc...
 		public static readonly DependencyProperty SourceProperty =
-			DependencyProperty.Register("Source", typeof(object), typeof(CollectionViewSource), new PropertyMetadata(null, (o, e) => ((CollectionViewSource)o).UpdateView()));
+			DependencyProperty.Register(nameof(Source), typeof(object), typeof(CollectionViewSource), new PropertyMetadata(null, (o, e) => ((CollectionViewSource)o).UpdateView()));
 
 		private void UpdateView()
 		{
             if (Source is IEnumerable enumerable)
             {
-                View = new CollectionView(enumerable, IsSourceGrouped);
+                View = new CollectionView(enumerable, IsSourceGrouped, ItemsPath);
             }
             else
             {
@@ -50,6 +48,32 @@ namespace Windows.UI.Xaml.Data
 
 		#endregion
 
-		public ICollectionView View { get; private set; }
+		public static DependencyProperty ViewProperty { get; } =
+			Windows.UI.Xaml.DependencyProperty.Register(
+				name: nameof(View),
+				propertyType: typeof(ICollectionView),
+				ownerType: typeof(CollectionViewSource),
+				typeMetadata: new FrameworkPropertyMetadata(null)
+			);
+
+		public ICollectionView View
+		{
+			get => (ICollectionView)GetValue(ViewProperty);
+			private set => SetValue(ViewProperty, value);
+		}
+
+		public global::Windows.UI.Xaml.PropertyPath ItemsPath
+		{
+			get => (PropertyPath)this.GetValue(ItemsPathProperty);
+			set => this.SetValue(ItemsPathProperty, value);
+		}
+
+		public static DependencyProperty ItemsPathProperty { get; } =
+			DependencyProperty.Register(
+				name: nameof(ItemsPath),
+				propertyType: typeof(PropertyPath),
+				ownerType: typeof(CollectionViewSource),
+				typeMetadata: new PropertyMetadata(null, (o, e) => ((CollectionViewSource)o).UpdateView())
+			);
 	}
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix
- Feature

## What is the current behavior?
Using a `CollectionViewSource` in ItemsControl does not work properly.

## What is the new behavior?
- Using `CollectionViewSource` directly now works properly, and updating the source property updates observer properly.
- Added support for the `CollectionViewSource.ItemsPath` property

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
