### PR TITLE
Fixed support for dots in resource names

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -36,6 +36,7 @@
 * `KeyUp` event properly sends `KeyEventArgs` to the controls
 * Add ItemsSource CollectionViewSource update support (#697)
 * Add support for the `CollectionViewSource.ItemsPath` property
+* Fixed support for dots in resource names (#700)
 
 ### Breaking changes
 * Make `UIElement.IsPointerPressed` and `IsPointerOver` internal

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -511,7 +511,17 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 		}
 
-		private static string SanitizeResourceName(string name) => name.Replace("-", "_");
+		private static readonly char[] ResourceInvalidCharacters = new[] { '.', '-' };
+
+		private static string SanitizeResourceName(string name)
+		{
+			foreach (var c in ResourceInvalidCharacters)
+			{
+				name = name.Replace(c, '_');
+			}
+
+			return name;
+		}
 
 		private void BuildChildSubclasses(IIndentedStringBuilder writer, bool isTopLevel = false)
 		{

--- a/src/SourceGenerators/XamlGenerationTests/GlobalStaticResources02.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/GlobalStaticResources02.xaml
@@ -37,10 +37,15 @@
         <Setter Property="Background" Value="Blue" />
     </Style>
 
-    <Style x:Key="Resource-with-dashes"  TargetType="Grid"
+	<Style x:Key="Resource-with-dashes"  TargetType="Grid"
 		   BasedOn="{StaticResource baseGridStyle}">
-        <Setter Property="Background" Value="Blue" />
-    </Style>
+		<Setter Property="Background" Value="Blue" />
+	</Style>
+
+	<Style x:Key="Resource.with.dots"  TargetType="Grid"
+		   BasedOn="{StaticResource baseGridStyle}">
+		<Setter Property="Background" Value="Blue" />
+	</Style>
 	
 	<x:Double x:Key="Double-Resource-With-Dashes">42</x:Double>
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the new behavior?
Fixed support for dots in resource names (#700)

 ## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)