### PR TITLE
Dismiss android virtual keyboard when a textbox is losing focus

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -40,6 +40,7 @@
 * 145203 [Android] Fix overflow on LogicalToPhysicalPixels(double.MaxValue), allowing ScrollViewer.ChangeView(double.MaxValue,...) to work
 * 150679 [iOS] Fix path issue with Media Player not being able to play local files.
 * Adjust support for `StaticResource.ResourceKey`
+* 151081 [Android] Fix Keyboard not always dismissed when unfocusing a TextBox
 
 ## Release 1.44.0
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -457,7 +457,11 @@ namespace Windows.UI.Xaml.Controls
 						{
 							// Hide they keyboard for the activity's current focus instead of the view
 							// because it may have already been assigned to another focused control
-							inputManager?.HideSoftInputFromWindow(activity?.CurrentFocus?.WindowToken, Android.Views.InputMethods.HideSoftInputFlags.None);
+
+							//Seems like CurrentFocus can be null if the previously focused element is not part of the view anymore,
+							//resulting in the keyboard not being closed.
+							//We still try to get the Window token from it and it and if we fail, we get it from the TextBox we're currently unfocusing. 
+							inputManager?.HideSoftInputFromWindow(activity?.CurrentFocus?.WindowToken ?? ((View)this).WindowToken, Android.Views.InputMethods.HideSoftInputFlags.None);
 						}
 
 						if (hasFocus)


### PR DESCRIPTION
## Bugfix 

## What is the current behavior?
On Android, the virtual Keyboard does not always disappear when we unfocus a TextBox while the view changes simultaneously.


## What is the new behavior?
The Keyboard is always dismissed 


## PR Checklist

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue :
[https://nventive.visualstudio.com/Umbrella/_workitems/edit/151081](https://nventive.visualstudio.com/Umbrella/_workitems/edit/151081)
