### PR TITLE
WASM: Added support for DOM's CustomEvents

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -18,6 +18,7 @@
 * 149377 Improve performance of `TimePicker` and `DatePicker` on iOS.
 * 145203 [iOS] Support ScrollViewer.ChangeView() inside TextBox
 * 150793 [iOS] Add ListView.UseCollectionAnimations flag to allow disabling native insert/delete animations
+* [Wasm] Added support for custom DOM events
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.
@@ -185,7 +186,7 @@
 * Time picker flyout default styles has been changed to include done and cancel buttons
 * DataTemplateSelector implementations are now called using the 2 parameters overload first with a fallback to the 1 parameter overload on null returned value.
   Old behavior could be restored using `FeatureConfiguration.DataTemplateSelector.UseLegacyTemplateSelectorOverload = true`.
-* Using "/n" directly in the XAML for a text/content property is not supported anymore in order to match the UWP behavior. 
+* Using "/n" directly in the XAML for a text/content property is not supported anymore in order to match the UWP behavior.
   You can use "&#x0a;" instead in the text/content properties or a carriage return where you need it in the localized resources.
 * The `ResourcesGeneration` msbuild target has been renamed to `UnoResourcesGeneration`
   If your csproj is using this target explicily, change it to the new name.
@@ -325,10 +326,10 @@
  * 136093, 136172 [iOS] ComboBox does not display its Popup
  * 134819, 134828 [iOS] Ensures the back gesture is enabled and disabled properly when the CommandBar is visible, collapsed, visible with a navigation command and collapsed with a navigation command.
  * 137081 Xaml generator doesn't support setting a style on the root control
- * 148228 [Android] Right theme (clock or spinner) is selected for specific time increments 
- * 148229 [Android] Right time is picked and rounded to nearest time increment in clock mode 
+ * 148228 [Android] Right theme (clock or spinner) is selected for specific time increments
+ * 148229 [Android] Right time is picked and rounded to nearest time increment in clock mode
  * 148241 [Android] won't open if `MinuteIncrement` is not set
- * 148582 Time picker initial time when using time increment is using initial time seconds when rounding.. it should ignore seconds.. 
+ * 148582 Time picker initial time when using time increment is using initial time seconds when rounding.. it should ignore seconds..
  * 148285 [iOS] TimePicker is clipped off screen when ios:FlyoutPlacement isnt set
 
 ## Release 1.40
@@ -358,7 +359,7 @@ Here are some highlights of this release:
 - Added support for `AutomationPeer`
 - Android status bar height is now included in `Window.Bounds`
 - Add support for `Underline` in `HyperLinkButton`
-- Add support for TextBlock.TextDecorations 
+- Add support for TextBlock.TextDecorations
 - TextBlock base class is now `FrameworkElement` on iOS, instead of `UILabel`
 - Auto generated list of views implemented in Uno in the documentation
 - Add support for string to `Type` conversion in XAML generator and binding engine
@@ -382,21 +383,21 @@ Here's the full change log:
     - TextBox InputScope fixes
     - Improved ListViewBase stability
     - SimpleOrientationSensor fixes
-    - PathMarkupParser: Add support for whitespace following FillRule command 
+    - PathMarkupParser: Add support for whitespace following FillRule command
     - Fix DependencyObjectStore.PopCurrentlySettingProperty
     - Raised navigation completed after setting CanGoBack/Forward
     - Fix layouting that sometimes misapplies margin
-    - Selector: Coerce SelectedItem to ensure its value is always valid 
-    - Remove legacy panel default constructor restriction 
+    - Selector: Coerce SelectedItem to ensure its value is always valid
+    - Remove legacy panel default constructor restriction
     - Wasm image support improvements
-    - Add support for forward slash in image source 
+    - Add support for forward slash in image source
     - Add support for CollectionViewSource set directly on ItemsControl.ItemSource
-    - Fix Pane template binding for SplitView 
-    - Add support for Object as DependencyProperty owner 
-    - Add Wasm support for UIElement.Tapped 
+    - Fix Pane template binding for SplitView
+    - Add support for Object as DependencyProperty owner
+    - Add Wasm support for UIElement.Tapped
     - Fix iOS UnregisterDoubleTapped stack overflow
 - Compatibility and stability fixes [#43](https://github.com/nventive/Uno/pull/43)
-    - Adjust WASM thickness support for children arrange 
+    - Adjust WASM thickness support for children arrange
     - Fix support for inline text content using ContentProperty
     - Fix memory leaks in ScrollViewer
     - Adjust for missing styles in UWP Styles FeatureConfiguration
@@ -494,9 +495,9 @@ Here's the full change log:
     - Adjust `MessageDialog` behavior for android
     - `ContentControl` Data Context is now properly unset
     - Add `EmailNameOrAddress` InputScope for `TextBox`
-    - Fixed duplicated resw entry support 
+    - Fixed duplicated resw entry support
     - Fixed `ComboBox` popup touch issue
-    - Add support for TextBlock.TextDecorations 
+    - Add support for TextBlock.TextDecorations
     - TextBlock base class from UILabel to FrameworkElement
 - Auto-generate list of views implemented in Uno [#152](https://github.com/nventive/Uno/pull/152)
 - Add support for string to `Type` conversion in Xaml generator and Binding engine. [#159](https://github.com/nventive/Uno/pull/159)
@@ -505,5 +506,5 @@ Here's the full change log:
 - Added support for XAML inline collections declaration [#184](https://github.com/nventive/Uno/pull/184)
 - Adjust the sequence of control template materialization [#192](https://github.com/nventive/Uno/pull/192)
 - Support for ListView.ScrollIntoView with leading alignment
-- Added support for ListView GroupStyle.HeaderTemplateSelector 
-- [IOS-ANDROID] Added support for time picker minute increment 
+- Added support for ListView GroupStyle.HeaderTemplateSelector
+- [IOS-ANDROID] Added support for time picker minute increment

--- a/doc/articles/toc.yml
+++ b/doc/articles/toc.yml
@@ -28,3 +28,5 @@
   href: MediaPlayerElement.md
 - name: Build Tools Telemetry
   href: uno-toolchain-telemetry.md
+- name: Html Custom Events (Wasm)
+  href: wasm-custom-events.md

--- a/doc/articles/wasm-custom-events.md
+++ b/doc/articles/wasm-custom-events.md
@@ -1,0 +1,53 @@
+# (Wasm) Handling custom HTML events
+
+There is a specification in HTML to create custom DOM events.
+
+It could be useful to intercept those events in managed code.
+To reach this, you need to register to those events.
+
+## Creating an Event or a CustomEvent
+
+In javascript (or Typescript), you can send a custom event
+using the following code:
+
+``` javascript
+    // Generate a custom generic event from Javascript/Typescript
+    htmlElement.dispatchEvent(new Event("simpleEvent"));
+
+    // Generate a custom event with a string payload
+    const payload = "this is the payload of the event";
+    htmlElement.dispatchEvent(new CustomEvent("stringEvent", {detail: payload}));
+
+    // Generate a custom event with a complex payload
+    const payload = { property:"value", property2: 1234 };
+    htmlElement.dispatchEvent(new CustomEvent("complexEvent", {detail: payload}));
+```
+
+## Registering an event handler in C# for those events
+
+``` csharp
+    protected override void OnLoaded()
+    {
+        // Note: following extensions are in the namespace "Uno.Extensions"
+        this.RegisterHtmlEventHandler("simpleEvent", OnSimpleEvent);
+        this.RegisterHtmlCustomEventHandler("stringEvent", OnStringEvent, isDetailJson: false);
+        this.RegisterHtmlCustomEventHandler("complexEvent", OnComplexEvent, isDetailJson: true);
+    }
+
+    private void OnSimpleEvent(object sender, EventArgs e)
+    {
+        // You can react on "simpleEvent" here
+    }
+
+    private void OnStringEvent(object sender, HtmlCustomEventArgs e)
+    {
+        // You can react on "stringEvent" here
+        // The payload is availabe on e.Detail
+    }
+
+    private void OnComplexEvent(object sender, HtmlCustomEventArgs e)
+    {
+        // You can react on "complexEvent" here
+        // The payload is availabe on e.Detail as a JSON string
+    }
+```

--- a/src/AddIns/Uno.UI.Lottie/LottieVisualSource.wasm.cs
+++ b/src/AddIns/Uno.UI.Lottie/LottieVisualSource.wasm.cs
@@ -7,6 +7,7 @@ using Windows.Foundation;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
+using Uno.Extensions;
 
 namespace Microsoft.Toolkit.Uwp.UI.Lottie
 {

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -13,6 +13,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Wasm\Wasm_CustomEvent.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_ApplicationModel_Resources_ResourceLoader\ResourceLoader_Simple.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1237,6 +1241,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\ViewModelBase.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Lottie\SampleLottieAnimation.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Wasm\Wasm_CustomEvent.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_ApplicationModel_Resources_ResourceLoader\ResourceLoader_Simple.xaml.cs">
       <DependentUpon>ResourceLoader_Simple.xaml</DependentUpon>
     </Compile>
@@ -2118,6 +2123,9 @@
     <PRIResource Include="$(MSBuildThisFileDirectory)UITestsStrings\en-US\Resources.resw" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Wasm\Wasm_CustomEvent.xaml.cs">
+      <DependentUpon>Wasm_CustomEvent.xaml</DependentUpon>
+    </Compile>
     <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Button\AppBarButtonTest.xaml.cs">
       <DependentUpon>AppBarButtonTest.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Wasm/Wasm_CustomEvent.xaml
+++ b/src/SamplesApp/UITests.Shared/Wasm/Wasm_CustomEvent.xaml
@@ -1,0 +1,23 @@
+﻿<Page
+	x:Class="UITests.Shared.Wasm.Wasm_CustomEvent"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<StackPanel>
+		<TextBlock>This test is for the WASM target only. Don't do anything on other platforms.</TextBlock>
+		<Border Height="100" Background="BurlyWood" x:Name="genericEvent">
+			<TextBlock>Tap here to generate a generic html event</TextBlock>
+		</Border>
+		<Border Height="100" Background="Cyan" x:Name="customEventString">
+			<TextBlock>Tap here to generate a custom html event with string payload</TextBlock>
+		</Border>
+		<Border Height="100" Background="BurlyWood" x:Name="customEventJson">
+			<TextBlock>Tap here to generate a custom html event with json payload</TextBlock>
+		</Border>
+		<TextBlock x:Name="result">Result here...</TextBlock>
+
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Wasm/Wasm_CustomEvent.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Wasm/Wasm_CustomEvent.xaml.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+#if __WASM__
+using Uno.Foundation;
+using Uno.Extensions;
+#endif
+
+namespace UITests.Shared.Wasm
+{
+#if __WASM__
+	[SampleControlInfo("Wasm", nameof(Wasm_CustomEvent))]
+#endif
+	public sealed partial class Wasm_CustomEvent : Page
+	{
+		public Wasm_CustomEvent()
+		{
+			this.InitializeComponent();
+		}
+
+#if __WASM__
+		protected override void OnLoaded()
+		{
+			var genericId = genericEvent.HtmlId;
+			var stringId = customEventString.HtmlId;
+			var jsonId = customEventJson.HtmlId;
+
+			var script = @"
+(function(id1, id2, id3){
+	const div1 = document.getElementById(id1);
+	const div2 = document.getElementById(id2);
+	const div3 = document.getElementById(id3);
+
+	const onDiv1 = function(){
+		div1.dispatchEvent(new Event(""unoevent1""));
+	};
+
+	const onDiv2 = function(){
+		div2.dispatchEvent(new CustomEvent(""unoevent2"", {detail:""String detail from event.""}));
+	};
+
+	const onDiv3 = function(){
+		div3.dispatchEvent(new CustomEvent(""unoevent3"", {detail: {msg:""msg"",int:123,txt:""it works!""}}));
+	};
+
+	div1.addEventListener(""click"", onDiv1);
+	div2.addEventListener(""click"", onDiv2);
+	div3.addEventListener(""click"", onDiv3);
+
+	return ""ok"";
+})";
+			WebAssemblyRuntime.InvokeJS($"{script}({genericId},{stringId},{jsonId});");
+
+			genericEvent.RegisterHtmlEventHandler("unoevent1", OnUnoEvent1);
+			customEventString.RegisterHtmlCustomEventHandler("unoevent2", OnUnoEvent2, isDetailJson: false);
+			customEventJson.RegisterHtmlCustomEventHandler("unoevent3", OnUnoEvent3, isDetailJson: true);
+
+		}
+
+		private void OnUnoEvent1(object sender, EventArgs e)
+		{
+			result.Text += $"Received generic event from {sender}\n.";
+		}
+
+		private void OnUnoEvent2(object sender, HtmlCustomEventArgs e)
+		{
+			result.Text += $"Received string event from {sender}: \"{e.Detail}\"\n.";
+		}
+
+		private void OnUnoEvent3(object sender, HtmlCustomEventArgs e)
+		{
+			result.Text += $"Received json event from {sender}: {e.Detail}\n.";
+		}
+#endif
+	}
+}

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.d.ts
@@ -352,6 +352,8 @@ declare namespace Uno.UI {
          * @param evt
          */
         private focusEventExtractor;
+        private customEventDetailExtractor;
+        private customEventDetailStringExtractor;
         /**
          * Gets the event extractor function. See UIElement.HtmlEventExtractor
          * @param eventExtractorName an event extractor name.

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -876,6 +876,18 @@ var Uno;
                 }
                 return "";
             }
+            customEventDetailExtractor(evt) {
+                if (evt) {
+                    const detail = evt.detail;
+                    if (detail) {
+                        return JSON.stringify(detail);
+                    }
+                }
+                return "";
+            }
+            customEventDetailStringExtractor(evt) {
+                return evt ? `${evt.detail}` : "";
+            }
             /**
              * Gets the event extractor function. See UIElement.HtmlEventExtractor
              * @param eventExtractorName an event extractor name.
@@ -891,6 +903,10 @@ var Uno;
                             return this.tappedEventExtractor;
                         case "FocusEventExtractor":
                             return this.focusEventExtractor;
+                        case "CustomEventDetailJsonExtractor":
+                            return this.customEventDetailExtractor;
+                        case "CustomEventDetailStringExtractor":
+                            return this.customEventDetailStringExtractor;
                     }
                     throw `Event filter ${eventExtractorName} is not supported`;
                 }

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -763,6 +763,21 @@
 			return "";
 		}
 
+		private customEventDetailExtractor(evt: CustomEvent): string {
+			if (evt) {
+				const detail = evt.detail;
+				if (detail) {
+					return JSON.stringify(detail);
+				}
+			}
+
+			return "";
+		}
+
+		private customEventDetailStringExtractor(evt: CustomEvent): string {
+			return evt ? `${evt.detail}` : "";
+		}
+
 		/**
 		 * Gets the event extractor function. See UIElement.HtmlEventExtractor
 		 * @param eventExtractorName an event extractor name.
@@ -782,6 +797,12 @@
 
 					case "FocusEventExtractor":
 						return this.focusEventExtractor;
+
+					case "CustomEventDetailJsonExtractor":
+						return this.customEventDetailExtractor;
+
+					case "CustomEventDetailStringExtractor":
+						return this.customEventDetailStringExtractor;
 				}
 
 				throw `Event filter ${eventExtractorName} is not supported`;

--- a/src/Uno.UI/UI/Xaml/HtmlCustomEventArgs.cs
+++ b/src/Uno.UI/UI/Xaml/HtmlCustomEventArgs.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Uno.Extensions
+{
+	public class HtmlCustomEventArgs : EventArgs
+	{
+		public string Detail { get; }
+
+		public HtmlCustomEventArgs(string detail)
+		{
+			Detail = detail;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -265,6 +265,8 @@ namespace Windows.UI.Xaml
 			TappedEventExtractor,
 			KeyboardEventExtractor,
 			FocusEventExtractor,
+			CustomEventDetailStringExtractor, // For use with CustomEvent("name", {detail:{string detail here}})
+			CustomEventDetailJsonExtractor, // For use with CustomEvent("name", {detail:{detail here}}) - will be JSON.stringify
 		}
 
 		private class EventRegistration

--- a/src/Uno.UI/UI/Xaml/UIElementExtensions.Wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElementExtensions.Wasm.cs
@@ -1,6 +1,7 @@
 ﻿using System;
+using Windows.UI.Xaml;
 
-namespace Windows.UI.Xaml
+namespace Uno.Extensions
 {
 	public static class UIElementExtensions
 	{
@@ -16,6 +17,36 @@ namespace Windows.UI.Xaml
 		/// Unregister previously registered event with RegisterHtmlEventHandler.
 		/// </summary>
 		public static void UnregisterHtmlEventHandler(this UIElement element, string eventName, EventHandler handler)
+		{
+			element.UnregisterEventHandler(eventName, handler);
+		}
+
+		/// <summary>
+		/// Will invoke `addEventListener(<paramref name="eventName"/>)` on the corresponding HTML element.
+		/// </summary>
+		/// <remarks>
+		/// For use with CustomEvent("name", {detail:{detail here}}).
+		/// </remarks>
+		/// <param name="isDetailJson">
+		/// True will JSON.stringify the content. False will treat the content as a string.
+		/// </param>
+		public static void RegisterHtmlCustomEventHandler(this UIElement element, string eventName, EventHandler<HtmlCustomEventArgs> handler, bool isDetailJson = false)
+		{
+			var extractor = isDetailJson
+				? UIElement.HtmlEventExtractor.CustomEventDetailJsonExtractor
+				: UIElement.HtmlEventExtractor.CustomEventDetailStringExtractor;
+
+			element.RegisterEventHandler(
+				eventName,
+				handler,
+				eventExtractor: extractor,
+				payloadConverter: s => new HtmlCustomEventArgs(s));
+		}
+
+		/// <summary>
+		/// Unregister previously registered event with RegisterHtmlCustomEventHandler.
+		/// </summary>
+		public static void UnregisterHtmlCustomEventHandler(this UIElement element, string eventName, EventHandler<HtmlCustomEventArgs> handler)
 		{
 			element.UnregisterEventHandler(eventName, handler);
 		}

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -338,6 +338,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <UpToDateCheckInput Remove="UI\Xaml\HtmlCustomEventArgs.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
 	  <None Update="Mixins\net461\VisualStatesMixins.tt">
 	    <Generator>TextTemplatingFileGenerator</Generator>
 	  </None>


### PR DESCRIPTION
## Feature

You can now add event listener for HTML's `CustomEvent` and get a string payload.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
