### PR TITLE
Allow to invoke JS methods which has no return value

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -64,7 +64,7 @@
                 reason="Removed as Routed Events implement it properly"/>  
         
         <Member fullName="System.Boolean Uno.Foundation.WebAssemblyRuntime.InvokeJSUnmarshalled(System.String functionIdentifier, System.IntPtr arg0, System.IntPtr arg1, System.IntPtr arg2)" 
-                reason="Removed to improve the C#/JS call performance"/>  
+                reason="Removed to improve the C#/JS call performance"/>
       </Methods>
       
       <Events>
@@ -92,5 +92,18 @@
                 reason="Unused Uno specific property" />
       </Properties>
     </IgnoreSet>
+    
+    <IgnoreSet baseVersion="1.44.0">
+      <Types>
+        <Member fullName="Windows.UI.Xaml.UIElementExtensions"
+                reason="Moved to Uno.Extensions"/>
+      </Types>
+
+      <Methods>
+        <Member fullName="System.Boolean Uno.Foundation.WebAssemblyRuntime.InvokeJSUnmarshalled(System.String functionIdentifier, System.IntPtr arg0, System.IntPtr arg1, System.IntPtr arg2)"
+                reason="Removed to improve the C#/JS call performance"/>
+      </Methods>
+      
+    </IgnoreSet>  
   </IgnoreSets>
 </DiffIgnore>

--- a/src/Uno.Foundation/Runtime.wasm.cs
+++ b/src/Uno.Foundation/Runtime.wasm.cs
@@ -215,11 +215,6 @@ namespace Uno.Foundation
 				result = InvokeJSOverride(str);
 			}
 
-			if (result == null)
-			{
-				throw new InvalidOperationException("The invoked Javascript method did not return a value (" + str + ")");
-			}
-
 			return result;
 		}
 


### PR DESCRIPTION
## PR Type
- Feature

## What is the current behavior?
All JavaScript method must return a string

## What is the new behavior?
Method can now don't have any return type (a.k.a. void)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

