### PR TITLE
Add breaking changes validation

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -91,7 +91,7 @@ jobs:
 
   - task: PublishBuildArtifacts@1
     # https://developercommunity.visualstudio.com/content/problem/284991/public-vsts-previouw-cant-set-build-number-of-pr-b.html
-    condition: eq(variables['System.PullRequest.IsFork'], 'False')
+    condition: always()
     inputs:
       PathtoPublish: $(build.artifactstagingdirectory)
       ArtifactName: NugetPackages

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -35,13 +35,52 @@
                 reason="Removed unused type" />
         <Member fullName="Uno.UI.BaseFragment Uno.UI.Extensions.FragmentManagerExtensions.GetCurrentFragment(Android.App.FragmentManager fragmentManager)"
                 reason="Removed unused type" />
+
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.Canvas.add_PointerPressed(Windows.UI.Xaml.Input.PointerEventHandler value)"
+                reason="Removed as Routed Events implement it properly" />
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.Canvas.remove_PointerPressed(Windows.UI.Xaml.Input.PointerEventHandler value)" 
+                reason="Removed as Routed Events implement it properly"/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.Canvas.TouchesBegan(Foundation.NSSet touches, UIKit.UIEvent evt)"
+                reason="Removed as Routed Events implement it properly" />
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.TextBlock.TouchesBegan(Foundation.NSSet touches, UIKit.UIEvent evt)"
+                reason="Removed as Routed Events implement it properly" />
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.TextBlock.TouchesEnded(Foundation.NSSet touches, UIKit.UIEvent evt)" 
+                reason="Removed as Routed Events implement it properly"/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.TextBlock.TouchesCancelled(Foundation.NSSet touches, UIKit.UIEvent evt)" 
+                reason="Removed as Routed Events implement it properly"/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.TextBox.add_KeyUp(Windows.UI.Xaml.Input.KeyEventHandler value)"
+                reason="Removed as Routed Events implement it properly" />
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.TextBox.remove_KeyUp(Windows.UI.Xaml.Input.KeyEventHandler value)"
+                reason="Removed as Routed Events implement it properly" />
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.TextBox.add_KeyDown(Windows.UI.Xaml.Input.KeyEventHandler value)" 
+                reason="Removed as Routed Events implement it properly"/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.TextBox.remove_KeyDown(Windows.UI.Xaml.Input.KeyEventHandler value)"
+                reason="Removed as Routed Events implement it properly" />
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.Primitives.Thumb.TouchesEnded(Foundation.NSSet touches, UIKit.UIEvent evt)"
+                reason="Removed as Routed Events implement it properly" />
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.Primitives.Thumb.TouchesBegan(Foundation.NSSet touches, UIKit.UIEvent evt)"
+                reason="Removed as Routed Events implement it properly" />
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.Primitives.Thumb.TouchesMoved(Foundation.NSSet touches, UIKit.UIEvent evt)" 
+                reason="Removed as Routed Events implement it properly"/>  
+        
       </Methods>
       
+      <Events>
+        <Member fullName="Windows.UI.Xaml.Input.PointerEventHandler Windows.UI.Xaml.Controls.Canvas::PointerPressed"
+                reason="Removed as Routed Events implement it properly" />
+        <Member fullName="Windows.UI.Xaml.Input.KeyEventHandler Windows.UI.Xaml.Controls.TextBox::KeyUp"
+                reason="Removed as Routed Events implement it properly" />
+        <Member fullName="Windows.UI.Xaml.Input.KeyEventHandler Windows.UI.Xaml.Controls.TextBox::KeyDown"
+                reason="Removed as Routed Events implement it properly" />
+      </Events>
+
       <Fields>
         <Member fullName="Windows.UI.Xaml.RoutedEventArgs Windows.UI.Xaml.RoutedEventArgs::Empty"
                 reason="Type was incorrectly changed in 1.43.1" />
         <Member fullName="Windows.UI.Xaml.DependencyProperty Windows.UI.Xaml.Controls.SymbolIcon::SymbolProperty"
                 reason="Type was incorrectly changed in 1.43.1" />
+        <Member fullName="Windows.UI.Xaml.DependencyProperty Windows.UI.Xaml.Controls.TimePicker::TimeProperty"
+                reason="Type was incorrectly marked as a field in 1.43.1" />
       </Fields>
 
       <Properties>

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<DiffIgnore>
+  <IgnoreSets>
+    <IgnoreSet baseVersion="1.43.1">
+      <Methods>
+        <Member fullName="System.Void Windows.UI.Xaml.WindowCreatedEventArgs..ctor()"
+                reason="Parameter-less ctor does not exist in UWP" />
+        
+        <Member fullName="System.Void Windows.UI.Xaml.RoutedEvent..ctor()"
+                reason="Parameter-less ctor does not exist in UWP" />
+
+        <Member fullName="System.Boolean Windows.UI.Xaml.Controls.TextBlock.OnTouchEvent(Android.Views.MotionEvent e)"
+                reason="Removed as Routed Events implement it properly" />
+        <Member fullName="System.Boolean Windows.UI.Xaml.Controls.Primitives.Thumb.DispatchTouchEvent(Android.Views.MotionEvent e)"
+                reason="Removed as Routed Events implement it properly" />
+
+        <Member fullName="Windows.Foundation.Rect Windows.UI.ViewManagement.InputPane.get_KeyboardRect()"
+                reason="Unused Uno specific property" />
+        <Member fullName="Windows.Foundation.Rect Windows.UI.ViewManagement.InputPane.get_NavigationBarRect()"
+                reason="Unused Uno specific property" />
+
+        <Member fullName="System.Void Uno.UI.IFragmentTracker.PushCreated(Android.App.Fragment fragment)"
+                reason="Removed unused type" />
+        <Member fullName="System.Void Uno.UI.IFragmentTracker.PushStart(Android.App.Fragment fragment)"
+                reason="Removed unused type" />
+        <Member fullName="System.Void Uno.UI.IFragmentTracker.PushPause(Android.App.Fragment fragment)"
+                reason="Removed unused type" />
+        <Member fullName="System.Void Uno.UI.IFragmentTracker.PushResume(Android.App.Fragment fragment)" 
+                reason="Removed unused type"/>
+        <Member fullName="System.Void Uno.UI.IFragmentTracker.PushViewCreated(Android.App.Fragment fragment)"
+                reason="Removed unused type" />
+        <Member fullName="System.Void Uno.UI.IFragmentTracker.PushStop(Android.App.Fragment fragment)"
+                reason="Removed unused type" />
+        <Member fullName="System.Void Uno.UI.IFragmentTracker.PushDestroyed(Android.App.Fragment fragment)"
+                reason="Removed unused type" />
+        <Member fullName="Uno.UI.BaseFragment Uno.UI.Extensions.FragmentManagerExtensions.GetCurrentFragment(Android.App.FragmentManager fragmentManager)"
+                reason="Removed unused type" />
+      </Methods>
+      
+      <Fields>
+        <Member fullName="Windows.UI.Xaml.RoutedEventArgs Windows.UI.Xaml.RoutedEventArgs::Empty"
+                reason="Type was incorrectly changed in 1.43.1" />
+        <Member fullName="Windows.UI.Xaml.DependencyProperty Windows.UI.Xaml.Controls.SymbolIcon::SymbolProperty"
+                reason="Type was incorrectly changed in 1.43.1" />
+      </Fields>
+
+      <Properties>
+        <Member fullName="Windows.Foundation.Rect Windows.UI.ViewManagement.InputPane::KeyboardRect()"
+                reason="Unused Uno specific property" />
+        <Member fullName="Windows.Foundation.Rect Windows.UI.ViewManagement.InputPane::NavigationBarRect()"
+                reason="Unused Uno specific property" />
+      </Properties>
+    </IgnoreSet>
+  </IgnoreSets>
+</DiffIgnore>

--- a/build/Uno.UI.proj
+++ b/build/Uno.UI.proj
@@ -152,6 +152,11 @@
     <Exec Command="$(NuGetBin) pack Uno.UI.Lottie.nuspec -Verbosity Detailed -Version &quot;$(GITVERSION_FullSemVer)&quot;" />
   </Target>
 
+  <Target Name="ValidatePackage" AfterTargets="Build">
+    <Exec Command="dotnet tool install --global Uno.PackageDiff --version 1.0.0-dev.6" IgnoreExitCode="true" />
+    <Exec Command="generatepkgdiff --base=Uno.UI --other=Uno.UI.$(GITVERSION_FullSemVer).nupkg --diffignore=PackageDiffIgnore.xml --outfile=$(OutputDir)\diff.md" />
+  </Target>
+
   <Import Project="GetMsBuildVersion.targets" />
 
 </Project>

--- a/build/Uno.UI.proj
+++ b/build/Uno.UI.proj
@@ -154,7 +154,7 @@
 
   <Target Name="ValidatePackage" AfterTargets="Build">
     <Exec Command="dotnet tool install --global Uno.PackageDiff --version 1.0.0-dev.6" IgnoreExitCode="true" />
-    <Exec Command="generatepkgdiff --base=Uno.UI --other=Uno.UI.$(GITVERSION_FullSemVer).nupkg --diffignore=PackageDiffIgnore.xml --outfile=$(OutputDir)\diff.md" />
+    <Exec Command="generatepkgdiff --base=Uno.UI --other=Uno.UI.$(GITVERSION_FullSemVer).nupkg --diffignore=PackageDiffIgnore.xml --outfile=$(OutputDir)\ApiDiff.$(GITVERSION_FullSemVer).md" />
   </Target>
 
   <Import Project="GetMsBuildVersion.targets" />

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -44,6 +44,11 @@
 ### Breaking changes
 * Make `UIElement.IsPointerPressed` and `IsPointerOver` internal
 * You will not be able to build projects targeting Android 8.0 locally anymore. Change your Android target to Android 9.0 or replace MonoAndroid90 by MonoAndroid80 in the TargetFrameworks of your projects files.
+* 1.43.1 breaking changes rollback to 1.42.0:
+    - `ObservableVector<T>` is now internal again
+    - `TimePicker.Time` and `TimePicker.MinuteIncrement` are now back for `netstandard2.0`
+    - `MediaPlaybackItem.Source` is back as a readonly property
+    - `MediaPlaybackList.Items` is back to an `IObservableVector`
 
 ### Bug fixes
  * Transforms are now fully functionnal

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -39,6 +39,7 @@
 * Fixed support for dots in resource names (#700)
 * Add support for `BindingExpression.UpdateSource()`
 * Updated Android version to target Android 9.0
+* The CI validates for API breaking changes
 
 ### Breaking changes
 * Make `UIElement.IsPointerPressed` and `IsPointerOver` internal

--- a/doc/articles/debugging-uno-ui.md
+++ b/doc/articles/debugging-uno-ui.md
@@ -51,6 +51,19 @@ Once Uno.UI built, open the files you want to debug inside the solution running 
 The Uno solution provides a set of sample applications that provide a way to test features, as
 well as provide a way to write UI Tests. See [this document](working-with-the-samples-apps.md) for more information.
 
+## Using the Package Diff tool
+
+Uno uses a [Package Diff tool](https://github.com/nventive/Uno.PackageDiff) to ensure that binary breaking changes do not
+go unnoticed. Binary breaking changes are making packages depending on Uno.UI unuseable, as the IL Linker is crawling all
+the code of all assemblies.
+
+The package diff tool is run on every Pull Request, and generates a markdown document that can be found in the build artifacts. The
+CI will use the last published non-experimental package available on nuget.org, and compare it with the output of the current PR.
+
+In most cases, breaking changes are not acceptable, but in cases where there is no easy work around, the
+[build/PackageDiffIgnore.xml](build/PackageDiffIgnore.xml) can be used to make diff exclusions. Please refer
+to the documentation of the [Uno.PackageDiff tool](https://github.com/nventive/Uno.PackageDiff) for more information.
+
 ## Building Uno.UI for macOS using Visual Studio for Mac
 
 Building Uno.UI for the macOS platform using vs4mac requires Visual Studio for mac 7.7 preview or later.
@@ -149,7 +162,7 @@ You'll also need to add the following logger filter:
 	{ "Uno.UI.DataBinding.BinderReferenceHolder", LogLevel.Information },
 ```
 
-### Interpeting the statistics output
+### Interpreting the statistics output
 
 The output provides two sets of DependencyObject in memory:
 - Active, for which the instances have a parent dependency object (e.g. an item in a Grid)

--- a/src/Uno.Foundation/Collections/ObservableVector.cs
+++ b/src/Uno.Foundation/Collections/ObservableVector.cs
@@ -6,7 +6,7 @@ using Windows.Foundation.Collections;
 
 namespace Windows.Foundation.Collections
 {
-	public class ObservableVector<T> : IObservableVector<T>
+	internal class ObservableVector<T> : IObservableVector<T>
 	{
 		private readonly List<T> _list = new List<T>();
 

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePicker.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml.Controls/TimePicker.cs
@@ -7,6 +7,34 @@ namespace Windows.UI.Xaml.Controls
 	#endif
 	public  partial class TimePicker : global::Windows.UI.Xaml.Controls.Control
 	{
+		#if false || false || NET461 || __WASM__ || false
+		[global::Uno.NotImplemented]
+		public  global::System.TimeSpan Time
+		{
+			get
+			{
+				return (global::System.TimeSpan)this.GetValue(TimeProperty);
+			}
+			set
+			{
+				this.SetValue(TimeProperty, value);
+			}
+		}
+		#endif
+		#if false || false || NET461 || __WASM__ || false
+		[global::Uno.NotImplemented]
+		public  int MinuteIncrement
+		{
+			get
+			{
+				return (int)this.GetValue(MinuteIncrementProperty);
+			}
+			set
+			{
+				this.SetValue(MinuteIncrementProperty, value);
+			}
+		}
+		#endif
 		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  global::Windows.UI.Xaml.DataTemplate HeaderTemplate
@@ -80,10 +108,24 @@ namespace Windows.UI.Xaml.Controls
 			"HeaderTemplate", typeof(global::Windows.UI.Xaml.DataTemplate), 
 			typeof(global::Windows.UI.Xaml.Controls.TimePicker), 
 			new FrameworkPropertyMetadata(default(global::Windows.UI.Xaml.DataTemplate)));
-#endif
-
-		// Skipping already declared property TimeProperty
-#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#endif
+		#if false || false || NET461 || __WASM__ || false
+		[global::Uno.NotImplemented]
+		public static global::Windows.UI.Xaml.DependencyProperty MinuteIncrementProperty { get; } = 
+		Windows.UI.Xaml.DependencyProperty.Register(
+			"MinuteIncrement", typeof(int), 
+			typeof(global::Windows.UI.Xaml.Controls.TimePicker), 
+			new FrameworkPropertyMetadata(default(int)));
+		#endif
+		#if false || false || NET461 || __WASM__ || false
+		[global::Uno.NotImplemented]
+		public static global::Windows.UI.Xaml.DependencyProperty TimeProperty { get; } = 
+		Windows.UI.Xaml.DependencyProperty.Register(
+			"Time", typeof(global::System.TimeSpan), 
+			typeof(global::Windows.UI.Xaml.Controls.TimePicker), 
+			new FrameworkPropertyMetadata(default(global::System.TimeSpan)));
+		#endif
+		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public static global::Windows.UI.Xaml.DependencyProperty LightDismissOverlayModeProperty { get; } = 
 		Windows.UI.Xaml.DependencyProperty.Register(

--- a/src/Uno.UWP/Media/Playback/MediaPlaybackItem.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlaybackItem.cs
@@ -5,7 +5,7 @@ namespace Windows.Media.Playback
 {
 	public partial class MediaPlaybackItem : IMediaPlaybackSource
 	{
-		public MediaSource Source;
+		public MediaSource Source { get; }
 
 		public MediaPlaybackItem(MediaSource source)
 		{

--- a/src/Uno.UWP/Media/Playback/MediaPlaybackList.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlaybackList.cs
@@ -5,7 +5,7 @@ namespace Windows.Media.Playback
 {
 	public partial class MediaPlaybackList : IMediaPlaybackList, IMediaPlaybackSource
 	{
-		public ObservableVector<MediaPlaybackItem> Items { get; set; } = new ObservableVector<MediaPlaybackItem>();
+		public IObservableVector<MediaPlaybackItem> Items { get; } = new ObservableVector<MediaPlaybackItem>();
 	}
 }
 #endif


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Feature

## What is the current behavior?
API breaking changes are not visible, ending breaking tooling such as the IL Linker.


## What is the new behavior?
A [new check is added in the CI](https://github.com/nventive/Uno.PackageDiff) that validates the presence of API breaking changes. 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
