### PR TITLE
Adds support for Android 9

### DIFF
--- a/build/Uno.UI.Lottie.nuspec
+++ b/build/Uno.UI.Lottie.nuspec
@@ -47,5 +47,6 @@
 	<file src="..\src\AddIns\Uno.UI.Lottie\bin\Release\netstandard2.0\Uno.UI.Lottie.dll" target="lib\netstandard2.0" />
 	<file src="..\src\AddIns\Uno.UI.Lottie\bin\Release\xamarinios10\Uno.UI.Lottie.dll" target="lib\xamarinios10" />
 	<file src="..\src\AddIns\Uno.UI.Lottie\bin\Release\MonoAndroid80\Uno.UI.Lottie.dll" target="lib\MonoAndroid80" />
+	<file src="..\src\AddIns\Uno.UI.Lottie\bin\Release\MonoAndroid90\Uno.UI.Lottie.dll" target="lib\MonoAndroid90" />
   </files>
 </package>

--- a/build/Uno.UI.nuspec
+++ b/build/Uno.UI.nuspec
@@ -25,6 +25,16 @@
 		<dependency id="Uno.Core.Build" version="1.27.0-dev.68" />
 	  </group>
 
+		<!-- Android 9.0 -->
+	  <group targetFramework="MonoAndroid90">
+		<dependency id="Xamarin.Android.Support.v4" version="26.1.0.1" />
+		<dependency id="Xamarin.Android.Support.v7.AppCompat" version="26.1.0.1" />
+		<dependency id="Xamarin.Android.Support.v7.RecyclerView" version="26.1.0.1" />
+		<dependency id="Uno.SourceGenerationTasks" version="1.30.0-dev.277" />
+		<dependency id="Uno.Core" version="1.27.0-dev.68" />
+		<dependency id="Uno.Core.Build" version="1.27.0-dev.68" />
+	  </group>
+
 	  <!-- iOS -->
 	  <group targetFramework="xamarinios10">
 		<dependency id="Uno.SourceGenerationTasks" version="1.30.0-dev.277" />
@@ -93,6 +103,8 @@
 	<file src="..\src\Uno.UI.Toolkit\bin\Release\uap10.0\Uno.UI.Toolkit.pdb" target="lib\UAP" />
 	<file src="..\src\Uno.UI.Toolkit\bin\Release\MonoAndroid80\Uno.UI.Toolkit.dll" target="lib\MonoAndroid80" />
 	<file src="..\src\Uno.UI.Toolkit\bin\Release\MonoAndroid80\Uno.UI.Toolkit.pdb" target="lib\MonoAndroid80" />
+	<file src="..\src\Uno.UI.Toolkit\bin\Release\MonoAndroid90\Uno.UI.Toolkit.dll" target="lib\MonoAndroid90" />
+	<file src="..\src\Uno.UI.Toolkit\bin\Release\MonoAndroid90\Uno.UI.Toolkit.pdb" target="lib\MonoAndroid90" />
 	<file src="..\src\Uno.UI.Toolkit\bin\Release\xamarinios10\Uno.UI.Toolkit.dll" target="lib\xamarinios10" />
 	<file src="..\src\Uno.UI.Toolkit\bin\Release\xamarinios10\Uno.UI.Toolkit.pdb" target="lib\xamarinios10" />
 	<file src="..\src\Uno.UI.Toolkit\bin\Release\netstandard2.0\Uno.UI.Toolkit.dll" target="lib\netstandard2.0" />
@@ -110,6 +122,20 @@
 	<file src="..\src\Uno.UI\Bin\Release\monoandroid80\Uno.Xaml.dll" target="lib\MonoAndroid80" />
 	<file src="..\src\Uno.UI\Bin\Release\monoandroid80\Uno.Xaml.pdb" target="lib\MonoAndroid80" />
 	<file src="..\src\Uno.UI\Bin\Release\monoandroid80\*.xml" target="lib\MonoAndroid80" />
+
+	<!-- Android 9.0 -->
+	<file src="..\src\Uno.UI\Bin\Release\monoandroid90\Uno.dll" target="lib\MonoAndroid90" />
+	<file src="..\src\Uno.UI\Bin\Release\monoandroid90\Uno.pdb" target="lib\MonoAndroid90" />
+	<file src="..\src\Uno.UI\Bin\Release\monoandroid90\Uno.Foundation.dll" target="lib\MonoAndroid90" />
+	<file src="..\src\Uno.UI\Bin\Release\monoandroid90\Uno.Foundation.pdb" target="lib\MonoAndroid90" />
+	<file src="..\src\Uno.UI\Bin\Release\monoandroid90\Uno.UI.BindingHelper.Android.dll" target="lib\MonoAndroid90" />
+	<file src="..\src\Uno.UI\Bin\Release\monoandroid90\Uno.UI.BindingHelper.Android.pdb" target="lib\MonoAndroid90" />
+	<file src="..\src\Uno.UI\Bin\Release\monoandroid90\Uno.UI.dll" target="lib\MonoAndroid90" />
+	<file src="..\src\Uno.UI\Bin\Release\monoandroid90\Uno.UI.pdb" target="lib\MonoAndroid90" />
+	<file src="..\src\Uno.UI\Bin\Release\monoandroid90\Uno.Xaml.dll" target="lib\MonoAndroid90" />
+	<file src="..\src\Uno.UI\Bin\Release\monoandroid90\Uno.Xaml.pdb" target="lib\MonoAndroid90" />
+	<file src="..\src\Uno.UI\Bin\Release\monoandroid90\*.xml" target="lib\MonoAndroid90" />
+
 
 	<!-- iOS Unified -->
 	<file src="..\src\Uno.UI\Bin\Release\xamarinios10\Uno.dll" target="lib\xamarinios10" />

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -38,9 +38,11 @@
 * Add support for the `CollectionViewSource.ItemsPath` property
 * Fixed support for dots in resource names (#700)
 * Add support for `BindingExpression.UpdateSource()`
+* Updated Android version to target Android 9.0
 
 ### Breaking changes
 * Make `UIElement.IsPointerPressed` and `IsPointerOver` internal
+* You will not be able to build projects targeting Android 8.0 locally anymore. Change your Android target to Android 9.0 or replace MonoAndroid90 by MonoAndroid80 in the TargetFrameworks of your projects files.
 
 ### Bug fixes
  * Transforms are now fully functionnal

--- a/src/AddIns/Uno.UI.Lottie/Uno.UI.Lottie.csproj
+++ b/src/AddIns/Uno.UI.Lottie/Uno.UI.Lottie.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
 
 	<PropertyGroup>
-		<TargetFrameworks>xamarinmac20;MonoAndroid80;xamarinios10;net461;netstandard2.0</TargetFrameworks>
-
+		<TargetFrameworks>xamarinmac20;MonoAndroid90;xamarinios10;net461;netstandard2.0</TargetFrameworks>
+		<TargetFrameworksCI>xamarinmac20;MonoAndroid80;MonoAndroid90;xamarinios10;net461;netstandard2.0</TargetFrameworksCI>
 		<NoWarn>$(NoWarn);NU1701</NoWarn>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<Deterministic>true</Deterministic>
@@ -34,6 +34,10 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid80'">
+		<PackageReference Include="Com.Airbnb.Android.Lottie" Version="2.5.2.1" PrivateAssets="none" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Com.Airbnb.Android.Lottie" Version="2.5.2.1" PrivateAssets="none" />
 	</ItemGroup>
 

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,4 +1,5 @@
 <Project ToolsVersion="15.0">
+	<Import Project="TargetFrameworkSelection.targets"/>
 	<Import Project="../build/GetMsBuildVersion.targets" />
 
   <Target Name="AndroidResourceGenWorkaround" BeforeTargets="Build" Condition="'$(AndroidUseIntermediateDesignerFile)'=='True' and $(IsMonoAndroid)">

--- a/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
+++ b/src/SamplesApp/SamplesApp.Droid/SamplesApp.Droid.csproj
@@ -16,7 +16,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
     <ResourcesDirectory>..\SamplesApp.Shared\Strings</ResourcesDirectory>

--- a/src/SolutionTemplate/UnoLibraryTemplate/CrossTargetedLibrary.csproj
+++ b/src/SolutionTemplate/UnoLibraryTemplate/CrossTargetedLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="MSBuild.Sdk.Extras/1.6.68">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;xamarinios10;monoandroid80;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;xamarinios10;monoandroid80;monoandroid90;uap10.0.16299</TargetFrameworks>
 		
 		<!-- Ensures the .xr.xml files are generated in a proper layout folder -->
 		<GenerateLibraryLayout>true</GenerateLibraryLayout>
@@ -11,7 +11,7 @@
 		<DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
 	</PropertyGroup>
 	
-	<ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid80' or '$(TargetFramework)'=='netstandard2.0'">
+	<ItemGroup Condition="'$(TargetFramework)'=='xamarinios10' or '$(TargetFramework)'=='monoandroid80' or '$(TargetFramework)'=='monoandroid90' or '$(TargetFramework)'=='netstandard2.0'">
 		<PackageReference Include="Uno.UI" Version="1.43.0-dev.965" />
 	</ItemGroup>
 	

--- a/src/SolutionTemplate/UnoSolutionTemplate/Droid/UnoQuickStart.Droid.csproj
+++ b/src/SolutionTemplate/UnoSolutionTemplate/Droid/UnoQuickStart.Droid.csproj
@@ -16,7 +16,7 @@
 		<AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
 		<GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
 		<AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
-		<TargetFrameworkVersion>v8.0</TargetFrameworkVersion>
+		<TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
 		<AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
 		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>
 		<ResourcesDirectory>..\$ext_safeprojectname$.Shared\Strings</ResourcesDirectory>

--- a/src/SourceGenerators/System.Xaml/Uno.Xaml.csproj
+++ b/src/SourceGenerators/System.Xaml/Uno.Xaml.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
 	<PropertyGroup>
-		<TargetFrameworks>xamarinmac20;net461;xamarinios10;MonoAndroid80;netstandard2.0</TargetFrameworks>
-		<TargetFrameworksCI>net461;MonoAndroid80;xamarinios10;netstandard2.0;xamarinmac20</TargetFrameworksCI>
+		<TargetFrameworks>xamarinmac20;net461;xamarinios10;MonoAndroid90;netstandard2.0</TargetFrameworks>
+		<TargetFrameworksCI>net461;MonoAndroid80;MonoAndroid90;xamarinios10;netstandard2.0;xamarinmac20</TargetFrameworksCI>
 		<DisableBuildTargetFramework>true</DisableBuildTargetFramework>
 
 		<AndroidUseIntermediateDesignerFile>True</AndroidUseIntermediateDesignerFile>

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/DependencyObject/DependencyObjectGenerator.cs
@@ -50,7 +50,7 @@ namespace Uno.UI.SourceGenerators.DependencyObject
 				_androidViewSymbol = comp.GetTypeByMetadataName("Android.Views.View");
 				_javaObjectSymbol = comp.GetTypeByMetadataName("Java.Lang.Object");
 				_androidActivitySymbol = comp.GetTypeByMetadataName("Android.App.Activity");
-				_androidFragmentSymbol = comp.GetTypeByMetadataName("Android.App.Fragment");
+				_androidFragmentSymbol = comp.GetTypeByMetadataName("Android.Support.V4.App.Fragment");
 			    _bindableAttributeSymbol = comp.GetTypeByMetadataName("Windows.UI.Xaml.Data.BindableAttribute");
 				_iFrameworkElementSymbol = comp.GetTypeByMetadataName(XamlConstants.Types.IFrameworkElement);
 			}

--- a/src/SourceGenerators/XamlGenerationTests.Core/XamlGenerationTests.Core.csproj
+++ b/src/SourceGenerators/XamlGenerationTests.Core/XamlGenerationTests.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
 	<PropertyGroup>
-		<TargetFrameworks>MonoAndroid80;xamarinios10</TargetFrameworks>
-		<TargetFrameworksCI>MonoAndroid80;xamarinios10</TargetFrameworksCI>
+		<TargetFrameworks>MonoAndroid90;xamarinios10</TargetFrameworks>
+		<TargetFrameworksCI>MonoAndroid80;MonoAndroid90;xamarinios10</TargetFrameworksCI>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -27,7 +27,18 @@
 		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
 			<Version>26.1.0.1</Version>
 		</PackageReference>
+	</ItemGroup>
 
+	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
+		<PackageReference Include="Xamarin.Android.Support.v4">
+			<Version>26.1.0.1</Version>
+		</PackageReference>
+		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
+			<Version>26.1.0.1</Version>
+		</PackageReference>
+		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
+			<Version>26.1.0.1</Version>
+		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
+++ b/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
 	<PropertyGroup>
-		<TargetFrameworks>MonoAndroid80;xamarinios10</TargetFrameworks>
-		<TargetFrameworksCI>MonoAndroid80;xamarinios10</TargetFrameworksCI>
+		<TargetFrameworks>MonoAndroid90;xamarinios10</TargetFrameworks>
+		<TargetFrameworksCI>MonoAndroid80;MonoAndroid90;xamarinios10</TargetFrameworksCI>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -18,6 +18,18 @@
 	</ItemGroup>
 	
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80'">
+		<PackageReference Include="Xamarin.Android.Support.v4">
+			<Version>26.1.0.1</Version>
+		</PackageReference>
+		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
+			<Version>26.1.0.1</Version>
+		</PackageReference>
+		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
+			<Version>26.1.0.1</Version>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.Android.Support.v4">
 			<Version>26.1.0.1</Version>
 		</PackageReference>

--- a/src/TargetFrameworkSelection.targets
+++ b/src/TargetFrameworkSelection.targets
@@ -1,0 +1,59 @@
+<Project ToolsVersion="15.0">
+
+  <ItemGroup>
+    <_OverrideTargetFrameworksDependency Include="Restore" />
+    <_OverrideTargetFrameworksDependency Include="Build" />
+
+    <_OverrideTargetFrameworksDependency Include="_ComputeTargetFrameworkItems" />
+    <_OverrideTargetFrameworksDependency Include="DispatchToInnerBuilds" />
+    <_OverrideTargetFrameworksDependency Include="Pack" />
+    <_OverrideTargetFrameworksDependency Include="BuiltProjectOutputGroup" />
+    <_OverrideTargetFrameworksDependency Include="DocumentationProjectOutputGroup" />
+    <_OverrideTargetFrameworksDependency Include="_AddPriFileToPackBuildOutput" />
+    <_OverrideTargetFrameworksDependency Include="PrepareForBuild" />
+
+    <!-- Used when restoring packages in VS15.2 -->
+    <_OverrideTargetFrameworksDependency Include="GetRestoreProjectFrameworks" />
+
+    <!-- Used when evaluation compatibility between referenced projects -->
+		<_OverrideTargetFrameworksDependency Include="GetTargetFrameworkProperties" />
+		
+		<!-- this target has been introduced in VS15.5 -->
+		<_OverrideTargetFrameworksDependency Include="GetTargetFrameworks" />
+
+		<!--This items get excuted by the nuget Restore target-->
+    <_OverrideTargetFrameworksDependency Include="_GenerateRestoreGraphProjectEntry" />
+    <_OverrideTargetFrameworksDependency Include="_IsProjectRestoreSupported" />
+    <_OverrideTargetFrameworksDependency Include="_GenerateRestoreProjectPathWalk" />
+  </ItemGroup>
+
+  <Target Name="_ResolveTargetFrameworks"
+    Condition="'$(TargetFrameworks)'!=''"
+    BeforeTargets="@(_OverrideTargetFrameworksDependency)"
+    DependsOnTargets="_FillMsBuildVersion">
+
+    <PropertyGroup>
+      <TargetFrameworksOverride Condition="'$(MicrosoftBuildVersion)' &gt;= '15.4'">$(TargetFrameworks)</TargetFrameworksOverride>
+      <TargetFrameworksOverride Condition="'$(CI_Build)'!='' and '$(TargetFrameworksCI)'!='' and '$(UITestsEnabled)'==''">$(TargetFrameworksCI)</TargetFrameworksOverride>
+
+      <_CanOverrideFramework>false</_CanOverrideFramework>
+      <_CanOverrideFramework Condition="'$(BuildTargetFramework)' !='' and '$(DisableBuildTargetFramework)' =='' and '$(ExcludeRestorePackageImports)'!='true' and '$(DesignTimeBuild)' != 'true' and $(TargetFrameworks.Contains($(BuildTargetFramework)))">true</_CanOverrideFramework>
+      
+      <!-- Override the building target framework, for faster compilation -->
+      <TargetFrameworksOverride Condition="$(_CanOverrideFramework)">$(BuildTargetFramework)</TargetFrameworksOverride>
+    </PropertyGroup>
+
+    <CreateProperty Value="$(TargetFrameworksOverride)">
+      <Output TaskParameter="Value" PropertyName="TargetFrameworks" />
+    </CreateProperty>
+
+    <Message Text="Target framework override to $(TargetFrameworks) because BuildTargetFramework is set ($(BuildTargetFramework))." Condition="$(_CanOverrideFramework) and '$(TargetFramework)'==''" Importance="high" />
+    <Message Text="MSBuild Version $(MicrosoftBuildVersion), TargetFrameworks $(TargetFrameworks)" />
+  </Target>
+
+  <PropertyGroup Condition="('$(ExcludeRestorePackageImports)'!='true' and '$(TargetFrameworks)'!='') or '$(CI_Build)'!=''">
+    <TargetFrameworks Condition="'$(TargetFrameworksOverride)'==''">$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="'$(TargetFrameworksOverride)'!=''">$(TargetFrameworksOverride)</TargetFrameworks>
+  </PropertyGroup>
+
+</Project>

--- a/src/Uno.Foundation/Uno.Foundation.csproj
+++ b/src/Uno.Foundation/Uno.Foundation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFrameworks>xamarinmac20;xamarinios10;MonoAndroid80;net461;netstandard2.0</TargetFrameworks>
-		<TargetFrameworksCI>MonoAndroid80;xamarinios10;net461;netstandard2.0;xamarinmac20</TargetFrameworksCI>
+    <TargetFrameworks>xamarinmac20;xamarinios10;MonoAndroid90;net461;netstandard2.0</TargetFrameworks>
+		<TargetFrameworksCI>MonoAndroid80;MonoAndroid90;xamarinios10;net461;netstandard2.0;xamarinmac20</TargetFrameworksCI>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
+++ b/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
 	<PropertyGroup>
-		<TargetFrameworks>MonoAndroid80;net461;xamarinios10;netstandard2.0;xamarinmac20</TargetFrameworks>
+		<TargetFrameworks>MonoAndroid80;MonoAndroid90;net461;xamarinios10;netstandard2.0;xamarinmac20</TargetFrameworks>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<NoWarn>1701;1702;1705;109</NoWarn>
 
@@ -10,7 +10,7 @@
 		<ProduceReferenceAssembly>false</ProduceReferenceAssembly>
 		<Deterministic>true</Deterministic>
 		
-		<IsBindingProject Condition="'$(TargetFramework)' == 'MonoAndroid80'">true</IsBindingProject>
+		<IsBindingProject Condition="'$(TargetFramework)' == 'MonoAndroid80' or '$(TargetFramework)' == 'MonoAndroid90'">true</IsBindingProject>
 		<_isWindows>$([MSBuild]::IsOsPlatform(Windows))</_isWindows>
 	</PropertyGroup>
 	
@@ -19,6 +19,15 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80'">
+		<PackageReference Include="Xamarin.Android.Support.v4">
+			<Version>26.1.0.1</Version>
+		</PackageReference>
+		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
+			<Version>26.1.0.1</Version>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.Android.Support.v4">
 			<Version>26.1.0.1</Version>
 		</PackageReference>

--- a/src/Uno.UI.Maps/Uno.UI.Maps.csproj
+++ b/src/Uno.UI.Maps/Uno.UI.Maps.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
   <PropertyGroup>
-		<TargetFrameworks>MonoAndroid80;xamarinios10</TargetFrameworks>
-		<TargetFrameworksCI>MonoAndroid80;xamarinios10</TargetFrameworksCI>
+		<TargetFrameworks>MonoAndroid90;xamarinios10</TargetFrameworks>
+		<TargetFrameworksCI>MonoAndroid80;MonoAndroid90;xamarinios10</TargetFrameworksCI>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -27,6 +27,12 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80'">
+		<PackageReference Include="Xamarin.GooglePlayServices.Location" Version="60.1142.0" />
+		<PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="60.1142.0" />
+		<PackageReference Include="Xamarin.Android.Support.v4" Version="26.1.0.1" PrivateAssets="none" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.GooglePlayServices.Location" Version="60.1142.0" />
 		<PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="60.1142.0" />
 		<PackageReference Include="Xamarin.Android.Support.v4" Version="26.1.0.1" PrivateAssets="none" />

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;xamarinios10;monoandroid80;xamarinmac20;uap10.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;xamarinios10;monoandroid80;monoandroid90;xamarinmac20;uap10.0</TargetFrameworks>
 		
     <!-- Ensures the .xr.xml files are generated in a proper layout folder -->
     <GenerateLibraryLayout>true</GenerateLibraryLayout>

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
 	<PropertyGroup>
-		<TargetFrameworks>xamarinmac20;MonoAndroid80;uap10.0;xamarinios10;netstandard2.0</TargetFrameworks>
-		<TargetFrameworksCI>MonoAndroid80;uap10.0;xamarinios10;netstandard2.0;xamarinmac20</TargetFrameworksCI>
+		<TargetFrameworks>xamarinmac20;MonoAndroid90;uap10.0;xamarinios10;netstandard2.0</TargetFrameworks>
+		<TargetFrameworksCI>MonoAndroid80;MonoAndroid90;uap10.0;xamarinios10;netstandard2.0;xamarinmac20</TargetFrameworksCI>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -30,22 +30,22 @@
 		<Reference Include="System.Numerics.Vectors" />
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid60' or '$(TargetFramework)' == 'MonoAndroid70'">
+	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80'">
 		<PackageReference Include="Xamarin.Android.Support.v4">
-			<Version>23.4.0.1</Version>
+			<Version>26.1.0.1</Version>
 			<PrivateAssets>none</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-			<Version>23.4.0.1</Version>
+			<Version>26.1.0.1</Version>
 			<PrivateAssets>none</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-			<Version>23.4.0.1</Version>
+			<Version>26.1.0.1</Version>
 			<PrivateAssets>none</PrivateAssets>
 		</PackageReference>
 	</ItemGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80'">
+	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.Android.Support.v4">
 			<Version>26.1.0.1</Version>
 			<PrivateAssets>none</PrivateAssets>

--- a/src/Uno.UI/BaseFragment.Android.cs
+++ b/src/Uno.UI/BaseFragment.Android.cs
@@ -9,6 +9,7 @@ using System;
 using Uno.Disposables;
 using System.Runtime.CompilerServices;
 using System.Collections.Generic;
+using Fragment = Android.Support.V4.App.Fragment;
 
 namespace Uno.UI
 {

--- a/src/Uno.UI/Controls/BindableFragment.Android.cs
+++ b/src/Uno.UI/Controls/BindableFragment.Android.cs
@@ -11,7 +11,7 @@ using Android.Views;
 using Android.Widget;
 using Android.Support.V4.App;
 using Uno.Extensions;
-using Fragment = Android.App.Fragment;
+using Fragment = Android.Support.V4.App.Fragment;
 using Windows.UI.Xaml.Data;
 using System.Runtime.CompilerServices;
 using Windows.UI.Xaml;

--- a/src/Uno.UI/Extensions/FragmentManagerExtensions.Android.cs
+++ b/src/Uno.UI/Extensions/FragmentManagerExtensions.Android.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-using Android.App;
+using Android.Support.V4.App;
 using Android.Content;
 using Android.OS;
 using Android.Runtime;

--- a/src/Uno.UI/IFragmentTracker.Android.cs
+++ b/src/Uno.UI/IFragmentTracker.Android.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Fragment = Android.Support.V4.App.Fragment; 
+
 
 namespace Uno.UI
 {

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
 	<PropertyGroup>
-		<TargetFrameworks>xamarinmac20;MonoAndroid80;xamarinios10;net461;netstandard2.0</TargetFrameworks>
-		<TargetFrameworksCI>MonoAndroid80;xamarinios10;net461;netstandard2.0;xamarinmac20</TargetFrameworksCI>
+		<TargetFrameworks>xamarinmac20;MonoAndroid90;xamarinios10;net461;netstandard2.0</TargetFrameworks>
+		<TargetFrameworksCI>MonoAndroid80;MonoAndroid90;xamarinios10;net461;netstandard2.0;xamarinmac20</TargetFrameworksCI>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -156,6 +156,18 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80'">
+		<PackageReference Include="Xamarin.Android.Support.v4" Version="26.1.0.1">
+			<PrivateAssets>none</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="26.1.0.1">
+			<PrivateAssets>none</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="26.1.0.1">
+			<PrivateAssets>none</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.Android.Support.v4" Version="26.1.0.1">
 			<PrivateAssets>none</PrivateAssets>
 		</PackageReference>

--- a/src/Uno.UWP/Uno.csproj
+++ b/src/Uno.UWP/Uno.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
   
   <PropertyGroup>
-    <TargetFrameworks>xamarinmac20;xamarinios10;MonoAndroid80;net461;netstandard2.0</TargetFrameworks>
-    <TargetFrameworksCI>MonoAndroid80;xamarinios10;net461;netstandard2.0;xamarinmac20</TargetFrameworksCI>
+    <TargetFrameworks>xamarinmac20;xamarinios10;MonoAndroid90;net461;netstandard2.0</TargetFrameworks>
+    <TargetFrameworksCI>MonoAndroid80;MonoAndroid90;xamarinios10;net461;netstandard2.0;xamarinmac20</TargetFrameworksCI>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -37,6 +37,17 @@
 	</ItemGroup>
 	
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid80'">
+		<PackageReference Include="Xamarin.Android.Support.v4">
+			<Version>26.1.0.1</Version>
+			<PrivateAssets>none</PrivateAssets>
+		</PackageReference>
+		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
+			<Version>26.1.0.1</Version>
+			<PrivateAssets>none</PrivateAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.Android.Support.v4">
 			<Version>26.1.0.1</Version>
 			<PrivateAssets>none</PrivateAssets>

--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -50,7 +50,7 @@ namespace Uno.UWPSyncGenerator
 
 			_referenceCompilation = LoadProject(@"..\..\..\..\Uno.UWPSyncGenerator.Reference\Uno.UWPSyncGenerator.Reference.csproj");
 			_iOSCompilation = LoadProject($@"{basePath}\{baseName}.csproj", "xamarinios10");
-			_androidCompilation = LoadProject($@"{basePath}\{baseName}.csproj", "MonoAndroid80");
+			_androidCompilation = LoadProject($@"{basePath}\{baseName}.csproj", "MonoAndroid90");
 			_net461Compilation = LoadProject($@"{basePath}\{baseName}.csproj", "net461");
 			_wasmCompilation = LoadProject($@"{basePath}\{baseName}.csproj", "netstandard2.0");
 			_macCompilation = LoadProject($@"{basePath}\{baseName}.csproj", "xamarinmac20");


### PR DESCRIPTION
## Android version upgrade
Upgraded the Android target from Android 8.0 to Android 9.0. As a first step before also updating support librairies


## What is the current behavior?
Uno Targets Android 8.0


## What is the new behavior?
Uno Targets both Android 8.0 and Android 9.0 using CI Pipelines
Uno Targets Android 9.0 when building locally


## PR Checklist

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Breaking Changes

You will not be able to debug projects targeting Android 8.0 locally anymore. Change your Android target to Android 9.0 or replace MonoAndroid90 by MonoAndroid80 in the TargetFrameworks of your uno projects files.


Internal Issue :
132095 - [Target MonoAndroid90](https://nventive.visualstudio.com/Umbrella/_workitems/edit/132095)
