### PR TITLE
[Android] Fix PointerCanceled not called for views with a RenderTransform

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -29,6 +29,7 @@
 * 150143 [Android] Toggling `TextBox.IsReadOnly` from true to false no longer breaks the cursor
 * `WasmHttpHandler` was broken because of a change in the internal Mono implementation.
 * 140946 [Android] Upon modifying a list, incorrect/duplicated items appear
+* 150489 [Android] PointerCanceled not called on scrolling for views with a RenderTransform set
 * 150469 [iOS] Virtualized ListView items don't always trigger their multi-select VisualStates
 * 1580172 ToggleSwitch wasn't working after an unload/reload: caused by routedevent's unregistration not working.
 

--- a/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoViewGroup.java
+++ b/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoViewGroup.java
@@ -389,10 +389,8 @@ public abstract class UnoViewGroup
 		//		 (e.g. the growing circles in buttons when keeping pressed (RippleEffect)).
 
 		boolean superDispatchTouchEvent = false;
-		if (_childrenTransformations.size() == 0
-			|| e.getAction() == MotionEvent.ACTION_CANCEL) {
-			// We don't have any child which has s static transform, or the event is a "cancel" (cf. https://android.googlesource.com/platform/frameworks/base/+/0e71b4f19ba602c8c646744e690ab01c69808b42/core/java/android/view/ViewGroup.java#3013)
-			// propagate the event through the 'super' logic
+		if (_childrenTransformations.size() == 0) {
+			// We don't have any child which has a static transform, so propagate the event through the 'super' logic
 
 			superDispatchTouchEvent = super.dispatchTouchEvent(e);
 		} else {
@@ -408,6 +406,9 @@ public abstract class UnoViewGroup
 			// and thios support is sufficent enough for our current cases.
 			// Note: this is not fully complient with the UWP contract (cf. https://github.com/nventive/Uno/issues/649)
 
+			// Note: If this logic is called once, it has to be called for all MotionEvents in the same touch cycle, including Cancel, because if
+			// ViewGroup.dispatchTouchEvent() isn't called for Down then all subsequent events won't be handled correctly
+			// (because mFirstTouchTarget won't be set)
 			Matrix inverse = new Matrix();
 
 			for (int i = getChildCount() - 1; i >= 0; i--) { // Inverse enumeration in order to prioritize controls that are on top


### PR DESCRIPTION
Use StaticTransformation special case even for ACTION_CANCEL, because ViewGroup's touch logic needs to handle the gesture from the very beginning of the touch or not at all.

GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://nventive.visualstudio.com/Umbrella/_workitems/edit/150489