### PR TITLE
Grid - fix ArgOOREx from Span

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid.cs
@@ -924,5 +924,41 @@ namespace Uno.UI.Tests.GridTests
 			Assert.AreEqual(measuredSize, new Windows.Foundation.Size(80, 80));
 			Assert.AreEqual(6, SUT.GetChildren().Count());
 		}
+
+		[TestMethod]
+		public void When_RowSpan_Out_Of_Range()
+		{
+			var SUT = new Grid();
+
+			SUT.RowDefinitions.Add(new RowDefinition { Height = "*" });
+			SUT.RowDefinitions.Add(new RowDefinition { Height = "*" });
+
+			SUT.AddChild(new View { RequestedDesiredSize = new Windows.Foundation.Size(100, 100) });
+			SUT.AddChild(new View { RequestedDesiredSize = new Windows.Foundation.Size(100, 100) })
+				.GridPosition(1, 0)
+				.GridRowSpan(3);
+
+			SUT.Measure(new Windows.Foundation.Size(100, 1000));
+			var measuredSize = SUT.DesiredSize;
+			SUT.Arrange(new Windows.Foundation.Rect(0, 0, 100, 1000));
+		}
+
+		[TestMethod]
+		public void When_ColumnSpan_Out_Of_Range()
+		{
+			var SUT = new Grid();
+
+			SUT.ColumnDefinitions.Add(new ColumnDefinition { Width = "*" });
+			SUT.ColumnDefinitions.Add(new ColumnDefinition { Width = "*" });
+
+			SUT.AddChild(new View { RequestedDesiredSize = new Windows.Foundation.Size(100, 100) });
+			SUT.AddChild(new View { RequestedDesiredSize = new Windows.Foundation.Size(100, 100) })
+				.GridPosition(0, 1)
+				.GridColumnSpan(3);
+
+			SUT.Measure(new Windows.Foundation.Size(1000, 100));
+			var measuredSize = SUT.DesiredSize;
+			SUT.Arrange(new Windows.Foundation.Rect(0, 0, 1000, 100));
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
@@ -642,7 +642,7 @@ namespace Windows.UI.Xaml.Controls
 					maxMeasuredWidth = Math.Max(maxMeasuredWidth, size.Width);
 
 					var starHeight = size.Height;
-					var sizes = allHeights.Span.Slice(starChild.Value.Row, starChild.Value.RowSpan);
+					var sizes = allHeights.Span.SliceClamped(starChild.Value.Row, starChild.Value.RowSpan);
 
 					for (int i = 0; i < sizes.Length; i++)
 					{


### PR DESCRIPTION
Use SliceClamped (as elsewhere in Grid layouting), fixes bug when a Grid child has a RowSpan that would exceed # of rows.

GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://nventive.visualstudio.com/Umbrella/_workitems/edit/150798
https://nventive.visualstudio.com/Umbrella/_workitems/edit/150799
