### PR TITLE
Fixed potential null-ref in custom http handler.

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -25,6 +25,7 @@
 * The `XamlReader` fails when a property has no getter
 * `Click` and `Tapped` events were not working property for `ButtonBase` on Android and iOS.
 * 150143 [Android] Toggling `TextBox.IsReadOnly` from true to false no longer breaks the cursor
+* `WasmHttpHandler` was broken because of a change in the internal Mono implementation.
 
 ## Release 1.44.0
 

--- a/src/SamplesApp/SamplesApp.Shared/Samples/UnitTests/HttpUnitTests.xaml
+++ b/src/SamplesApp/SamplesApp.Shared/Samples/UnitTests/HttpUnitTests.xaml
@@ -1,0 +1,21 @@
+﻿<Page
+    x:Class="SamplesApp.Samples.UnitTests.HttpUnitTests"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:uno="using:Uno.UI.Samples.Controls"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<uno:StarStackPanel Sizes="Auto,Auto,*">
+		<TextBox x:Name="address" Text="https://uno-platform.visualstudio.com/_apis/customerintelligence/Events" />
+		<Button HorizontalAlignment="Stretch" Click="Go">-GO- (make sure your url supports CORS!)</Button>
+		<ScrollViewer>
+			<TextBlock x:Name="log" />
+		</ScrollViewer>
+		<ScrollViewer>
+			<TextBlock x:Name="result" />
+		</ScrollViewer>
+	</uno:StarStackPanel>
+</Page>

--- a/src/SamplesApp/SamplesApp.Shared/Samples/UnitTests/HttpUnitTests.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/Samples/UnitTests/HttpUnitTests.xaml.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Net.Http;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Samples.UnitTests
+{
+	[SampleControlInfo("Unit Tests", "Wasm Http Handler")]
+	public sealed partial class HttpUnitTests : Page
+	{
+		public HttpUnitTests()
+		{
+			this.InitializeComponent();
+		}
+
+		private async void Go(object sender, RoutedEventArgs e)
+		{
+#if __WASM__
+			var handler = new Uno.UI.Wasm.WasmHttpHandler();
+#else
+			var handler = new HttpClientHandler();
+#endif
+
+			try
+			{
+				using (handler)
+				using (var client = new HttpClient(handler))
+				{
+					Log("Creating a request message");
+					var request = new HttpRequestMessage(HttpMethod.Get, new Uri(address.Text));
+					Log("Sending request message");
+					var response = await client.SendAsync(request);
+					Log("Reading from response");
+					var s = await response.Content.ReadAsStringAsync();
+					result.Text = s;
+				}
+			}
+			catch (Exception ex)
+			{
+				while (ex != null)
+				{
+					Log($"Exception: {ex}\n\n");
+					ex = ex.InnerException;
+				}
+			}
+
+		}
+
+		private void Log(string s)
+		{
+			log.Text += $"{s}\n";
+		}
+	}
+}

--- a/src/SamplesApp/SamplesApp.Shared/Samples/UnitTests/UnitTestsPage.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/Samples/UnitTests/UnitTestsPage.xaml.cs
@@ -1,33 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Uno.UI.Samples.Controls;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
+﻿using System.Reflection;
 using Windows.UI.Xaml;
+using Uno.UI.Samples.Controls;
 using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Controls.Primitives;
-using Windows.UI.Xaml.Data;
-using Windows.UI.Xaml.Input;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Navigation;
-
-// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
 
 namespace SamplesApp.Samples.UnitTests
 {
 	[SampleControlInfo("Unit Tests", "Unit Tests Runner")]
 	public sealed partial class UnitTestsPage : Page
-    {
-        public UnitTestsPage()
-        {
-            this.InitializeComponent();
+	{
+		public UnitTestsPage()
+		{
+			this.InitializeComponent();
 
 			// Manually load the runtime tests assembly
 			Assembly.Load("Uno.UI.RuntimeTests");
-        }
-    }
+			Assembly.Load("Uno.UI.Wasm.Tests");
+		}
+	}
 }

--- a/src/SamplesApp/SamplesApp.Shared/SamplesApp.Shared.projitems
+++ b/src/SamplesApp/SamplesApp.Shared/SamplesApp.Shared.projitems
@@ -21,12 +21,17 @@
     <Compile Include="$(MSBuildThisFileDirectory)MainPage.xaml.cs">
       <DependentUpon>MainPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Samples\UnitTests\HttpUnitTests.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Samples\UnitTests\UnitTestsPage.xaml.cs">
       <DependentUpon>UnitTestsPage.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
     <Page Include="$(MSBuildThisFileDirectory)MainPage.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Samples\UnitTests\HttpUnitTests.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -52,5 +57,10 @@
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\en\Test01.resw" />
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\fr\Resources.resw" />
     <PRIResource Include="$(MSBuildThisFileDirectory)Strings\sr-Cyrl-BA\Resources.resw" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="C:\src\Uno\src\SamplesApp\SamplesApp.Shared\Samples\UnitTests\HttpUnitTests.xaml.cs">
+      <DependentUpon>HttpUnitTests.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/src/Uno.UI.Wasm/WasmHttpHandler.cs
+++ b/src/Uno.UI.Wasm/WasmHttpHandler.cs
@@ -81,13 +81,7 @@ namespace Uno.UI.Wasm
 
 				foreach (var header in headers)
 				{
-					var isContent = GetHeaderIsContent(header.Key);
-
-					if (isContent)
-					{
-						responseMessage.Content.Headers.TryAddWithoutValidation(header.Key, header);
-					}
-					else
+					if (!responseMessage.Content.Headers.TryAddWithoutValidation(header.Key, header))
 					{
 						responseMessage.Headers.TryAddWithoutValidation(header.Key, header);
 					}
@@ -100,29 +94,6 @@ namespace Uno.UI.Wasm
 				Console.Error.WriteLine(ex);
 				throw;
 			}
-		}
-
-		private static MethodInfo _getKnownHeaderKindMethodInfo;
-
-		private static bool GetHeaderIsContent(string headerName)
-		{
-			MethodInfo GetMethod()
-			{
-				// Hack for a method to know if the header is content or response.
-				// This method is internal in Mono.
-				var assembly = typeof(HttpHeaders).Assembly;
-				var type = assembly.GetType(typeof(HttpHeaders).FullName);
-				var method = type.GetMethod("GetKnownHeaderKind", BindingFlags.Static | BindingFlags.NonPublic);
-				return method;
-			}
-
-			if (_getKnownHeaderKindMethodInfo == null)
-			{
-				_getKnownHeaderKindMethodInfo = GetMethod();
-			}
-
-			var headerKind = (int) _getKnownHeaderKindMethodInfo.Invoke(null, new object[] {headerName});
-			return headerKind == 1 << 2;
 		}
 
 		[Preserve]


### PR DESCRIPTION
This was due to access to an internal method through reflection. A better pattern has been implemented.

GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## Bugfix
Recent changes in Mono were causing null reference for a method got
using reflection.

## What is the new behavior?
Reflection is no more used to assign headers from _native_ (browser) http response.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
