### PR TITLE
Fix ButtonBase click and tapped events

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ insert_final_newline = true
 [{*.xaml, *.xml, *.targets, *.props}]
 indent_style = tab
 
-[{*.cs, *.tt}]
+[{*.cs, *.tt, *.java}]
 indent_style = tab
 
 [{*.ts, *.json}]
@@ -98,7 +98,7 @@ csharp_space_after_keywords_in_control_flow_statements = true
 # http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_after_semicolon_in_for_statement
 csharp_space_after_semicolon_in_for_statement = true
 
-# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_around_binary_operators 
+# http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_around_binary_operators
 csharp_space_around_binary_operators = before_and_after
 
 # http://kent-boogaart.com/blog/editorconfig-reference-for-c-developers#csharp_space_around_declaration_statements

--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -23,6 +23,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="..\src\Directory.Build.targets" Link="Directory.Build.targets" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="docfx.console" Version="2.36.0" />
     <PackageReference Include="Microsoft.VisualStudio.TextTemplating.15.0">
       <Version>15.8.28010</Version>

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -16,6 +16,7 @@
 ### Bug fixes
 * The `HAS_UNO` define is now not defined in `uap10.0.x` target frameworks.
 * The `XamlReader` fails when a property has no getter
+* `Click` and `Tapped` events were not working property for `ButtonBase` on Android and iOS.
 
 ## Release 1.44.0
 

--- a/src/AddIns/Uno.UI.Lottie/Uno.UI.Lottie.csproj
+++ b/src/AddIns/Uno.UI.Lottie/Uno.UI.Lottie.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
+﻿<Project Sdk="MSBuild.Sdk.Extras" ToolsVersion="15.0">
 
 	<PropertyGroup>
 		<TargetFrameworks>xamarinmac20;MonoAndroid90;xamarinios10;net461;netstandard2.0</TargetFrameworks>
@@ -10,13 +10,8 @@
 
 	<ItemGroup>
 		<EmbeddedResource Include="WasmScripts\**\*.js" />
-
+		<UpToDateCheckInput Remove="WasmScripts\uno-lottie.js" />
 		<UpToDateCheckInput Include="ts\**\*" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <UpToDateCheckInput Remove="ts\lottie-web.d.ts" />
-	  <UpToDateCheckInput Remove="ts\Uno.UI.Lottie.ts" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -189,6 +189,90 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\AppBarButtonTest.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\AppBarButtonWithIconTest.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\AppBarToggleButtonTest.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Buttons.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_IsEnabled.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\CheckBox_Button.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\CheckBox_Button_UWA_Style.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\CheckBox_Button_With_CanExecute_Changing.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\ComboBox_Simple.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Custom_Button_With_ContentTemplate.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Custom_Button_With_ContentTemplate_And_StackPanel.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Hyperlink_Button.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Hyperlink_CanExecute_False.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Hyperlink_Disabled.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Nested_Buttons.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Overlapped_Buttons.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\RadioButton_Multiple_Unnamed_Groups.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\RadioButton_With_GroupName.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Radio_Button.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Simple_Button.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Simple_Button_With_CanExecute_Changing.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\FlyoutTests\Flyout_Events.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -646,6 +730,10 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\RoutedEvents\RoutedEvent_Tapped.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\RoutedEvents\RoutedEvent_Tapped2.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -1239,6 +1327,28 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\BorderTests\ZeroThicknessWithRadius.xaml.cs">
       <DependentUpon>ZeroThicknessWithRadius.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\AppBarButtonTest.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\AppBarButtonWithIconTest.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\AppBarToggleButtonTest.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Buttons.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\ButtonTestsViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_IsEnabled.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\CheckBox_Button.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\CheckBox_Button_UWA_Style.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\CheckBox_Button_With_CanExecute_Changing.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\ComboBox_Simple.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Custom_Button_With_ContentTemplate.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Custom_Button_With_ContentTemplate_And_StackPanel.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Hyperlink_Button.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Hyperlink_CanExecute_False.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Hyperlink_Disabled.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Nested_Buttons.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Overlapped_Buttons.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\RadioButton_Multiple_Unnamed_Groups.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\RadioButton_With_GroupName.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Radio_Button.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Simple_Button.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Simple_Button_With_CanExecute_Changing.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\FlyoutTests\Flyout_Events.xaml.cs">
       <DependentUpon>Flyout_Events.xaml</DependentUpon>
     </Compile>
@@ -1574,6 +1684,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\RoutedEvents\RoutedEvent_Tapped.xaml.cs">
       <DependentUpon>RoutedEvent_Tapped.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\RoutedEvents\RoutedEvent_Tapped2.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\RoutedEvents\RoutedEvent_TappedControl.xaml.cs">
       <DependentUpon>RoutedEvent_TappedControl.xaml</DependentUpon>
     </Compile>
@@ -1946,11 +2057,77 @@
     <PRIResource Include="$(MSBuildThisFileDirectory)UITestsStrings\en-US\Resources.resw" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\AppBarButtonTest.xaml.cs">
+      <DependentUpon>AppBarButtonTest.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\AppBarButtonWithIconTest.xaml.cs">
+      <DependentUpon>AppBarButtonWithIconTest.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\AppBarToggleButtonTest.xaml.cs">
+      <DependentUpon>AppBarToggleButtonTest.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\Buttons.xaml.cs">
+      <DependentUpon>Buttons.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\Button_IsEnabled.xaml.cs">
+      <DependentUpon>Button_IsEnabled.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\CheckBox_Button.xaml.cs">
+      <DependentUpon>CheckBox_Button.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\CheckBox_Button_UWA_Style.xaml.cs">
+      <DependentUpon>CheckBox_Button_UWA_Style.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\CheckBox_Button_With_CanExecute_Changing.xaml.cs">
+      <DependentUpon>CheckBox_Button_With_CanExecute_Changing.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\ComboBox_Simple.xaml.cs">
+      <DependentUpon>ComboBox_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\Custom_Button_With_ContentTemplate.xaml.cs">
+      <DependentUpon>Custom_Button_With_ContentTemplate.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\Custom_Button_With_ContentTemplate_And_StackPanel.xaml.cs">
+      <DependentUpon>Custom_Button_With_ContentTemplate_And_StackPanel.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\Hyperlink_Button.xaml.cs">
+      <DependentUpon>Hyperlink_Button.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\Hyperlink_CanExecute_False.xaml.cs">
+      <DependentUpon>Hyperlink_CanExecute_False.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\Hyperlink_Disabled.xaml.cs">
+      <DependentUpon>Hyperlink_Disabled.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\Nested_Buttons.xaml.cs">
+      <DependentUpon>Nested_Buttons.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\Overlapped_Buttons.xaml.cs">
+      <DependentUpon>Overlapped_Buttons.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\RadioButton_Multiple_Unnamed_Groups.xaml.cs">
+      <DependentUpon>RadioButton_Multiple_Unnamed_Groups.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\RadioButton_With_GroupName.xaml.cs">
+      <DependentUpon>RadioButton_With_GroupName.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\Radio_Button.xaml.cs">
+      <DependentUpon>Radio_Button.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\Simple_Button.xaml.cs">
+      <DependentUpon>Simple_Button.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\Simple_Button_With_CanExecute_Changing.xaml.cs">
+      <DependentUpon>Simple_Button_With_CanExecute_Changing.xaml</DependentUpon>
+    </Compile>
     <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Popup\Popup_Simple.xaml.cs">
       <DependentUpon>Popup_Simple.xaml</DependentUpon>
     </Compile>
     <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Slider\Slider_Transformed.xaml.cs">
       <DependentUpon>Slider_Transformed.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Input\RoutedEvents\RoutedEvent_Tapped2.xaml.cs">
+      <DependentUpon>RoutedEvent_Tapped2.xaml</DependentUpon>
     </Compile>
     <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Lottie\SampleLottieAnimation.xaml.cs">
       <DependentUpon>SampleLottieAnimation.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/AppBarButtonTest.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/AppBarButtonTest.xaml
@@ -1,0 +1,32 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.AppBarButtonTest"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="urn:xamarin"
+	xmlns:ios="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d android"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="AppBarButton">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<ios:StackPanel >
+					<TextBlock Text="Sample AppBarButton with Text Content"/>
+					<AppBarButton Content="Content - Text" Label="AppBarButton - Label" Command="{Binding [SampleCommand]}"/>
+					<TextBlock Text="AppBarButton with Rectangle Content (Green Rectangle)"/>
+					<AppBarButton Label="AppBarButton - Label" Command="{Binding [SampleCommand]}">
+						<AppBarButton.Content>
+							<Rectangle Height="15" Width="25" Fill="Green"/>
+						</AppBarButton.Content>
+					</AppBarButton>
+				</ios:StackPanel>
+				<android:TextBlock Text="Not implemented for Android"/>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/AppBarButtonTest.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/AppBarButtonTest.xaml.cs
@@ -1,0 +1,15 @@
+﻿using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", nameof(AppBarButtonTest), typeof(ButtonTestsViewModel))]
+	public sealed partial class AppBarButtonTest : UserControl
+	{
+		public AppBarButtonTest()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/AppBarButtonWithIconTest.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/AppBarButtonWithIconTest.xaml
@@ -1,0 +1,30 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.AppBarButtonWithIconTest"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="urn:xamarin"
+	xmlns:ios="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d xamarin android"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="AppBarButtonWithIcon">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<ios:StackPanel >
+					<TextBlock Text="AppBarButton with PathIcon and no Content"/>
+					<AppBarButton Label="AppBarButton - Label" Command="{Binding [SampleCommand]}">
+						<AppBarButton.Icon>
+							<PathIcon Data="M15.483,20.522C12.747,20.522 10.511,18.286 10.511,15.55 10.511,12.747 12.747,10.511 15.483,10.511 18.253,10.511 20.489,12.747 20.489,15.55 20.489,18.286 18.253,20.522 15.483,20.522z M26.395,12.113C26.228,11.512 25.961,10.878 25.628,10.211 26.262,9.343 26.996,8.475 27.63,7.508 27.83,7.241 27.83,6.94 27.63,6.64 26.829,5.472 25.494,4.271 24.393,3.336 24.126,3.069 23.759,3.069 23.459,3.303L20.655,5.372C20.121,5.105,19.487,4.871,18.92,4.638L18.386,1.1C18.353,0.733,18.086,0.5,17.685,0.5L13.347,0.5C12.947,0.5 12.68,0.733 12.613,1.067 12.346,2.202 12.213,3.503 12.079,4.638 11.479,4.838 10.878,5.071 10.344,5.405L7.641,3.336C7.474,3.203 7.241,3.103 7.107,3.103 6.44,3.103 3.837,6.006 3.336,6.64 3.069,6.974 3.103,7.174 3.37,7.541 4.07,8.475 4.771,9.343 5.439,10.244 5.138,10.878 4.905,11.379 4.704,12.046L1.034,12.58C0.733,12.647,0.5,13.014,0.5,13.347L0.5,17.652C0.5,17.986,0.733,18.286,1.067,18.353L4.604,18.92C4.771,19.521 5.071,20.155 5.372,20.789 4.738,21.69 4.037,22.524 3.37,23.492 3.169,23.792 3.203,24.093 3.37,24.36 4.204,25.528 5.505,26.729 6.606,27.697 6.907,27.964 7.241,27.964 7.541,27.763L10.344,25.694C10.911,25.961,11.512,26.195,12.079,26.395L12.613,29.966C12.647,30.266,12.947,30.566,13.347,30.566L17.685,30.566C18.086,30.566 18.286,30.333 18.386,29.999 18.687,28.865 18.82,27.563 18.954,26.429 19.554,26.228 20.155,25.961 20.722,25.694L23.425,27.797C23.592,27.93 23.792,27.964 23.959,27.964 24.593,27.964 27.229,25.027 27.73,24.393 27.93,24.126 27.897,23.859 27.663,23.525 26.962,22.558 26.262,21.69 25.594,20.722 25.895,20.188 26.128,19.654 26.362,18.987L29.932,18.453C30.266,18.42,30.5,18.053,30.5,17.786L30.5,13.381C30.5,13.08,30.266,12.747,29.932,12.647z" />
+						</AppBarButton.Icon>
+					</AppBarButton>
+				</ios:StackPanel>
+				<android:TextBlock Text="Not implemented for Android"/>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/AppBarButtonWithIconTest.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/AppBarButtonWithIconTest.xaml.cs
@@ -1,0 +1,15 @@
+﻿using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", nameof(AppBarButtonWithIconTest), typeof(ButtonTestsViewModel))]
+	public sealed partial class AppBarButtonWithIconTest : UserControl
+	{
+		public AppBarButtonWithIconTest()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/AppBarToggleButtonTest.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/AppBarToggleButtonTest.xaml
@@ -1,0 +1,32 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.AppBarToggleButtonTest"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="urn:xamarin"
+	xmlns:ios="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d android"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="AppBarToggleButton">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<ios:StackPanel >
+					<TextBlock Text="AppBarToggleButton with Text Content"/>
+					<AppBarToggleButton Content="Content - Text" Label="AppBarToggleButton - Label" Command="{Binding [SampleCommand]}" />
+					<TextBlock Text="AppBarToggleButton with Rectangle Content (Green Rectangle)"/>
+					<AppBarToggleButton Label="AppBarToggleButton - Label" Command="{Binding [SampleCommand]}">
+						<AppBarToggleButton.Content>
+							<Rectangle Height="15" Width="25" Fill="Green"/>
+						</AppBarToggleButton.Content>
+					</AppBarToggleButton>
+				</ios:StackPanel>
+				<android:TextBlock Text="Not implemented for Android"/>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/AppBarToggleButtonTest.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/AppBarToggleButtonTest.xaml.cs
@@ -1,0 +1,15 @@
+﻿using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", nameof(AppBarToggleButtonTest), typeof(ButtonTestsViewModel))]
+	public sealed partial class AppBarToggleButtonTest : UserControl
+	{
+		public AppBarToggleButtonTest()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/ButtonTestsViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/ButtonTestsViewModel.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.Extensions;
+using Microsoft.Extensions.Logging;
+using Uno.Logging;
+using Uno.UI.Samples.UITests.Helpers;
+using System.Windows.Input;
+using Windows.UI.Core;
+using System.Runtime.CompilerServices;
+
+namespace Uno.UI.Samples.Presentation.SamplePages
+{
+	public class ButtonTestsViewModel : ViewModelBase
+	{
+		private int _myData;
+		private string _message = string.Empty;
+		private int comboBoxSimple_SelectedItem = 1;
+		private int[] comboBoxSimple_ItemsSource = new[] { 1, 2, 3 };
+
+		public ButtonTestsViewModel(CoreDispatcher dispatcher) : base(dispatcher)
+		{
+			StartData();
+
+			((Command)DisableCommand).ManualCanExecute = false;
+		}
+
+		private async void StartData()
+		{
+			var alternateEnableCommand = (Command)AlternateEnableCommand;
+
+			while (!CT.IsCancellationRequested)
+			{
+				await Task.Delay(1000);
+				MyData += 1;
+
+				alternateEnableCommand.ManualCanExecute = MyData % 2 == 0;
+			}
+		}
+
+		public int MyData
+		{
+			get => _myData;
+			set
+			{
+				_myData = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public string Message
+		{
+			get => _message;
+			set
+			{
+				_message = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public int ComboBoxSimple_SelectedItem
+		{
+			get => comboBoxSimple_SelectedItem;
+			set
+			{
+				comboBoxSimple_SelectedItem = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public int[] ComboBoxSimple_ItemsSource
+		{
+			get => comboBoxSimple_ItemsSource;
+			private set
+			{
+				comboBoxSimple_ItemsSource = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public ICommand ComboBoxSimple_GenerateNewList => CreateCommand(() =>
+		{
+			ComboBoxSimple_ItemsSource = ComboBoxSimple_ItemsSource.Select(x => x + 1).ToArray();
+		});
+
+		public ICommand SampleCommand => MsgCommand();
+
+		public ICommand SampleCommand2 => MsgCommand();
+
+		public ICommand AlternateEnableCommand => MsgCommand();
+
+		public ICommand DisableCommand => MsgCommand();
+
+		public ICommand CheckBox01_Command => MsgCommand();
+		public ICommand CheckBox02_Command => MsgCommand();
+		public ICommand CheckBox03_Command => MsgCommand();
+
+		public ICommand OuterCommand => MsgCommand();
+		public ICommand InnerCommand => MsgCommand();
+
+		public ICommand ComboBoxSimple_Command => CreateCommand<int>(i => WriteMsg($"ComboBoxSimple_Command - {i}"));
+
+		private ICommand MsgCommand([CallerMemberName] string commandName = null) => CreateCommand(() => WriteMsg(commandName));
+
+		private void DoStuff()
+		{
+			if (this.Log().IsEnabled(LogLevel.Warning))
+			{
+				this.Log().Warn("Do Stuff");
+			}
+
+			WriteMsg("SampleCommand !" + DateTime.Now);
+		}
+
+		private void DoOtherStuff()
+		{
+			if (this.Log().IsEnabled(LogLevel.Warning))
+			{
+				this.Log().Warn("Do Other Stuff");
+			}
+
+			WriteMsg("SampleCommand 2 !" + DateTime.Now);
+		}
+
+		private void WriteMsg(string m)
+		{
+			Message = $"{Message}\n{DateTime.Now}: {m}";
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_IsEnabled.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_IsEnabled.xaml
@@ -1,0 +1,35 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.Button_IsEnabled"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel>
+
+		<Button x:Name="Button"
+					Content="Button" />
+
+		<CheckBox x:Name="ButtonIsEnabled"
+					IsChecked="True"
+					Content="Button.IsEnabled"
+					Click="ButtonIsEnabled_Click" />
+
+		<CheckBox x:Name="ButtonCommand"
+					Content="Button.Command"
+					Click="ButtonCommand_Click" />
+
+		<CheckBox x:Name="ButtonCommandParameter"
+					Content="Button.CommandParameter"
+					Click="ButtonCommandParameter_Click" />
+
+		<CheckBox x:Name="ButtonCommandIsEnabled"
+					Content="Button.Command.IsEnabled"
+					Click="ButtonCommandIsEnabled_Click" />
+
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_IsEnabled.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Button_IsEnabled.xaml.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Windows.Input;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "Button_IsEnabled")]
+	public sealed partial class Button_IsEnabled : UserControl
+	{
+		public Button_IsEnabled()
+		{
+			this.InitializeComponent();
+		}
+
+		private void ButtonIsEnabled_Click(object sender, RoutedEventArgs args)
+		{
+			Button.IsEnabled = ButtonIsEnabled.IsChecked == true;
+		}
+
+		private void ButtonCommand_Click(object sender, RoutedEventArgs args)
+		{
+			Button.Command = ButtonCommand.IsChecked == true
+				? new Command { IsEnabled = ButtonCommandIsEnabled.IsChecked == true }
+				: null;
+		}
+
+		private void ButtonCommandParameter_Click(object sender, RoutedEventArgs args)
+		{
+			Button.CommandParameter = ButtonCommandParameter.IsChecked == true;
+		}
+
+		private void ButtonCommandIsEnabled_Click(object sender, RoutedEventArgs args)
+		{
+			if (Button.Command is Command command)
+			{
+				command.IsEnabled = ButtonCommandIsEnabled.IsChecked == true;
+			}
+		}
+
+		private class Command : ICommand
+		{
+			private bool _isEnabled;
+
+			public Command()
+			{
+				CanExecuteChanged += MyCommand_CanExecuteChanged;
+			}
+
+			public bool IsEnabled
+			{
+				get => _isEnabled;
+				set
+				{
+					if (_isEnabled != value)
+					{
+						_isEnabled = value;
+						CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+					}
+				}
+			}
+
+			#region ICommand
+
+			private void MyCommand_CanExecuteChanged(object sender, EventArgs e)
+			{
+			}
+
+			public event EventHandler CanExecuteChanged;
+
+			public bool CanExecute(object parameter)
+			{
+				return IsEnabled && parameter is bool b && b;
+			}
+
+			public void Execute(object parameter)
+			{
+			}
+
+			#endregion
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Buttons.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Buttons.xaml
@@ -1,0 +1,97 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.Buttons"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d xamarin ios android"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<Grid>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<StackPanel Grid.Column="0">
+			<HyperlinkButton Content="HyperlinkButton"
+							 Click="OnClick"
+							 Tapped="OnTapped"
+							 IsEnabled="{Binding IsEnabled}"
+							 Command="{Binding Command}"
+							 CommandParameter="Windows.UI.Xaml.Controls.HyperlinkButton" />
+			<HyperlinkButton Content="HyperlinkButton (NavigateUri)"
+							 Click="OnClick"
+							 Tapped="OnTapped"
+							 IsEnabled="{Binding IsEnabled}"
+							 Command="{Binding Command}"
+							 CommandParameter="Windows.UI.Xaml.Controls.HyperlinkButton"
+							 NavigateUri="http://nventive.com" />
+			<Button Content="Button"
+					Click="OnClick"
+					Tapped="OnTapped"
+					IsEnabled="{Binding IsEnabled}"
+					Command="{Binding Command}"
+					CommandParameter="Windows.UI.Xaml.Controls.Button" />
+			<ToggleButton Content="ToggleButton"
+						  Click="OnClick"
+						  Tapped="OnTapped"
+						  IsChecked="{Binding IsChecked}"
+						  IsEnabled="{Binding IsEnabled}"
+						  Command="{Binding Command}"
+						  CommandParameter="Windows.UI.Xaml.Controls.Primitives.ToggleButton" />
+			<CheckBox Content="CheckBox"
+					  Click="OnClick"
+					  Tapped="OnTapped"
+					  IsChecked="{Binding IsChecked}"
+					  IsEnabled="{Binding IsEnabled}"
+					  Command="{Binding Command}"
+					  CommandParameter="Windows.UI.Xaml.Controls.CheckBox" />
+			<RadioButton Content="RadioButton"
+						 Click="OnClick"
+						 Tapped="OnTapped"
+						 IsChecked="{Binding IsChecked}"
+						 IsEnabled="{Binding IsEnabled}"
+						 Command="{Binding Command}"
+						 CommandParameter="Windows.UI.Xaml.Controls.RadioButton" />
+			<TextBlock Text="Native styles (if applicable)"
+					   Margin="0,20,0,0"/>
+			<Button Content="Button"
+					android:Style="{StaticResource AndroidButtonStyle}"
+					ios:Style="{StaticResource iOSButtonStyle}"
+					Click="OnClick"
+					Tapped="OnTapped"
+					IsEnabled="{Binding IsEnabled}"
+					Command="{Binding Command}"
+					CommandParameter="Windows.UI.Xaml.Controls.Button" />
+			<CheckBox Content="CheckBox"
+					  android:Style="{StaticResource AndroidCheckBoxStyle}"
+					  Click="OnClick"
+					  Tapped="OnTapped"
+					  IsChecked="{Binding IsChecked}"
+					  IsEnabled="{Binding IsEnabled}"
+					  Command="{Binding Command}"
+					  CommandParameter="Windows.UI.Xaml.Controls.CheckBox" />
+			<RadioButton Content="RadioButton"
+						 android:Style="{StaticResource AndroidRadioButtonStyle}"
+						 Click="OnClick"
+						 Tapped="OnTapped"
+						 IsChecked="{Binding IsChecked}"
+						 IsEnabled="{Binding IsEnabled}"
+						 Command="{Binding Command}"
+						 CommandParameter="Windows.UI.Xaml.Controls.RadioButton" />
+		</StackPanel>
+		<StackPanel Grid.Column="1">
+			<CheckBox Content="IsEnabled"
+					  IsChecked="{Binding IsEnabled, Mode=TwoWay}" />
+			<CheckBox Content="IsChecked"
+					  IsChecked="{Binding IsChecked, Mode=TwoWay}" />
+			<Button Content="Clear"
+					Command="{Binding ClearCommand}" />
+			<ItemsControl ItemsSource="{Binding Output}" />
+		</StackPanel>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Buttons.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Buttons.xaml.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "Buttons")]
+	public sealed partial class Buttons : UserControl
+	{
+		private ButtonsViewModel _viewModel;
+
+		public Buttons()
+		{
+			this.InitializeComponent();
+
+			DataContext = _viewModel = new ButtonsViewModel();
+		}
+
+		private void OnClick(object sender, RoutedEventArgs e) => _viewModel.Log($"{sender}.Click");
+		private void OnTapped(object sender, TappedRoutedEventArgs e) => _viewModel.Log($"{sender}.Tapped");
+
+		protected override void OnTapped(TappedRoutedEventArgs e)
+		{
+			_viewModel.Log($"[page].Tapped, source={e.OriginalSource}");
+		}
+
+		protected override void OnPointerPressed(PointerRoutedEventArgs e)
+		{
+			_viewModel.Log($"[page].PointerPressed, source={e.OriginalSource}");
+		}
+
+		protected override void OnPointerReleased(PointerRoutedEventArgs e)
+		{
+			_viewModel.Log($"[page].PointerReleased, source={e.OriginalSource}");
+		}
+	}
+
+	public class ButtonsViewModel : INotifyPropertyChanged
+	{
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		public ButtonsViewModel()
+		{
+			Command = (ActionCommand)OnCommand;
+			ClearCommand = (ActionCommand)Clear;
+		}
+
+		private bool _isEnabled = true;
+		public bool IsEnabled
+		{
+			get { return _isEnabled; }
+			set
+			{
+				_isEnabled = value;
+				NotifyPropertyChanged();
+			}
+		}
+
+		private bool _isChecked = false;
+		public bool IsChecked
+		{
+			get { return _isChecked; }
+			set
+			{
+				_isChecked = value;
+				NotifyPropertyChanged();
+			}
+		}
+
+		public ICommand Command { get; private set; }
+		public ICommand ClearCommand { get; private set; }
+		public ObservableCollection<string> Output { get; } = new ObservableCollection<string>();
+
+		private void OnCommand(object sender) => Log($"{sender}.Command");
+
+		public void Clear() => Output.Clear();
+		public void Log(object parameter) => Output.Add(parameter.ToString());
+
+		private void NotifyPropertyChanged([CallerMemberName] string property = "*") => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(property));
+	}
+
+	public class ActionCommand : ICommand
+	{
+		private Action<object> _action;
+
+		public ActionCommand(Action action)
+		{
+			_action = new Action<object>(_ => action());
+		}
+
+		public ActionCommand(Action<object> action)
+		{
+			_action = action;
+		}
+
+#pragma warning disable CS0067
+		public event EventHandler CanExecuteChanged;
+
+		public bool CanExecute(object parameter) => true;
+
+		public void Execute(object parameter) => _action(parameter);
+
+		public static implicit operator ActionCommand(Action action) => new ActionCommand(action);
+		public static implicit operator ActionCommand(Action<object> action) => new ActionCommand(action);
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button.xaml
@@ -1,0 +1,51 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.CheckBox_Button"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:android="http://uno.ui/android"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:xamarin="urn:xamarin"
+	mc:Ignorable="d xamarin ios android"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="CheckBox_Button">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+
+				<StackPanel>
+
+					<TextBlock Text="Native Checkbox" />
+					<CheckBox Content="Checkbox"
+							  Command="{Binding [SampleCommand]}"
+							  android:Style="{StaticResource AndroidCheckBoxStyle}" />
+					<CheckBox Content="Checkbox"
+							  Command="{Binding [SampleCommand]}"
+							  android:Style="{StaticResource AndroidCheckBoxStyle}"
+							  IsChecked="true" />
+
+					<TextBlock Text="Checkbox with the default style from UWA" />
+					<CheckBox Content="UWACheckbox"
+							  Command="{Binding [SampleCommand]}" />
+					<CheckBox Content="UWACheckbox"
+							  Command="{Binding [SampleCommand]}"
+							  IsChecked="true" />
+
+					<TextBlock Text="Checkbox with the default style from UWA Disabled" />
+					<CheckBox Content="UWACheckbox"
+							  Command="{Binding [SampleCommand]}"
+							  IsEnabled="False" />
+					<CheckBox Content="UWACheckbox"
+							  Command="{Binding [SampleCommand]}"
+							  IsEnabled="False"
+							  IsChecked="true" />
+
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button.xaml.cs
@@ -1,0 +1,15 @@
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "CheckBox_Button", typeof(ButtonTestsViewModel))]
+	public sealed partial class CheckBox_Button : UserControl
+	{
+		public CheckBox_Button()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button_UWA_Style.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button_UWA_Style.xaml
@@ -1,0 +1,23 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.CheckBox_Button_UWA_Style" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+  
+	<controls:SampleControl SampleDescription="CheckBox_Button_UWA_Style">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<CheckBox Content="UWACheckbox" Command="{Binding [SampleCommand]}" />
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button_UWA_Style.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button_UWA_Style.xaml.cs
@@ -1,0 +1,15 @@
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "CheckBox_Button_UWA_Style", typeof(ButtonTestsViewModel))]
+	public sealed partial class CheckBox_Button_UWA_Style : UserControl
+	{
+		public CheckBox_Button_UWA_Style()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button_With_CanExecute_Changing.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button_With_CanExecute_Changing.xaml
@@ -1,0 +1,20 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.CheckBox_Button_With_CanExecute_Changing" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="urn:xamarin"
+	mc:Ignorable="d xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="CheckBox_Button_With_CanExecute_Changing">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<CheckBox Content="My Checkbox" Command="{Binding [AlternateEnableCommand]}" />
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button_With_CanExecute_Changing.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/CheckBox_Button_With_CanExecute_Changing.xaml.cs
@@ -1,0 +1,15 @@
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "CheckBox_Button_With_CanExecute_Changing", typeof(ButtonTestsViewModel))]
+	public sealed partial class CheckBox_Button_With_CanExecute_Changing : UserControl
+	{
+		public CheckBox_Button_With_CanExecute_Changing()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/ComboBox_Simple.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/ComboBox_Simple.xaml
@@ -1,0 +1,25 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.ComboBox_Simple" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="urn:xamarin"
+	mc:Ignorable="d xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="ComboBox_Simple">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel >
+					<ComboBox ItemsSource="{Binding [ComboBoxSimple_ItemsSource]}" SelectedItem="{Binding [ComboBoxSimple_SelectedItem]}" xamarin:Command="{Binding [ComboBoxSimple_Command]}"/>
+					<TextBlock Text="{Binding [ComboBoxSimple_SelectedItem]}" />
+					<TextBlock Text="{Binding [MyData]}" />
+					<Button Content="Generate new list" Command="{Binding [ComboBoxSimple_GenerateNewList]}" />
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/ComboBox_Simple.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/ComboBox_Simple.xaml.cs
@@ -1,0 +1,15 @@
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfoAttribute("Button", "ComboBox_Simple", typeof(ButtonTestsViewModel))]
+	public sealed partial class ComboBox_Simple : UserControl
+	{
+		public ComboBox_Simple()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Custom_Button_With_ContentTemplate.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Custom_Button_With_ContentTemplate.xaml
@@ -1,0 +1,26 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.Custom_Button_With_ContentTemplate"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="urn:xamarin"
+	mc:Ignorable="d xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Custom_Button_With_ContentTemplate">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<Button Content="{Binding [MyData]}" Command="{Binding [AlternateEnableCommand]}" >
+					<Button.ContentTemplate>
+						<DataTemplate>
+							<TextBlock Text="{Binding}" Foreground="Blue" />
+						</DataTemplate>
+					</Button.ContentTemplate>
+				</Button>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Custom_Button_With_ContentTemplate.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Custom_Button_With_ContentTemplate.xaml.cs
@@ -1,0 +1,16 @@
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "Custom_Button_With_ContentTemplate", typeof(ButtonTestsViewModel))]
+
+	public sealed partial class Custom_Button_With_ContentTemplate : UserControl
+	{
+		public Custom_Button_With_ContentTemplate()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Custom_Button_With_ContentTemplate_And_StackPanel.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Custom_Button_With_ContentTemplate_And_StackPanel.xaml
@@ -1,0 +1,122 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.Custom_Button_With_ContentTemplate_And_StackPanel" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="urn:xamarin"
+	mc:Ignorable="d xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<UserControl.Resources>
+		<Style x:Key="LabelButtonStyle"
+			   TargetType="Button">
+			<Setter Property="Background"
+					Value="{ThemeResource ButtonBackgroundThemeBrush}" />
+			<Setter Property="Foreground"
+					Value="{ThemeResource ButtonForegroundThemeBrush}" />
+			<Setter Property="BorderBrush"
+					Value="{ThemeResource ButtonBorderThemeBrush}" />
+			<Setter Property="BorderThickness"
+					Value="{ThemeResource ButtonBorderThemeThickness}" />
+			<Setter Property="HorizontalAlignment"
+					Value="Left" />
+			<Setter Property="VerticalAlignment"
+					Value="Center" />
+			<Setter Property="FontFamily"
+					Value="{ThemeResource ContentControlThemeFontFamily}" />
+			<Setter Property="FontWeight"
+					Value="SemiBold" />
+			<Setter Property="FontSize"
+					Value="{ThemeResource ControlContentThemeFontSize}" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="Button">
+						<Grid>
+							<Border x:Name="Border_"
+									BorderBrush="{TemplateBinding BorderBrush}"
+									BorderThickness="{TemplateBinding BorderThickness}"
+									Background="{TemplateBinding Background}"
+									Margin="0">
+								<ContentPresenter x:Name="ContentPresenter"
+												  AutomationProperties.AccessibilityView="Raw"
+												  ContentTemplate="{TemplateBinding ContentTemplate}"
+												  ContentTransitions="{TemplateBinding ContentTransitions}"
+												  Content="{TemplateBinding Content}"
+												  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+												  Margin="{TemplateBinding Padding}"
+												  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+							</Border>
+							<!--Suppress: NVX004-->
+							<Rectangle x:Name="FocusVisualWhite_"
+									   IsHitTestVisible="False"
+									   Opacity="0"
+									   Margin="-3"
+									   StrokeDashOffset="1.5"
+									   StrokeEndLineCap="Square"
+									   Stroke="{ThemeResource FocusVisualWhiteStrokeThemeBrush}"
+									   StrokeDashArray="1,1" />
+							<!--Suppress: NVX004-->
+							<Rectangle x:Name="FocusVisualBlack_"
+									   IsHitTestVisible="False"
+									   Opacity="0"
+									   Margin="-3"
+									   StrokeDashOffset="0.5"
+									   StrokeEndLineCap="Square"
+									   Stroke="{ThemeResource FocusVisualBlackStrokeThemeBrush}"
+									   StrokeDashArray="1,1" />
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</UserControl.Resources>
+	
+	<controls:SampleControl SampleDescription="Custom_Button_With_ContentTemplate_And_StackPanel">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel>
+					<Button Content="StackPanelButton" Command="{Binding [SampleCommand]}" >
+						<Button.ContentTemplate>
+							<DataTemplate>
+								<StackPanel>
+									<TextBlock Text="{Binding}" Foreground="Blue" />
+								</StackPanel>
+							</DataTemplate>
+						</Button.ContentTemplate>
+					</Button>
+					
+					<TextBlock Text="Button with button inside it" />
+					<Button Content="{Binding}"
+							Command="{Binding [SampleCommand]}"
+							Style="{StaticResource LabelButtonStyle}">
+						<Button.ContentTemplate>
+							<DataTemplate>
+								<StackPanel Padding="10"
+											Background="Green">
+									<TextBlock Text="Button1" Foreground="Blue" />
+									<Button Command="{Binding [SampleCommand2]}"
+											Style="{StaticResource LabelButtonStyle}">
+										<Button.ContentTemplate>
+											<DataTemplate>
+												<StackPanel Background="Yellow">
+													<TextBlock Text="Button2" Foreground="Red" />
+												</StackPanel>
+											</DataTemplate>
+										</Button.ContentTemplate>
+									</Button>
+								</StackPanel>
+							</DataTemplate>
+						</Button.ContentTemplate>
+					</Button>
+				
+				<TextBox Width="200"
+								 Height="100"/>
+				</StackPanel>
+				
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Custom_Button_With_ContentTemplate_And_StackPanel.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Custom_Button_With_ContentTemplate_And_StackPanel.xaml.cs
@@ -1,0 +1,16 @@
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "Custom_Button_With_ContentTemplate_And_StackPanel", typeof(ButtonTestsViewModel))]
+
+	public sealed partial class Custom_Button_With_ContentTemplate_And_StackPanel : UserControl
+	{
+		public Custom_Button_With_ContentTemplate_And_StackPanel()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Hyperlink_Button.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Hyperlink_Button.xaml
@@ -1,0 +1,22 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.Hyperlink_Button" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="urn:xamarin"
+	mc:Ignorable="d xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Hyperlink_Button">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel >
+					<HyperlinkButton Content="http://www.google.com" NavigateUri="http://www.google.com" />
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Hyperlink_Button.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Hyperlink_Button.xaml.cs
@@ -1,0 +1,16 @@
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "Hyperlink_Button", typeof(ButtonTestsViewModel))]
+
+	public sealed partial class Hyperlink_Button : UserControl
+	{
+		public Hyperlink_Button()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Hyperlink_CanExecute_False.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Hyperlink_CanExecute_False.xaml
@@ -1,0 +1,102 @@
+<UserControl
+	x:Class="nVentive.Umbrella.Views.UI.Samples.Content.UITests.ButtonTestsControl.Hyperlink_CanExecute_False"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://nventive.com/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://nventive.com/android"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<UserControl.Resources>
+		<Style x:Key="DefaultHyperlinkButtonStyle"
+			   TargetType="HyperlinkButton">
+			<Setter Property="Foreground"
+					Value="Blue" />
+			<Setter Property="Background"
+					Value="Transparent" />
+			<Setter Property="BorderThickness"
+					Value="0" />
+			<Setter Property="Padding"
+					Value="0,6,0,6" />
+			<Setter Property="HorizontalAlignment"
+					Value="Left" />
+			<Setter Property="VerticalAlignment"
+					Value="Center" />
+			<Setter Property="FontFamily"
+					Value="{ThemeResource ContentControlThemeFontFamily}" />
+			<Setter Property="FontSize"
+					Value="{ThemeResource ControlContentThemeFontSize}" />
+			<Setter Property="UseSystemFocusVisuals"
+					Value="True" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="HyperlinkButton">
+						<Grid x:Name="RootGrid">
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="PointerOver">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
+																		   Storyboard.TargetName="ContentPresenter">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Orange" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Pressed">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
+																		   Storyboard.TargetName="ContentPresenter">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Black" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Disabled">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
+																		   Storyboard.TargetName="ContentPresenter">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Red" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+							<ContentPresenter x:Name="ContentPresenter"
+											  AutomationProperties.AccessibilityView="Raw"
+											  BorderBrush="{TemplateBinding BorderBrush}"
+											  BorderThickness="{TemplateBinding BorderThickness}"
+											  Background="{TemplateBinding Background}"
+											  ContentTransitions="{TemplateBinding ContentTransitions}"
+											  Content="{TemplateBinding Content}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  Padding="{TemplateBinding Padding}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</UserControl.Resources>
+
+	<controls:SampleControl SampleDescription="Hyperlink_CanExecute_False">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel>
+					<TextBlock Text="Hyperlink should be red" />
+					<HyperlinkButton Content="http://www.google.com"
+									 NavigateUri="http://www.google.com"
+									 Command="{Binding [DisableCommand]}"
+									 Style="{StaticResource DefaultHyperlinkButtonStyle}" />
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Hyperlink_CanExecute_False.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Hyperlink_CanExecute_False.xaml.cs
@@ -1,0 +1,15 @@
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace nVentive.Umbrella.Views.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "Hyperlink_CanExecute_False", typeof(ButtonTestsViewModel))]
+	public sealed partial class Hyperlink_CanExecute_False : UserControl
+	{
+		public Hyperlink_CanExecute_False()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Hyperlink_Disabled.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Hyperlink_Disabled.xaml
@@ -1,0 +1,102 @@
+<UserControl
+	x:Class="nVentive.Umbrella.Views.UI.Samples.Content.UITests.ButtonTestsControl.Hyperlink_Disabled"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://nventive.com/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://nventive.com/android"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<UserControl.Resources>
+		<Style x:Key="UwaHyperlinkButtonStyle"
+			   TargetType="HyperlinkButton">
+			<Setter Property="Foreground"
+					Value="Blue" />
+			<Setter Property="BorderThickness"
+					Value="0" />
+			<Setter Property="Background"
+					Value="Transparent" />
+			<Setter Property="Padding"
+					Value="0,6,0,6" />
+			<Setter Property="HorizontalAlignment"
+					Value="Left" />
+			<Setter Property="VerticalAlignment"
+					Value="Center" />
+			<Setter Property="FontFamily"
+					Value="{ThemeResource ContentControlThemeFontFamily}" />
+			<Setter Property="FontSize"
+					Value="{ThemeResource ControlContentThemeFontSize}" />
+			<Setter Property="UseSystemFocusVisuals"
+					Value="True" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="HyperlinkButton">
+						<Grid x:Name="RootGrid">
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="PointerOver">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
+																		   Storyboard.TargetName="ContentPresenter">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Orange" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Pressed">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
+																		   Storyboard.TargetName="ContentPresenter">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Black" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Disabled">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
+																		   Storyboard.TargetName="ContentPresenter">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="Red" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+							<ContentPresenter x:Name="ContentPresenter"
+											  AutomationProperties.AccessibilityView="Raw"
+											  BorderBrush="{TemplateBinding BorderBrush}"
+											  BorderThickness="{TemplateBinding BorderThickness}"
+											  Background="{TemplateBinding Background}"
+											  ContentTransitions="{TemplateBinding ContentTransitions}"
+											  Content="{TemplateBinding Content}"
+											  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+											  Padding="{TemplateBinding Padding}"
+											  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</UserControl.Resources>
+
+	<controls:SampleControl SampleDescription="Hyperlink_Disabled">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel>
+					<TextBlock Text="Hyperlink should be red" />
+					<HyperlinkButton Content="http://www.google.com"
+									 NavigateUri="http://www.google.com"
+									 IsEnabled="False"
+									 Style="{StaticResource UwaHyperlinkButtonStyle}" />
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Hyperlink_Disabled.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Hyperlink_Disabled.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace nVentive.Umbrella.Views.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "Hyperlink_Disabled")]
+	public sealed partial class Hyperlink_Disabled : UserControl
+	{
+		public Hyperlink_Disabled()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Nested_Buttons.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Nested_Buttons.xaml
@@ -1,0 +1,48 @@
+<UserControl
+	x:Class="nVentive.Umbrella.Views.UI.Samples.Content.UITests.ButtonTestsControl.Nested_Buttons"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="urn:xamarin"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	mc:Ignorable="d xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Nested_Buttons">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel>
+					<Button
+						Name="Outer"
+						Height="200" 
+						Width="200"
+						Command="{Binding [OuterCommand]}"
+						Background="Tomato">
+						<Button.Template>
+							<ControlTemplate>
+								<Border Background="{TemplateBinding Background}">
+									<Button Command="{Binding [InnerCommand]}" 
+											Name="Inner"
+										Background="Olive"
+										HorizontalAlignment="Center"
+										VerticalAlignment="Center"
+										Height="100"
+										Width="100">
+										<Button.Template>
+											<ControlTemplate>
+												<Border Background="{TemplateBinding Background}" />
+											</ControlTemplate>
+										</Button.Template>
+									</Button>
+								</Border>
+							</ControlTemplate>
+						</Button.Template>
+					</Button>					
+					<TextBlock Text="{Binding [Message]}" />
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Nested_Buttons.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Nested_Buttons.xaml.cs
@@ -1,0 +1,16 @@
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace nVentive.Umbrella.Views.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "Nested_Buttons", typeof(ButtonTestsViewModel))]
+
+	public sealed partial class Nested_Buttons : UserControl
+	{
+		public Nested_Buttons()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Overlapped_Buttons.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Overlapped_Buttons.xaml
@@ -1,0 +1,102 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Button.Overlapped_Buttons"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.Button"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:uno="using:Uno.UI.Samples.Controls"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" MinHeight="100"/>
+			<RowDefinition Height="Auto" MinHeight="120" />
+			<RowDefinition Height="Auto"/>
+		</Grid.RowDefinitions>
+
+		<Button x:Name="layer1"
+		        Grid.Column="0"
+				Grid.ColumnSpan="2"
+				Opacity="0.75"
+				Click="OnClick"
+				Tapped="OnTapped"
+				Background="Aquamarine"
+				Margin="0,0,0,100"
+				HorizontalAlignment="Stretch"
+				VerticalAlignment="Stretch"
+				HorizontalContentAlignment="Stretch"
+				VerticalContentAlignment="Stretch">
+			<Grid HorizontalAlignment="Stretch"
+					VerticalAlignment="Stretch">
+				<TextBlock VerticalAlignment="Top">layer1 (lowest)</TextBlock>
+				<Button x:Name="layer1_inner"
+					Margin="40"
+					Click="OnClick"
+					Tapped="OnTapped"
+					Background="Navy"
+					HorizontalAlignment="Stretch"
+					VerticalAlignment="Stretch">layer1-inner</Button>
+			</Grid>
+		</Button>
+		<Button x:Name="layer2"
+				Grid.Column="1"
+				Grid.ColumnSpan="3"
+				Opacity="0.75"
+				Click="OnClick"
+				Tapped="OnTapped"
+				Background="HotPink"
+				Margin="0,50,0,50"
+				VerticalContentAlignment="Top"
+				HorizontalAlignment="Stretch"
+				VerticalAlignment="Stretch">layer2 (middle)</Button>
+		<Button x:Name="layer3"
+				Grid.Column="3"
+				Grid.ColumnSpan="2"
+				Opacity="0.75"
+				Click="OnClick"
+				Tapped="OnTapped"
+				Background="LawnGreen"
+				Margin="0,100,0,0"
+				VerticalContentAlignment="Bottom"
+				HorizontalAlignment="Stretch"
+				VerticalAlignment="Stretch">layer3 (top most)</Button>
+
+		<uno:StarStackPanel Grid.ColumnSpan="5" Height="70" Sizes="*,*">
+			<Border Background="DarkSalmon" Opacity=".5" IsHitTestVisible="False">
+				<Viewbox Stretch="Fill">
+					<TextBlock>--- IsHitTestVisible="False" ---</TextBlock>
+				</Viewbox>
+			</Border>
+			<Border Background="LightGoldenrodYellow" Opacity=".5" IsHitTestVisible="True">
+				<Viewbox Stretch="Fill">
+					<TextBlock>--- IsHitTestVisible="True" ---</TextBlock>
+				</Viewbox>
+			</Border>
+		</uno:StarStackPanel>
+
+		<Border BorderThickness="1"
+				BorderBrush="DarkCyan"
+				Margin="2"
+				Padding="4"
+				Grid.Row="1"
+				Grid.ColumnSpan="5">
+			<TextBlock x:Name="msgs" />
+		</Border>
+		<Button Tapped="ClearMsgs"
+				Grid.Row="2"
+				Grid.ColumnSpan="5"
+				HorizontalAlignment="Stretch"
+				VerticalAlignment="Stretch">CLEAR</Button>
+
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Overlapped_Buttons.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Overlapped_Buttons.xaml.cs
@@ -1,0 +1,43 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Button
+{
+	[SampleControlInfo("Button", "Overlapped_Buttons")]
+	public sealed partial class Overlapped_Buttons : Page
+	{
+		public Overlapped_Buttons()
+		{
+			this.InitializeComponent();
+
+			AddHandler(TappedEvent, new TappedEventHandler(TappedHandler), handledEventsToo: true);
+
+			void TappedHandler(object snd, TappedRoutedEventArgs tappedRoutedEventArgs)
+			{
+				Write($"[page].Tapped, handled={tappedRoutedEventArgs.Handled}, source={tappedRoutedEventArgs.OriginalSource}");
+			}
+
+		}
+		private void OnClick(object sender, RoutedEventArgs e)
+		{
+			Write($"[{(sender as FrameworkElement).Name}].Click");
+		}
+
+		private void OnTapped(object sender, TappedRoutedEventArgs e)
+		{
+			Write($"[{(sender as FrameworkElement).Name}].Tapped");
+		}
+
+		private void ClearMsgs(object sender, TappedRoutedEventArgs e)
+		{
+			msgs.Text = "";
+		}
+
+		private void Write(string s)
+		{
+			msgs.Text += s + "\n";
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/RadioButton_Multiple_Unnamed_Groups.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/RadioButton_Multiple_Unnamed_Groups.xaml
@@ -1,0 +1,37 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.RadioButton_Multiple_Unnamed_Groups"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="urn:xamarin"
+	mc:Ignorable="d xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="RadioButton_Multiple_Unnamed_Groups">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel Background="CornflowerBlue">
+					<Border BorderBrush="Black">
+						<StackPanel >
+							<TextBlock Text="RadioButton first unnamed group"/>
+							<RadioButton Content="Checkbox 01" Command="{Binding [CheckBox01_Command]}" />
+							<RadioButton Content="Checkbox 02" Command="{Binding [CheckBox02_Command]}" />
+							<RadioButton Content="Checkbox 03" Command="{Binding [CheckBox03_Command]}" />
+						</StackPanel>
+					</Border>
+					<Border BorderBrush="White">
+						<StackPanel >
+							<TextBlock Text="RadioButton second unnamed group"/>
+							<RadioButton Content="Checkbox 01" Command="{Binding [CheckBox01_Command]}" />
+							<RadioButton Content="Checkbox 02" Command="{Binding [CheckBox02_Command]}" />
+							<RadioButton Content="Checkbox 03" Command="{Binding [CheckBox03_Command]}" />
+						</StackPanel>
+					</Border>
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/RadioButton_Multiple_Unnamed_Groups.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/RadioButton_Multiple_Unnamed_Groups.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "RadioButton_Multiple_Unnamed_Groups", typeof(ButtonTestsViewModel))]
+
+	public sealed partial class RadioButton_Multiple_Unnamed_Groups : UserControl
+	{
+		public RadioButton_Multiple_Unnamed_Groups()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/RadioButton_With_GroupName.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/RadioButton_With_GroupName.xaml
@@ -1,0 +1,36 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.RadioButton_With_GroupName"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="urn:xamarin"
+	mc:Ignorable="d xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Radio Buttons with named groups. A selected radio button cannot be unchecked if already checked.">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel Background="CornflowerBlue">
+					<Border BorderBrush="Black" BorderThickness="2">
+						<StackPanel >
+							<TextBlock Text="First StackPanel"/>
+							<RadioButton Content="Cat" Command="{Binding [CheckBox01_Command]}" GroupName="Animal" Foreground="Brown"/>
+							<RadioButton Content="Apple" Command="{Binding [CheckBox02_Command]}" GroupName="Fruits" Foreground="Green"/>
+							<RadioButton Content="Orange" Command="{Binding [CheckBox03_Command]}" GroupName="Fruits" Foreground="Green"/>
+						</StackPanel>
+					</Border>
+					<Border BorderBrush="White" BorderThickness="2">
+						<StackPanel >
+							<TextBlock Text="Second StackPanel"/>
+							<RadioButton Content="Banana" Command="{Binding [CheckBox01_Command]}" GroupName="Fruits" Foreground="Green"/>
+							<RadioButton Content="Dog" Command="{Binding [CheckBox02_Command]}" GroupName="Animal" Foreground="Brown"/>
+						</StackPanel>
+					</Border>
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/RadioButton_With_GroupName.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/RadioButton_With_GroupName.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "RadioButton_With_GroupName", typeof(ButtonTestsViewModel))]
+
+	public sealed partial class RadioButton_With_GroupName : UserControl
+	{
+		public RadioButton_With_GroupName()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Radio_Button.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Radio_Button.xaml
@@ -1,0 +1,25 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.Radio_Button"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:xamarin="urn:xamarin"
+	mc:Ignorable="d xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Radio_Button">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel Background="CornflowerBlue">
+					<RadioButton Content="Checkbox 01" Command="{Binding [CheckBox01_Command]}" />
+					<RadioButton Content="Checkbox 02" Command="{Binding [CheckBox02_Command]}" />
+					<RadioButton Content="Checkbox 03" Command="{Binding [CheckBox03_Command]}" />
+					<RadioButton Content="Checkbox 04 (Alternating)" Command="{Binding [AlternateEnableCommand]}" />
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Radio_Button.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Radio_Button.xaml.cs
@@ -1,0 +1,16 @@
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "Radio_Button", typeof(ButtonTestsViewModel))]
+
+	public sealed partial class Radio_Button : UserControl
+	{
+		public Radio_Button()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Simple_Button.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Simple_Button.xaml
@@ -1,0 +1,173 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.Simple_Button"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	mc:Ignorable="d xamarin ios android"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<UserControl.Resources>
+		<!-- Styles -->
+		<Style x:Key="LabelButtonStyle"
+			   TargetType="Button">
+			<Setter Property="Background"
+					Value="{ThemeResource ButtonBackgroundThemeBrush}" />
+			<Setter Property="Foreground"
+					Value="{ThemeResource ButtonForegroundThemeBrush}" />
+			<Setter Property="BorderBrush"
+					Value="{ThemeResource ButtonBorderThemeBrush}" />
+			<Setter Property="BorderThickness"
+					Value="{ThemeResource ButtonBorderThemeThickness}" />
+			<!--<Setter Property="Padding"
+					Value="12,4,12,4" />-->
+			<Setter Property="HorizontalAlignment"
+					Value="Left" />
+			<Setter Property="VerticalAlignment"
+					Value="Center" />
+			<Setter Property="FontFamily"
+					Value="{ThemeResource ContentControlThemeFontFamily}" />
+			<Setter Property="FontWeight"
+					Value="SemiBold" />
+			<Setter Property="FontSize"
+					Value="{ThemeResource ControlContentThemeFontSize}" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="Button">
+						<Grid>
+							<!--<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="PointerOver">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background"
+																		   Storyboard.TargetName="Border_">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource ButtonPointerOverBackgroundThemeBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
+																		   Storyboard.TargetName="ContentPresenter">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource ButtonPointerOverForegroundThemeBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Pressed">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background"
+																		   Storyboard.TargetName="Border_">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource ButtonPressedBackgroundThemeBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
+																		   Storyboard.TargetName="ContentPresenter">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource ButtonPressedForegroundThemeBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Disabled">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background"
+																		   Storyboard.TargetName="Border_">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource ButtonDisabledBackgroundThemeBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="BorderBrush"
+																		   Storyboard.TargetName="Border_">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource ButtonDisabledBorderThemeBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
+																		   Storyboard.TargetName="ContentPresenter">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource ButtonDisabledForegroundThemeBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+								<VisualStateGroup x:Name="FocusStates">
+									<VisualState x:Name="Focused">
+										<Storyboard>
+											<DoubleAnimation Duration="0"
+															 To="1"
+															 Storyboard.TargetProperty="Opacity"
+															 Storyboard.TargetName="FocusVisualWhite_" />
+											<DoubleAnimation Duration="0"
+															 To="1"
+															 Storyboard.TargetProperty="Opacity"
+															 Storyboard.TargetName="FocusVisualBlack_" />
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Unfocused" />
+									<VisualState x:Name="PointerFocused" />
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>-->
+							<Border x:Name="Border_"
+									BorderBrush="{TemplateBinding BorderBrush}"
+									BorderThickness="{TemplateBinding BorderThickness}"
+									Background="{TemplateBinding Background}"
+									Margin="0">
+								<ContentPresenter x:Name="ContentPresenter"
+												  AutomationProperties.AccessibilityView="Raw"
+												  ContentTemplate="{TemplateBinding ContentTemplate}"
+												  ContentTransitions="{TemplateBinding ContentTransitions}"
+												  Content="{TemplateBinding Content}"
+												  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+												  Margin="{TemplateBinding Padding}"
+												  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+							</Border>
+							<!--Suppress: NVX004-->
+							<Rectangle x:Name="FocusVisualWhite_"
+									   IsHitTestVisible="False"
+									   Opacity="0"
+									   Margin="-3"
+									   StrokeDashOffset="1.5"
+									   StrokeEndLineCap="Square"
+									   Stroke="{ThemeResource FocusVisualWhiteStrokeThemeBrush}"
+									   StrokeDashArray="1,1" />
+							<!--Suppress: NVX004-->
+							<Rectangle x:Name="FocusVisualBlack_"
+									   IsHitTestVisible="False"
+									   Opacity="0"
+									   Margin="-3"
+									   StrokeDashOffset="0.5"
+									   StrokeEndLineCap="Square"
+									   Stroke="{ThemeResource FocusVisualBlackStrokeThemeBrush}"
+									   StrokeDashArray="1,1" />
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+
+	</UserControl.Resources>
+
+	<controls:SampleControl SampleDescription="Simple_Button">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel>
+					<TextBlock Text="Native style" />
+					<Button Content="{Binding [MyData]}"
+							Command="{Binding [SampleCommand]}"
+							android:Style="{StaticResource AndroidButtonStyle}"
+							ios:Style="{StaticResource iOSButtonStyle}"/>
+					<TextBlock Text="UWA style" />
+					<Button Content="{Binding [MyData]}"
+							Command="{Binding [SampleCommand]}" />
+					<TextBlock Text="LabelButtonStyle style" />
+					<Button Content="{Binding [MyData]}"
+							Command="{Binding [SampleCommand]}"
+							Style="{StaticResource LabelButtonStyle}"/>
+				</StackPanel>
+
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Simple_Button.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Simple_Button.xaml.cs
@@ -1,0 +1,16 @@
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "Simple_Button", typeof(ButtonTestsViewModel))]
+
+	public sealed partial class Simple_Button : UserControl
+	{
+		public Simple_Button()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Simple_Button_With_CanExecute_Changing.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Simple_Button_With_CanExecute_Changing.xaml
@@ -1,0 +1,173 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.ButtonTestsControl.Simple_Button_With_CanExecute_Changing"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	mc:Ignorable="d xamarin ios android"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<UserControl.Resources>
+		<!-- Styles -->
+		<Style x:Key="LabelButtonStyle"
+			   TargetType="Button">
+			<Setter Property="Background"
+					Value="{ThemeResource ButtonBackgroundThemeBrush}" />
+			<Setter Property="Foreground"
+					Value="{ThemeResource ButtonForegroundThemeBrush}" />
+			<Setter Property="BorderBrush"
+					Value="{ThemeResource ButtonBorderThemeBrush}" />
+			<Setter Property="BorderThickness"
+					Value="{ThemeResource ButtonBorderThemeThickness}" />
+			<!--<Setter Property="Padding"
+					Value="12,4,12,4" />-->
+			<Setter Property="HorizontalAlignment"
+					Value="Left" />
+			<Setter Property="VerticalAlignment"
+					Value="Center" />
+			<Setter Property="FontFamily"
+					Value="{ThemeResource ContentControlThemeFontFamily}" />
+			<Setter Property="FontWeight"
+					Value="SemiBold" />
+			<Setter Property="FontSize"
+					Value="{ThemeResource ControlContentThemeFontSize}" />
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="Button">
+						<Grid>
+							<!--<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="PointerOver">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background"
+																		   Storyboard.TargetName="Border_">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource ButtonPointerOverBackgroundThemeBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
+																		   Storyboard.TargetName="ContentPresenter">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource ButtonPointerOverForegroundThemeBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Pressed">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background"
+																		   Storyboard.TargetName="Border_">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource ButtonPressedBackgroundThemeBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
+																		   Storyboard.TargetName="ContentPresenter">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource ButtonPressedForegroundThemeBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Disabled">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background"
+																		   Storyboard.TargetName="Border_">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource ButtonDisabledBackgroundThemeBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="BorderBrush"
+																		   Storyboard.TargetName="Border_">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource ButtonDisabledBorderThemeBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
+																		   Storyboard.TargetName="ContentPresenter">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																		Value="{ThemeResource ButtonDisabledForegroundThemeBrush}" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+								<VisualStateGroup x:Name="FocusStates">
+									<VisualState x:Name="Focused">
+										<Storyboard>
+											<DoubleAnimation Duration="0"
+															 To="1"
+															 Storyboard.TargetProperty="Opacity"
+															 Storyboard.TargetName="FocusVisualWhite_" />
+											<DoubleAnimation Duration="0"
+															 To="1"
+															 Storyboard.TargetProperty="Opacity"
+															 Storyboard.TargetName="FocusVisualBlack_" />
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Unfocused" />
+									<VisualState x:Name="PointerFocused" />
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>-->
+							<Border x:Name="Border_"
+									BorderBrush="{TemplateBinding BorderBrush}"
+									BorderThickness="{TemplateBinding BorderThickness}"
+									Background="{TemplateBinding Background}"
+									Margin="0">
+								<ContentPresenter x:Name="ContentPresenter"
+												  AutomationProperties.AccessibilityView="Raw"
+												  ContentTemplate="{TemplateBinding ContentTemplate}"
+												  ContentTransitions="{TemplateBinding ContentTransitions}"
+												  Content="{TemplateBinding Content}"
+												  HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+												  Margin="{TemplateBinding Padding}"
+												  VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+							</Border>
+							<!--Suppress: NVX004-->
+							<Rectangle x:Name="FocusVisualWhite_"
+									   IsHitTestVisible="False"
+									   Opacity="0"
+									   Margin="-3"
+									   StrokeDashOffset="1.5"
+									   StrokeEndLineCap="Square"
+									   Stroke="{ThemeResource FocusVisualWhiteStrokeThemeBrush}"
+									   StrokeDashArray="1,1" />
+							<!--Suppress: NVX004-->
+							<Rectangle x:Name="FocusVisualBlack_"
+									   IsHitTestVisible="False"
+									   Opacity="0"
+									   Margin="-3"
+									   StrokeDashOffset="0.5"
+									   StrokeEndLineCap="Square"
+									   Stroke="{ThemeResource FocusVisualBlackStrokeThemeBrush}"
+									   StrokeDashArray="1,1" />
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+
+	</UserControl.Resources>
+
+	<controls:SampleControl SampleDescription="Simple_Button_With_CanExecute_Changing">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+
+				<StackPanel>
+					<TextBlock Text="Vanilla style" />
+					<Button Content="{Binding [MyData]}"
+							Command="{Binding [AlternateEnableCommand]}"
+							android:Style="{StaticResource AndroidButtonStyle}"
+							ios:Style="{StaticResource iOSButtonStyle}"/>
+					<TextBlock Text="UWA style" />
+					<Button Content="{Binding [MyData]}"
+							Command="{Binding [AlternateEnableCommand]}" />
+					<TextBlock Text="LabelButtonStyle style" />
+					<Button Content="{Binding [MyData]}"
+							Command="{Binding [AlternateEnableCommand]}"
+							Style="{StaticResource LabelButtonStyle}" />
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Simple_Button_With_CanExecute_Changing.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Button/Simple_Button_With_CanExecute_Changing.xaml.cs
@@ -1,0 +1,16 @@
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.ButtonTestsControl
+{
+	[SampleControlInfo("Button", "Simple_Button_With_CanExecute_Changing", typeof(ButtonTestsViewModel))]
+
+	public sealed partial class Simple_Button_With_CanExecute_Changing : UserControl
+	{
+		public Simple_Button_With_CanExecute_Changing()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToggleSwitchControl/Models/ToggleSwitchViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ToggleSwitchControl/Models/ToggleSwitchViewModel.cs
@@ -18,7 +18,7 @@ namespace Uno.UI.Samples.Presentation.SamplePages
 			Flip = CreateCommand(OnFlip);
 		}
 
-		private void OnFlip(object obj) => IsOn = !IsOn;
+		private void OnFlip() => IsOn = !IsOn;
 
 		public bool IsOn
 		{

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/RoutedEvents/RoutedEvent_Tapped2.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/RoutedEvents/RoutedEvent_Tapped2.xaml
@@ -1,0 +1,14 @@
+﻿<Page
+    x:Class="UITests.Shared.Windows_UI_Xaml_Input.RoutedEvents.RoutedEvent_Tapped2"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Input.RoutedEvents"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+
+    </Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/RoutedEvents/RoutedEvent_Tapped2.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/RoutedEvents/RoutedEvent_Tapped2.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace UITests.Shared.Windows_UI_Xaml_Input.RoutedEvents
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class RoutedEvent_Tapped2 : Page
+	{
+		public RoutedEvent_Tapped2()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.Android.cs
@@ -1,18 +1,9 @@
-﻿using Android.App;
-using Android.Graphics;
-using Android.Util;
-using Android.Views;
-using Uno;
-using Uno.Client;
+﻿using Android.Views;
+using Uno.Disposables;
 using Uno.Extensions;
 using Uno.Logging;
 using Uno.UI;
 using Windows.UI.Xaml.Input;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using Uno.Disposables;
-using System.Text;
 
 namespace Windows.UI.Xaml.Controls.Primitives
 {
@@ -31,6 +22,8 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			RegisterEvents();
 
 			OnCanExecuteChanged();
+
+			Tapped += HandleTapped;
 		}
 
 		protected override void OnUnloaded()
@@ -38,8 +31,14 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			base.OnUnloaded();
 			_isEnabledSubscription.Disposable = null;
 			_touchSubscription.Disposable = null;
+
+			Tapped -= HandleTapped;
 		}
 
+		private void HandleTapped(object sender, TappedRoutedEventArgs e)
+		{
+			e.Handled = true;
+		}
 
 		partial void OnIsEnabledChangedPartial(bool oldValue, bool newValue)
 		{
@@ -66,7 +65,13 @@ namespace Windows.UI.Xaml.Controls.Primitives
 							this.Log().Debug("TouchUpInside, executing command");
 						}
 
+						OnPointerPressed(new PointerRoutedEventArgs { OriginalSource = this });
+
 						OnClick();
+
+						var args = new TappedRoutedEventArgs { OriginalSource = this };
+
+						RaiseEvent(TappedEvent, args);
 					});
 
 				_isEnabledSubscription.Disposable =

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.cs
@@ -156,22 +156,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			{
 				this.Log().Error("Failed to execute command", e);
 			}
-			
-			if (args != null)
-			{
-				args.Handled = true;
-			}
-
-			// This is a naive implementation that doesn't consider ClickMode or the distance traveled between press and release.
-			// Will be implemented properly when pointer logic is moved to UIElement.
-			// It is important that Tapped is raised after Click.
-			var tappedRoutedEventArgs = new TappedRoutedEventArgs
-			{
-				OriginalSource = args?.OriginalSource,
-				CanBubbleNatively = false
-			};
-
-			RaiseEvent(TappedEvent, tappedRoutedEventArgs);
 		}
 
 		protected override void OnPointerPressed(PointerRoutedEventArgs args)
@@ -180,8 +164,6 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 			IsPointerOver = true;
 			IsPointerPressed = true;
-
-			args.Handled = true;
 
 #if !__WASM__
 			// TODO: Remove when Focus is implemented properly.

--- a/src/Uno.UI/UI/Xaml/GestureHandler.Android.cs
+++ b/src/Uno.UI/UI/Xaml/GestureHandler.Android.cs
@@ -73,7 +73,7 @@ namespace Windows.UI.Xaml
 				var pointer = e.GetPointer(0);
 				var args = new TappedRoutedEventArgs(new Point(e.GetX(), e.GetY()))
 				{
-					OriginalSource = this,
+					OriginalSource = _target,
 					PointerDeviceType = pointer.PointerDeviceType,
 					CanBubbleNatively = true
 				};
@@ -95,7 +95,7 @@ namespace Windows.UI.Xaml
 
 				var args = new DoubleTappedRoutedEventArgs(new Point(e.GetX(), e.GetY()))
 				{
-					OriginalSource = this,
+					OriginalSource = _target,
 					PointerDeviceType = pointer.PointerDeviceType,
 					CanBubbleNatively = true
 				};
@@ -203,7 +203,7 @@ namespace Windows.UI.Xaml
 		{
 			return new PointerRoutedEventArgs(ev)
 			{
-				OriginalSource = this,
+				OriginalSource = _target,
 				Pointer = ev.GetPointer(pointerIndex),
 				CanBubbleNatively = true
 			};

--- a/src/Uno.UI/UI/Xaml/UIElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.iOS.cs
@@ -427,7 +427,8 @@ namespace Windows.UI.Xaml
 
 					var args = new PointerRoutedEventArgs(touches, evt)
 					{
-						CanBubbleNatively = true
+						CanBubbleNatively = true,
+						OriginalSource = this
 					};
 
 					pointerEventIsHandledInManaged = RaiseEvent(PointerEnteredEvent, args);
@@ -455,7 +456,8 @@ namespace Windows.UI.Xaml
 			{
 				var args = new PointerRoutedEventArgs(touches, evt)
 				{
-					CanBubbleNatively = true
+					CanBubbleNatively = true,
+					OriginalSource = this
 				};
 				var isHandledInManaged = RaiseEvent(PointerCanceledEvent, args);
 
@@ -485,7 +487,8 @@ namespace Windows.UI.Xaml
 				// Call entered/exited one last time
 				var args = new PointerRoutedEventArgs(touches, evt)
 				{
-					CanBubbleNatively = true
+					CanBubbleNatively = true,
+					OriginalSource = this
 				};
 
 				var pointerEventIsHandledInManaged = false;
@@ -538,7 +541,8 @@ namespace Windows.UI.Xaml
 
 				var args = new PointerRoutedEventArgs(touches, evt)
 				{
-					CanBubbleNatively = true
+					CanBubbleNatively = true,
+					OriginalSource = this
 				};
 
 				if (IsPointerCaptured || IsPointerOver)


### PR DESCRIPTION
GitHub Issue (If applicable): #691

## Bugfix

## What is the current behavior?
`Click` and `Tapped` events were not generated properly on iOS and Android:`
* On _Android_, the `Tapped` event were generated twice.
* On _iOS_, the `Click` event were not fired on a button, preventing any _Command_
  from executing.

## What is the new behavior?
The event sequence `PointerPressed` -> `Click` -> _Command_ -> `Tapped` is now
correctly implemented.

## PR Checklist

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
* [Tapped handlers are invoked twice](https://nventive.visualstudio.com/Umbrella/_workitems/edit/149681)
