### PR TITLE
Fix ComboBox not working when using Popover on iOS.

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -63,6 +63,7 @@
  * Make CollectionViewSource.View a proper DependencyProperty (#697)
  * Fixed support for string support for `Path.Data` (#698)
  * 150018 Fix nullref in `Pivot` when using native style
+ * 150156 Fix `ComboBox` not working when using `Popover`.
 
 ## Release 1.43.1
 

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -234,7 +234,7 @@ namespace Windows.UI.Xaml.Controls
 					control.ApplyTemplate();
 				}
 
-				if (_popup is Popup popup)
+				if (_popup is PopupBase popup)
 				{
 					if (IsPopupFullscreen) // Legacy
 					{


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Using Popover in a ComboBox style doesn't work.

## What is the new behavior?
Using Popover in a ComboBox style works.

## PR Checklist

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/150156
