### PR TITLE
Improve performance of DatePicker and TimePicker on iOS

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -15,6 +15,7 @@
 * Add support for IDictionary objects in XAM (#729)
 * Add support for Binding typed property (#731)
 * Add support for `RelativeSource.Self` bindings
+* 149377 Improve performance of `TimePicker` and `DatePicker` on iOS.
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
@@ -131,6 +131,8 @@ namespace Windows.UI.Xaml.Controls
 		private TextBlock _dayTextBlock;
 		private TextBlock _monthTextBlock;
 		private TextBlock _yearTextBlock;
+		private bool _isLoaded;
+		private bool _isViewReady;
 
 		protected override void OnApplyTemplate()
 		{
@@ -150,8 +152,11 @@ namespace Windows.UI.Xaml.Controls
 					InitializeTextBlocks(flyoutContent);
 					UpdateDisplayedDate();
 				}
-				SetupFlyoutButton();
 			}
+
+			_isViewReady = true;
+
+			SetupFlyoutButton();
 
 			OnApplyTemplatePartial();
 
@@ -167,6 +172,9 @@ namespace Windows.UI.Xaml.Controls
 		protected override void OnLoaded()
 		{
 			base.OnLoaded();
+
+			_isLoaded = true;
+
 			var flyoutContent = _flyoutButton?.Content as IFrameworkElement;
 
 			if (flyoutContent != null)
@@ -177,21 +185,29 @@ namespace Windows.UI.Xaml.Controls
 
 		private void SetupFlyoutButton()
 		{
-#if __IOS__ || __ANDROID__
-			_flyoutButton.Flyout = new DatePickerFlyout()
+			if (!_isViewReady || !_isLoaded)
 			{
-#if __IOS__
-                Placement = FlyoutPlacement,
-#endif
-				Date = Date,
-				MinYear = MinYear,
-				MaxYear = MaxYear
-			};
+				return;
+			}
 
-			BindToFlyout("Date");
-			BindToFlyout("MinYear");
-			BindToFlyout("MaxYear");
+			if (_flyoutButton != null)
+			{
+#if __IOS__ || __ANDROID__
+				_flyoutButton.Flyout = new DatePickerFlyout()
+				{
+#if __IOS__
+					Placement = FlyoutPlacement,
 #endif
+					Date = Date,
+					MinYear = MinYear,
+					MaxYear = MaxYear
+				};
+
+				BindToFlyout("Date");
+				BindToFlyout("MinYear");
+				BindToFlyout("MaxYear");
+#endif
+			}
 		}
 
 		private void BindToFlyout(string propertyName)

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
@@ -27,6 +27,8 @@ namespace Windows.UI.Xaml.Controls
 		private TextBlock _periodTextBlock;
 		private Grid _flyoutButtonContentGrid;
 		private ColumnDefinition _thirdTextBlockColumn;
+		private bool _isLoaded;
+		private bool _isViewReady;
 
 		public TimePicker() { }
 
@@ -127,17 +129,29 @@ namespace Windows.UI.Xaml.Controls
 				_thirdTextBlockColumn = columns.ElementAt(periodColumnPosition);
 			}
 
+			_isViewReady = true;
+
 			SetupFlyoutButton();
 		}
 
 		protected override void OnLoaded()
 		{
 			base.OnLoaded();
+
+			_isLoaded = true;
+
 			SetupFlyoutButton();
 		}
 
 		private void SetupFlyoutButton()
 		{
+			if (!_isViewReady || !_isLoaded)
+			{
+				return;
+			}
+
+			UpdateDisplayedDate();
+
 			if (_flyoutButton != null)
 			{
 #if __IOS__ || __ANDROID__
@@ -156,8 +170,6 @@ namespace Windows.UI.Xaml.Controls
 				BindToFlyout(nameof(ClockIdentifier));
 #endif
 			}
-
-			UpdateDisplayedDate();
 		}
 
 		void OnTimeChangedPartial(TimeSpan oldTime, TimeSpan newTime)

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
@@ -14,9 +14,31 @@ namespace Windows.UI.Xaml.Controls
 		internal protected TimePickerSelector _timeSelector;
 		internal protected TimePickerFlyoutPresenter _timePickerPresenter;
 		internal protected FrameworkElement _headerUntapZone;
+		private bool _isInitialized;
 
 		public TimePickerFlyout()
 		{
+		}
+
+		/// <summary>
+		/// This method sets the Content property of the Flyout.
+		/// </summary>
+		/// <remarks>
+		/// Note that for performance reasons, we don't call it in the contructor. Instead, we wait for the popup to be opening.
+		/// The native UIDatePicker contained in the TimePickerSelector is known for being slow in general (https://bugzilla.xamarin.com/show_bug.cgi?id=49469).
+		/// Using this strategy means that a page containing a TimePicker will no longer be slowed down by this initialization during the page creation.
+		/// Instead, you'll see the delay when opening the TimePickerFlyout for the first time.
+		/// This is most notable on pages containing multiple TimePicker controls.
+		/// </remarks>
+		private void InitializeContent()
+		{
+			if (_isInitialized)
+			{
+				return;
+			}
+
+			_isInitialized = true;
+
 			_timeSelector = new TimePickerSelector()
 			{
 				BorderThickness = Thickness.Empty,
@@ -30,7 +52,7 @@ namespace Windows.UI.Xaml.Controls
 			this.Binding(nameof(MinuteIncrement), nameof(MinuteIncrement), Content, BindingMode.TwoWay);
 			this.Binding(nameof(ClockIdentifier), nameof(ClockIdentifier), Content, BindingMode.TwoWay);
 		}
-		
+
 		protected override Control CreatePresenter()
 		{
 			_timePickerPresenter = new TimePickerFlyoutPresenter() { Content = Content };
@@ -67,6 +89,8 @@ namespace Windows.UI.Xaml.Controls
 
 		protected internal override void Open()
 		{
+			InitializeContent();
+
 			_timeSelector.Initialize();
 
 			//Gobbling pressed tap on the flyout header background so that it doesn't close the flyout popup. 


### PR DESCRIPTION
## PR Type
- Bugfix
- Feature

## What is the current behavior?
Loading a page containing multiple `DatePicker` or `TimePicker` controls is very slow.

## What is the new behavior?
Loading a page containing multiple `DatePicker` or `TimePicker` controls is not slow.
`UIDatePicker` is the slow native control used under the hood. We now wait until we open the DatePickerFlyout/TimePickerFlyout before initializing it.

## PR Checklist
- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/149377