### PR TITLE
[iOS] Fix incorrect offset when setting RenderTransform

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -31,6 +31,7 @@
 * 149377 Improve performance of `TimePicker` and `DatePicker` on iOS.
 * 145203 [iOS] Support ScrollViewer.ChangeView() inside TextBox
 * 150793 [iOS] Add ListView.UseCollectionAnimations flag to allow disabling native insert/delete animations
+* 150882 [iOS] Fix visual glitch when setting new RenderTransform on a view
 * [Wasm] Add support of hardware/browser back button in `SystemNavigationManager.BackRequested`
 * [Wasm] Added support for custom DOM events
 * WebAssembly UI tests are now integrated in the CI

--- a/src/Uno.UI/Media/NativeRenderTransformAdapter.Android.cs
+++ b/src/Uno.UI/Media/NativeRenderTransformAdapter.Android.cs
@@ -30,7 +30,12 @@ namespace Uno.UI.Media
 		internal Android.Graphics.Matrix Matrix { get; } = new Android.Graphics.Matrix();
 
 		partial void Initialized()
-			=> UpdateParent(null, Owner.Parent);
+		{
+			// Apply the transform as soon as its been declared
+			Update();
+
+			UpdateParent(null, Owner.Parent);
+		}
 
 		public void UpdateParent(object oldParent, object newParent)
 		{
@@ -102,6 +107,6 @@ namespace Uno.UI.Media
 			(Owner.Parent as BindableView)?.UnregisterChildTransform(this);
 
 			Owner.Invalidate();
-		} 
+		}
 	}
 }

--- a/src/Uno.UI/Media/NativeRenderTransformAdapter.cs
+++ b/src/Uno.UI/Media/NativeRenderTransformAdapter.cs
@@ -38,9 +38,6 @@ namespace Uno.UI.Media
 			// This is used only by animations
 			transform.View = owner;
 
-			// Apply the transform as soon as its been declared
-			Update();
-
 			// Partial constructor
 			Initialized();
 

--- a/src/Uno.UI/Media/NativeRenderTransformAdapter.iOSmacOS.cs
+++ b/src/Uno.UI/Media/NativeRenderTransformAdapter.iOSmacOS.cs
@@ -15,7 +15,10 @@ namespace Uno.UI.Media
 		{
 			// On íOS and MacOS Transform are applied by default on the center on the view
 			// so make sure to reset it when the transform is attached to the view
-			Apply(isSizeChanged: false, isOriginChanged: true);
+			InitializeOrigin();
+
+			// Apply the transform as soon as its been declared
+			Update();
 		}
 
 		private CATransform3D _transform = CATransform3D.Identity;
@@ -62,6 +65,17 @@ namespace Uno.UI.Media
 			{
 				Owner.Layer.Transform = _transform = Transform.MatrixCore.ToTransform3D();
 			}
+		}
+
+		private void InitializeOrigin()
+		{
+			var oldFrame = Owner.Layer.Frame;
+
+			Owner.Layer.AnchorPoint = CurrentOrigin;
+
+			// Restore the old frame to correct the offset potentially introduced by changing AnchorPoint. This is safe to do since we know
+			// that the transform is currently identity.
+			Owner.Layer.Frame = oldFrame;
 		}
 
 		partial void Cleanup()

--- a/src/Uno.UI/Media/NativeRenderTransformAdapter.wasm.cs
+++ b/src/Uno.UI/Media/NativeRenderTransformAdapter.wasm.cs
@@ -10,6 +10,9 @@ namespace Uno.UI.Media
 	{
 		partial void Initialized()
 		{
+			// Apply the transform as soon as its been declared
+			Update();
+
 			// On WASM Transform are applied by default on the center on the view
 			// so make sure to reset it when the transform is attached to the view
 			Apply(isSizeChanged: false, isOriginChanged: true);


### PR DESCRIPTION
When view.Layer.AnchorPoint is set on initializing a transform, reapply the Frame to correct for the offset potentially introduced. This fixes a spurious visual offset when a RenderTransform is set after a view is already visible.

GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

Bugfix 
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://nventive.visualstudio.com/Umbrella/_workitems/edit/150882