### PR TITLE
Fix TextBox.IsReadOnly on Android

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -24,6 +24,7 @@
 * The `HAS_UNO` define is now not defined in `uap10.0.x` target frameworks.
 * The `XamlReader` fails when a property has no getter
 * `Click` and `Tapped` events were not working property for `ButtonBase` on Android and iOS.
+* 150143 [Android] Toggling `TextBox.IsReadOnly` from true to false no longer breaks the cursor
 
 ## Release 1.44.0
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -417,6 +417,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_IsReadOnly.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\Sample2.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1541,6 +1545,9 @@
       <DependentUpon>Slider_Styled.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Slider\Slider_Transformed.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_IsReadOnly.xaml.cs">
+      <DependentUpon>TextBox_IsReadOnly.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TimePicker\Sample2.xaml.cs">
       <DependentUpon>Sample2.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsReadOnly.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsReadOnly.xaml
@@ -1,0 +1,29 @@
+<UserControl x:Class="Uno.UI.Samples.UITests.TextBoxControl.TextBox_IsReadOnly"
+			 xmlns:controls="using:Uno.UI.Samples.Controls"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:Uno.UI.Samples.UITests"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:u="using:Uno.UI.Samples.Controls"
+			 xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+			 xmlns:ios="http://uno.ui/ios"
+			 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:android="http://uno.ui/android"
+			 mc:Ignorable="d ios android"
+			 d:DesignHeight="2000"
+			 d:DesignWidth="400">
+
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="auto" />
+		</Grid.RowDefinitions>
+		<TextBox Grid.Row="0"
+				 Text="This is the starting text..."
+				 x:Name="txt" />
+		<Button Grid.Row="1"
+				Click="OnClick"
+				Content="Toggle IsReadOnly" />
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsReadOnly.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBox/TextBox_IsReadOnly.xaml.cs
@@ -1,0 +1,20 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.UITests.TextBoxControl
+{
+	[SampleControlInfo("TextBox", "TextBox_IsReadOnly")]
+	public sealed partial class TextBox_IsReadOnly : UserControl
+	{
+		public TextBox_IsReadOnly()
+		{
+			this.InitializeComponent();
+		}
+
+		private void OnClick(object sender, RoutedEventArgs args)
+		{
+			txt.IsReadOnly = !txt.IsReadOnly;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -308,6 +308,11 @@ namespace Windows.UI.Xaml.Controls
 					inputType |= InputTypes.TextFlagMultiLine;
 				}
 
+				if (IsReadOnly)
+				{
+					inputType = InputTypes.Null;
+				}
+
 				_textBoxView.InputType = inputType;
 			}
 		}
@@ -398,7 +403,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (_textBoxView != null)
 			{
-				_textBoxView.InputType = InputTypes.Null;
+				UpdateInputScope(InputScope);
 			}
 		}
 


### PR DESCRIPTION
## PR Type
Bugfix

## What is the current behavior?
If a TextBox has IsReadOnly = true, setting IsReadOnly = false will not restore the cursor. This makes it impossible to remove or add text in a different position.

## What is the new behavior?
Setting TextBox.IsReadOnly = false restores the cursor.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
150143