### PR TITLE
Fix nullref in Pivot when using native default style

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -59,8 +59,8 @@
  * [Wasm] Disable the root element scrolling (bounce) on touch devices
  * Fixed invalid iOS assets folder. `ImageAsset` nodes must not be `<Visible>false</Visible>` to be copied to the generated project.
  * Make CollectionViewSource.View a proper DependencyProperty (#697)
-
  * Fixed support for string support for `Path.Data` (#698)
+ * 150018 Fix nullref in `Pivot` when using native style
 
 ## Release 1.43.1
 

--- a/src/Uno.UI/UI/Xaml/Controls/Pivot/Pivot.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Pivot/Pivot.cs
@@ -55,11 +55,14 @@ namespace Windows.UI.Xaml.Controls
 
 		private void UnregisterHeaderEvents()
 		{
-			foreach (var item in _staticHeader.Children)
+			if (_staticHeader != null)
 			{
-				if (item is PivotHeaderItem pivotHeaderItem)
+				foreach (var item in _staticHeader.Children)
 				{
-					pivotHeaderItem.PointerPressed -= OnItemPointerPressed;
+					if (item is PivotHeaderItem pivotHeaderItem)
+					{
+						pivotHeaderItem.PointerPressed -= OnItemPointerPressed;
+					}
 				}
 			}
 		}
@@ -68,11 +71,14 @@ namespace Windows.UI.Xaml.Controls
 		{
 			UnregisterHeaderEvents();
 
-			foreach (var item in _staticHeader.Children)
+			if (_staticHeader != null)
 			{
-				if (item is PivotHeaderItem pivotHeaderItem)
+				foreach (var item in _staticHeader.Children)
 				{
-					pivotHeaderItem.PointerPressed += OnItemPointerPressed;
+					if (item is PivotHeaderItem pivotHeaderItem)
+					{
+						pivotHeaderItem.PointerPressed += OnItemPointerPressed;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## PR Type
- Bugfix

## What is the current behavior?
You **can't** use the native default style of Pivot for both Android and iOS.

## What is the new behavior?
You **can** use the native default style of Pivot for both Android and iOS.

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/149965
