### PR TITLE
[Android] Fix overflow when using double.MaxValue

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -32,6 +32,7 @@
 * 150489 [Android] PointerCanceled not called on scrolling for views with a RenderTransform set
 * 150469 [iOS] Virtualized ListView items don't always trigger their multi-select VisualStates
 * 1580172 ToggleSwitch wasn't working after an unload/reload: caused by routedevent's unregistration not working.
+* 145203 [Android] Fix overflow on LogicalToPhysicalPixels(double.MaxValue), allowing ScrollViewer.ChangeView(double.MaxValue,...) to work
 
 ## Release 1.44.0
 

--- a/src/Uno.UI/Extensions/ViewHelper.Android.cs
+++ b/src/Uno.UI/Extensions/ViewHelper.Android.cs
@@ -59,6 +59,16 @@ namespace Uno.UI
 			}
 		}
 
+		/// <summary>
+		/// The maximum logical pixel value which can be converted to physical pixels without overflow.
+		/// </summary>
+		private static double MaxLogicalValue { get; }
+
+		/// <summary>
+		/// The minimum logical pixel value which can be converted to physical pixels without underflow.
+		/// </summary>
+		private static double MinLogicalValue { get; }
+
 		public static string Architecture { get; }
 
 		static ViewHelper()
@@ -77,6 +87,9 @@ namespace Uno.UI
 				}
 				_cachedScaledDensity = displayMetrics.ScaledDensity;
 				_cachedScaledXDpi = displayMetrics.Xdpi;
+
+				MaxLogicalValue = (int.MaxValue - 1) / _cachedDensity;
+				MinLogicalValue = (int.MinValue + 1) / _cachedDensity;
 			}
 
 			if (typeof(ViewHelper).Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
@@ -217,12 +230,12 @@ namespace Uno.UI
 				return 0;
 			}
 
-			if (double.IsPositiveInfinity(value))
+			if (double.IsPositiveInfinity(value) || value > MaxLogicalValue)
 			{
 				return int.MaxValue;
 			}
 
-			if (double.IsNegativeInfinity(value))
+			if (double.IsNegativeInfinity(value) || value < MinLogicalValue)
 			{
 				return int.MinValue;
 			}


### PR DESCRIPTION
Ensure this is converted correctly to physical pixels (eg when calling ScrollViewer.ChangeView(double.MaxValue,...)

GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://nventive.visualstudio.com/Umbrella/_workitems/edit/145203