### PR TITLE
Adjust support for StaticResource.ResourceKey

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -39,6 +39,7 @@
 * 1580172 ToggleSwitch wasn't working after an unload/reload: caused by routedevent's unregistration not working.
 * 145203 [Android] Fix overflow on LogicalToPhysicalPixels(double.MaxValue), allowing ScrollViewer.ChangeView(double.MaxValue,...) to work
 * 150679 [iOS] Fix path issue with Media Player not being able to play local files.
+* Adjust support for `StaticResource.ResourceKey`
 
 ## Release 1.44.0
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -363,6 +363,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			writer.AppendLineInvariant($"global::Windows.UI.Xaml.Media.ImageSource.Drawables = typeof(global::{_defaultNamespace}.Resource.Drawable);");
 			writer.AppendLineInvariant($"#endif");
 
+			RegisterResources(topLevelControl);
 			BuildProperties(writer, topLevelControl, isInline: false, returnsContent: false);
 			writer.AppendLineInvariant(";");
 		}
@@ -396,6 +397,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			writer.AppendLineInvariant("var nameScope = new global::Windows.UI.Xaml.NameScope();");
 			writer.AppendLineInvariant("NameScope.SetNameScope(this, nameScope);");
 
+			RegisterResources(topLevelControl);
 			var hasContent = BuildProperties(writer, topLevelControl, isInline: false, returnsContent: isDirectUserControlChild);
 
 			writer.AppendLineInvariant(";");
@@ -1276,8 +1278,6 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				if (topLevelControl.Members.Any())
 				{
 					var setterPrefix = string.IsNullOrWhiteSpace(closureName) ? string.Empty : closureName + ".";
-
-					RegisterResources(topLevelControl);
 
 					var implicitContentChild = FindImplicitContentMember(topLevelControl);
 
@@ -2788,6 +2788,10 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			{
 				return $"global::{resource.Namespace}.GlobalStaticResources.{SanitizeResourceName(resourceName)}";
 			}
+			else if (_staticResources.ContainsKey(resourceName))
+			{
+				return $"{GetCastString(targetType, _staticResources[resourceName])}StaticResources.{SanitizeResourceName(resourceName)}";
+			}
 			else
 			{
 				var validateString = _isDebug ? $" ?? throw new InvalidOperationException(\"The resource {resourceName} cannot be found\")" : "";
@@ -3150,6 +3154,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 
 				using (var innerWriter = CreateApplyBlock(writer, null, out var closureName))
 				{
+					RegisterResources(xamlObjectDefinition);
 					BuildLiteralProperties(innerWriter, xamlObjectDefinition, closureName);
 					BuildProperties(innerWriter, xamlObjectDefinition, closureName: closureName);
 				}
@@ -3237,6 +3242,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 					{
 						using (writer.BlockInvariant("new {0}{1}", GetGlobalizedTypeName(fullTypeName), GenerateConstructorParameters(xamlObjectDefinition.Type)))
 						{
+							RegisterResources(xamlObjectDefinition);
 							BuildLiteralProperties(writer, xamlObjectDefinition);
 							BuildProperties(writer, xamlObjectDefinition);
 						}

--- a/src/SourceGenerators/XamlGenerationTests/ResourceKeyTest.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/ResourceKeyTest.xaml
@@ -1,0 +1,24 @@
+﻿<Grid x:Class="XamlGenerationTests.Shared.ResourceKeyTest"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:XamlGenerationTests.Shared"
+	  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	  xmlns:ios="http://uno.ui/ios"
+	  xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:android="http://uno.ui/android"
+	  xmlns:xamarin="http://uno.ui/xamarin"
+	  mc:Ignorable="d xamarin"
+	  d:DesignHeight="300"
+	  d:DesignWidth="400">
+
+	<Button>
+		<Button.Resources>
+			<Style x:Key="MyResource" TargetType="Button">
+			</Style>
+		</Button.Resources>
+		<Button.Style>
+			<StaticResource ResourceKey="MyResource" />
+		</Button.Style>
+	</Button>
+</Grid>


### PR DESCRIPTION
# PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Using `<StaticResource ResourceKey="" />` results in a compilation error.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
