### PR TITLE
Paths were broken in Wasm

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -237,6 +237,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_Simple.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressRing.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1351,6 +1355,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Models\ImageWithLateSourceViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\TimePickerViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\NavigationViewTests\NavigationView_TopNavigation.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_Simple.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressRing.xaml.cs">
       <DependentUpon>ProgressRing.xaml</DependentUpon>
     </Compile>
@@ -1941,6 +1946,9 @@
     <PRIResource Include="$(MSBuildThisFileDirectory)UITestsStrings\en-US\Resources.resw" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Popup\Popup_Simple.xaml.cs">
+      <DependentUpon>Popup_Simple.xaml</DependentUpon>
+    </Compile>
     <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Slider\Slider_Transformed.xaml.cs">
       <DependentUpon>Slider_Transformed.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Simple.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Simple.xaml
@@ -1,0 +1,68 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.Popup.Popup_Simple" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="GenericApp.Views.Content.UITests.Popup"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://nventive.com/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://nventive.com/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Description for sample of Popup_Simple">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel>
+					<!-- Insert your code sample here -->
+					<TextBlock Text="This Toggle Button should open a Dismissable Popup" />
+					<ToggleButton x:Name="TogglePopup"/>
+					<Popup IsOpen="{Binding IsChecked, ElementName=TogglePopup, Mode=TwoWay}"
+						    HorizontalOffset="200"
+						   VerticalOffset="200"
+						   IsLightDismissEnabled="True">
+						<Popup.Child>
+							<Border Height="100"
+									Width="150"
+									Background="Red">
+								<TextBlock Text="Test" />
+							</Border>
+						</Popup.Child>
+					</Popup>
+					<TextBlock Text="This Toggle Button should open a NON-Dismissable Popup" />
+					<ToggleButton x:Name="TogglePopup2"/>
+					<Popup IsOpen="{Binding IsChecked, ElementName=TogglePopup2}"
+						   HorizontalOffset="300"
+						   VerticalOffset="300"
+						   IsLightDismissEnabled="False">
+						<Popup.Child>
+							<Border Height="100"
+									Width="150"
+									Background="Orange">
+								<TextBlock Text="Test" />
+							</Border>
+						</Popup.Child>
+					</Popup>
+					<TextBlock Text="This Toggle Button should open a Popup without fixed height" />
+					<ToggleButton x:Name="TogglePopup3"/>
+					<Popup IsOpen="{Binding IsChecked, ElementName=TogglePopup3, Mode=TwoWay}"
+						    HorizontalOffset="400"
+						   VerticalOffset="400"
+						   IsLightDismissEnabled="True">
+						<Popup.Child>
+							<Border Width="150"
+									Background="Blue">
+								<TextBlock Text="Test" />
+							</Border>
+						</Popup.Child>
+					</Popup>
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Simple.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/Popup_Simple.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.Popup
+{
+	[SampleControlInfoAttribute("Popup", "Popup_Simple")]
+	public sealed partial class Popup_Simple : UserControl
+	{
+		public Popup_Simple()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/Media/GeometryConverter.cs
+++ b/src/Uno.UI/Media/GeometryConverter.cs
@@ -21,7 +21,7 @@ namespace Uno.Media
 		{
 			if (value is string pathString)
 			{
-				return Parsers.ParseGeometry(pathString, CultureInfo.InvariantCulture);
+				return Parsers.ParseGeometry(pathString);
 			}
 
 			return base.ConvertFrom(context, culture, value);

--- a/src/Uno.UI/Media/GeometryConverter.cs
+++ b/src/Uno.UI/Media/GeometryConverter.cs
@@ -13,7 +13,7 @@ namespace Uno.Media
 			{
 				return true;
 			}
-			
+
 			return base.CanConvertFrom(context, sourceType);
 		}
 
@@ -21,7 +21,7 @@ namespace Uno.Media
 		{
 			if (value is string pathString)
 			{
-				return Parsers.ParseGeometry(pathString);
+				return (Geometry)pathString;
 			}
 
 			return base.ConvertFrom(context, culture, value);

--- a/src/Uno.UI/Media/Parsers.cs
+++ b/src/Uno.UI/Media/Parsers.cs
@@ -1,15 +1,14 @@
 ﻿using Windows.UI.Xaml.Media;
-using System;
 
 namespace Uno.Media
 {
 	static class Parsers
 	{
-		internal static Geometry ParseGeometry(string pathString, IFormatProvider formatProvider)
+		internal static Geometry ParseGeometry(string pathString)
 		{
-			FillRule fillRule = FillRule.EvenOdd;
+			var fillRule = FillRule.EvenOdd;
 			var streamGeometry = new StreamGeometry();
-			using (StreamGeometryContext context = streamGeometry.Open())
+			using (var context = streamGeometry.Open())
 			{
 				var parser = new PathMarkupParser(context);
 				parser.Parse(pathString, ref fillRule);

--- a/src/Uno.UI/UI/Xaml/Media/Geometry.cs
+++ b/src/Uno.UI/UI/Xaml/Media/Geometry.cs
@@ -1,5 +1,4 @@
 ﻿using System.Drawing;
-using System.Globalization;
 using Windows.UI.Xaml;
 using System;
 using System.ComponentModel;
@@ -30,9 +29,13 @@ namespace Windows.UI.Xaml.Media
 			InitializeBinder();
 		}
 
-		public static implicit operator Geometry(string path)
+		public static implicit operator Geometry(string data)
 		{
-			return Parsers.ParseGeometry(path, CultureInfo.InvariantCulture);
+#if __WASM__
+			return new GeometryData(data);
+#else
+			return Parsers.ParseGeometry(data);
+#endif
 		}
 
 		#region Transform


### PR DESCRIPTION
## Bugfix
The PR #698 introduced a bug on Wasm where "Data Path" were not properly translated to `DataGeometry` (a type used to hold a path data instead on parsing it).

## What is the current behavior?
The parsing of the _Data Path_ was not working properly on Wasm.

## What is the new behavior?
Old behavior has been restored, but only on Wasm.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- ~~[ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~
- [X] Contains **NO** breaking changes
- ~~[ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)~~
- ~~[ ] Associated with an issue (GitHub or internal)~~

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
