### PR TITLE
Don't set HAS_UNO for uap10.0.x

### DIFF
--- a/build/uno.ui.targets
+++ b/build/uno.ui.targets
@@ -8,7 +8,9 @@
 
 	<Import Project="$(SourceGeneratorBasePath)Uno.UI.SourceGenerators.props" />
 	<Import Project="$(UnoUIMSBuildTasksTargetPath)Uno.UI.Tasks.targets" />
-	<Target Name="_UnoFeatureDefines" BeforeTargets="BeforeCompile">
+	<Target Name="_UnoFeatureDefines"
+            BeforeTargets="BeforeCompile"
+            Condition="'$(TargetFramework)'=='netstandard2.0' or $(TargetFramework.ToLower().StartsWith('monoandroid')) or $(TargetFramework.ToLower().StartsWith('xamarinios')) or $(TargetFramework.ToLower().StartsWith('xamarinmac'))">
 
 		<!-- 
 			Defines Uno features. 

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -7,6 +7,7 @@
 ### Breaking Changes
 
 ### Bug fixes
+* The `HAS_UNO` define is now not defined in `uap10.0.x` target frameworks.
 
 ## Release 1.44.0
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Including the Uno.UI package adds the `HAS_UNO` define in `uap10.0.x` targets.

## What is the new behavior?
The `HAS_UNO` is only available for netstandard 2.0, Xamarin mac/iOS/Android.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
