### PR TITLE
Set IsPointerCaptured flag on iOS accordingly to the Pointer capture state

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -68,6 +68,7 @@
 * The CI validates for API breaking changes
 * Added samples application BenchmarkDotNet support.
 * `MediaTransportControls` buttons now use Tapped event instead of Click
+* Fixed Pointer capture issues on sliders on iOS
 
 ### Breaking changes
 * Make `UIElement.IsPointerPressed` and `IsPointerOver` internal

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -292,6 +292,9 @@ namespace Windows.UI.Xaml
 			else
 			{
 				_pointCaptures.Add(value);
+#if  __IOS__
+				IsPointerCaptured = true;
+#endif
 #if __WASM__
 				CapturePointerNative(value);
 #endif
@@ -304,7 +307,9 @@ namespace Windows.UI.Xaml
 			if(_pointCaptures.Contains(value))
 			{
 				_pointCaptures.Remove(value);
-
+#if __IOS__ 
+				IsPointerCaptured = false;
+#endif
 #if __WASM__
 				ReleasePointerCaptureNative(value);
 #endif

--- a/src/Uno.UI/UI/Xaml/UIElement.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.cs
@@ -292,9 +292,6 @@ namespace Windows.UI.Xaml
 			else
 			{
 				_pointCaptures.Add(value);
-#if  __IOS__
-				IsPointerCaptured = true;
-#endif
 #if __WASM__
 				CapturePointerNative(value);
 #endif
@@ -307,9 +304,6 @@ namespace Windows.UI.Xaml
 			if(_pointCaptures.Contains(value))
 			{
 				_pointCaptures.Remove(value);
-#if __IOS__ 
-				IsPointerCaptured = false;
-#endif
 #if __WASM__
 				ReleasePointerCaptureNative(value);
 #endif

--- a/src/Uno.UI/UI/Xaml/UIElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.iOS.cs
@@ -33,7 +33,7 @@ namespace Windows.UI.Xaml
 
 		private static Dictionary<UIView, CALayer> _debugLayers;
 
-		internal bool IsPointerCaptured { get; set; }
+		internal bool IsPointerCaptured => _pointCaptures.Any();
 
 		public UIElement()
 		{
@@ -469,7 +469,7 @@ namespace Windows.UI.Xaml
 
 				IsPointerPressed = false;
 				IsPointerOver = false;
-				IsPointerCaptured = false;
+				_pointCaptures.Clear();
 			}
 			catch (Exception e)
 			{
@@ -522,7 +522,7 @@ namespace Windows.UI.Xaml
 
 				IsPointerPressed = false;
 				IsPointerOver = false;
-				IsPointerCaptured = false;
+				_pointCaptures.Clear();
 			}
 			catch (Exception e)
 			{


### PR DESCRIPTION
## Bugfix 

## What is the current behavior?
On iOS, when manipulating a slider, the pointer is not properly captured, resulting in unpredictable behavior when releasing your finger outside of the slider bounds.

## What is the new behavior?
The pointer is properly captured and you can keep manipulating it as long as you don't release your finger.

## PR Checklist

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue :
[https://nventive.visualstudio.com/Umbrella/_workitems/edit/150453](https://nventive.visualstudio.com/Umbrella/_workitems/edit/150453)
