### PR TITLE
Fixed MediaElementButtons not working properly on iOS

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -51,6 +51,7 @@
 * Updated Android version to target Android 9.0
 * The CI validates for API breaking changes
 * Added samples application BenchmarkDotNet support.
+* `MediaTransportControls` buttons now use Tapped event instead of Click
 
 ### Breaking changes
 * Make `UIElement.IsPointerPressed` and `IsPointerOver` internal

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControls.MediaPlayer.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControls.MediaPlayer.cs
@@ -39,13 +39,13 @@ namespace Windows.UI.Xaml.Controls
 			_mediaPlayer.PlaybackSession.NaturalDurationChanged += OnNaturalDurationChanged;
 			_mediaPlayer.PlaybackSession.PositionChanged += OnPositionChanged;
 
-			_playPauseButton.Maybe(p => p.Click += PlayPause);
-			_playPauseButtonOnLeft.Maybe(p => p.Click += PlayPause);
-			_audioMuteButton.Maybe(p => p.Click += ToggleMute);
+			_playPauseButton.Maybe(p => p.Tapped += PlayPause);
+			_playPauseButtonOnLeft.Maybe(p => p.Tapped += PlayPause);
+			_audioMuteButton.Maybe(p => p.Tapped += ToggleMute);
 			_volumeSlider.Maybe(p => p.ValueChanged += OnVolumeChanged);
-			_stopButton.Maybe(p => p.Click += Stop);
-			_skipForwardButton.Maybe(p => p.Click += SkipForward);
-			_skipBackwardButton.Maybe(p => p.Click += SkipBackward);
+			_stopButton.Maybe(p => p.Tapped += Stop);
+			_skipForwardButton.Maybe(p => p.Tapped += SkipForward);
+			_skipBackwardButton.Maybe(p => p.Tapped += SkipBackward);
 
 			_subscriptions.Disposable = AttachThumbEventHandlers(_progressSlider);
 		}
@@ -74,13 +74,13 @@ namespace Windows.UI.Xaml.Controls
 					_mediaPlayer.PlaybackSession.PositionChanged -= OnPositionChanged;
 				}
 
-				_playPauseButton.Maybe(p => p.Click -= PlayPause);
-				_playPauseButtonOnLeft.Maybe(p => p.Click -= PlayPause);
-				_audioMuteButton.Maybe(p => p.Click -= ToggleMute);
+				_playPauseButton.Maybe(p => p.Tapped -= PlayPause);
+				_playPauseButtonOnLeft.Maybe(p => p.Tapped -= PlayPause);
+				_audioMuteButton.Maybe(p => p.Tapped -= ToggleMute);
 				_volumeSlider.Maybe(p => p.ValueChanged -= OnVolumeChanged);
-				_stopButton.Maybe(p => p.Click -= Stop);
-				_skipForwardButton.Maybe(p => p.Click -= SkipForward);
-				_skipBackwardButton.Maybe(p => p.Click -= SkipBackward);
+				_stopButton.Maybe(p => p.Tapped -= Stop);
+				_skipForwardButton.Maybe(p => p.Tapped -= SkipForward);
+				_skipBackwardButton.Maybe(p => p.Tapped -= SkipBackward);
 			}
 			catch (Exception ex)
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControls.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaTransportControls.cs
@@ -174,8 +174,8 @@ namespace Windows.UI.Xaml.Controls
 			{
 				_fullWindowButton.SetBinding(Button.VisibilityProperty, new Binding { Path = "IsFullWindowButtonVisible", Source = this, Mode = BindingMode.OneWay, FallbackValue = Visibility.Collapsed, Converter = trueToVisible });
 				_fullWindowButton.SetBinding(Button.IsEnabledProperty, new Binding { Path = "IsFullWindowEnabled", Source = this, Mode = BindingMode.OneWay, FallbackValue = true });
-				_fullWindowButton.Click -= FullWindowButtonClick;
-				_fullWindowButton.Click += FullWindowButtonClick;
+				_fullWindowButton.Tapped -= FullWindowButtonClick;
+				_fullWindowButton.Tapped += FullWindowButtonClick;
 			}
 
 			_castButton = this.GetTemplateChild(CastButtonName) as Button;
@@ -186,8 +186,8 @@ namespace Windows.UI.Xaml.Controls
 			{
 				_zoomButton?.SetBinding(Button.VisibilityProperty, new Binding { Path = "IsZoomButtonVisible", Source = this, Mode = BindingMode.OneWay, FallbackValue = Visibility.Collapsed, Converter = trueToVisible });
 				_zoomButton?.SetBinding(Button.IsEnabledProperty, new Binding { Path = "IsZoomEnabled", Source = this, Mode = BindingMode.OneWay, FallbackValue = true });
-				_zoomButton.Click -= ZoomButtonClick;
-				_zoomButton.Click += ZoomButtonClick;
+				_zoomButton.Tapped -= ZoomButtonClick;
+				_zoomButton.Tapped += ZoomButtonClick;
 			}
 
 			_playbackRateButton = this.GetTemplateChild(PlaybackRateButtonName) as Button;


### PR DESCRIPTION
## Bugfix 


## What is the current behavior?
MediaElement Buttons are not working.


## What is the new behavior?
MediaElement buttons trigger the right action when tapped


## PR Checklist

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue 
[https://nventive.visualstudio.com/Umbrella/_workitems/edit/150083](https://nventive.visualstudio.com/Umbrella/_workitems/edit/150083)
