### PR TITLE
Add pseudo Native styles for WASM

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -36,6 +36,7 @@
 * [Wasm] Added support for custom DOM events
 * WebAssembly UI tests are now integrated in the CI
 * Enable support for macOS head development
+* [Wasm] Add NativeXXX styles (which are aliases to the XamlXXX styles)
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.

--- a/doc/articles/using-uno-ui.md
+++ b/doc/articles/using-uno-ui.md
@@ -294,6 +294,13 @@ Uno.UI also generates a nested class named StaticResources in all non-ResourceDi
 
 Uno.UI supports the [authoring of styles](https://msdn.microsoft.com/en-us/library/windows/apps/windows.ui.xaml.style.aspx).
 
+Usually 2 styles are packaged for each control in Uno
+* NativeDefault<Control> which is customized to match the UI guidelines of the target platform
+* XamlDefault<Crontrol> which is the default style of controls on Windows
+
+On WASM, the NativeDefault<Control> styles are only aliases over the XamlDefault<Control> so you can reference them even 
+if currently there is no native styles per browser.
+
 ## Localization
 
 Localization is done through the `resw` files in the current project. Resources are then used using `x:Uid`.

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.Native.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.Native.xaml
@@ -15,8 +15,17 @@
 					xmlns:toolkit="using:Uno.UI.Toolkit"
 					xmlns:maps="using:Windows.UI.Xaml.Controls.Maps"
 					xmlns:mapsPresenter="using:Windows.UI.Xaml.Controls.Maps"
+					xmlns:wasm="http://uno.ui/wasm"
 					xmlns:not_wasm="http://uno.ui/not_wasm"
-					mc:Ignorable="d xamarin ios android not_wasm">
+					mc:Ignorable="d xamarin ios android wasm not_wasm">
+
+	<wasm:ResourceDictionary.MergedDictionaries>
+		<!--
+			On WASM we don't  necessarilly have native style, so we refrence the Windows styles as "native" so we are able
+			to multi-target their usage in application without having to discover which native styles are available or not.
+		-->
+		<ResourceDictionary Source="Generic.xaml" />
+	</wasm:ResourceDictionary.MergedDictionaries>
 
 	<!-- Default native Button styles -->
 	<android:Style x:Key="NativeDefaultButton"
@@ -55,8 +64,14 @@
 			   BasedOn="{StaticResource NativeDefaultButton}"
 			   TargetType="Button" />
 
-	<not_wasm:Style BasedOn="{StaticResource NativeDefaultButton}"
-					TargetType="Button" />
+	<wasm:Style
+		x:Key="NativeDefaultButton"
+		TargetType="Button"
+		BasedOn="{StaticResource XamlDefaultButton}" />
+
+	<xamarin:Style
+		TargetType="Button"
+		BasedOn="{StaticResource NativeDefaultButton}" />
 
 	<!-- Default native CheckBox styles -->
 	<android:Style x:Key="NativeDefaultCheckBox"
@@ -95,8 +110,14 @@
 		</Setter>
 	</ios:Style>
 
-	<not_wasm:Style BasedOn="{StaticResource NativeDefaultCheckBox}"
-					TargetType="CheckBox" />
+	<wasm:Style
+		x:Key="NativeDefaultCheckBox"
+		TargetType="CheckBox"
+		BasedOn="{StaticResource XamlDefaultCheckBox}" />
+
+	<xamarin:Style
+		TargetType="CheckBox"
+		BasedOn="{StaticResource NativeDefaultCheckBox}" />
 
 	<!-- Default native RadioButton styles -->
 	<android:Style x:Key="AndroidRadioButtonStyle"
@@ -141,8 +162,14 @@
 		</Setter>
 	</android:Style>
 
-	<not_wasm:Style BasedOn="{StaticResource NativeDefaultToggleSwitch}"
-					TargetType="ToggleSwitch" />
+	<wasm:Style
+		x:Key="NativeDefaultToggleSwitch"
+		TargetType="ToggleSwitch"
+		BasedOn="{StaticResource XamlDefaultToggleSwitch}" />
+
+	<xamarin:Style
+		TargetType="ToggleSwitch"
+		BasedOn="{StaticResource NativeDefaultToggleSwitch}" />
 
 	<!-- Default native Slider styles -->
 	<ios:Style x:Key="NativeDefaultSlider"
@@ -173,8 +200,14 @@
 		</Setter>
 	</android:Style>
 
-	<not_wasm:Style BasedOn="{StaticResource NativeDefaultSlider}"
-					TargetType="Slider" />
+	<wasm:Style
+		x:Key="NativeDefaultSlider"
+		TargetType="Slider"
+		BasedOn="{StaticResource XamlDefaultSlider}" />
+
+	<xamarin:Style
+		BasedOn="{StaticResource NativeDefaultSlider}"
+		TargetType="Slider" />
 
 	<converters:UnoNativeDefaultProgressBarReverseBoolConverter x:Key="nativeDefaultProgressBarReverseBool" />
 
@@ -215,8 +248,14 @@
 		</Setter>
 	</android:Style>
 
-	<not_wasm:Style BasedOn="{StaticResource NativeDefaultProgressBar}"
-					TargetType="ProgressBar" />
+	<wasm:Style
+		x:Key="NativeDefaultProgressBar"
+		TargetType="ProgressBar" 
+		BasedOn="{StaticResource XamlDefaultProgressBar}" />
+
+	<xamarin:Style
+		TargetType="ProgressBar" 
+		BasedOn="{StaticResource NativeDefaultProgressBar}" />
 
 	<!-- Default native TextBox styles -->
 	<xamarin:Style x:Key="NativeDefaultTextBox"
@@ -296,8 +335,13 @@
 		</Setter>
 	</android:Style>
 
-	<not_wasm:Style BasedOn="{StaticResource NativeDefaultPivot}"
-					TargetType="Pivot" />
+	<not_wasm:Style
+		TargetType="Pivot"
+		BasedOn="{StaticResource NativeDefaultPivot}" />
+
+	<wasm:Style
+		TargetType="Pivot"
+		BasedOn="{StaticResource XamlDefaultPivot}" />
 
 	<ios:Style x:Key="NativeDefaultCommandBar"
 			   TargetType="CommandBar">
@@ -342,8 +386,14 @@
 		</Setter>
 	</android:Style>
 
-	<not_wasm:Style TargetType="CommandBar"
-					BasedOn="{StaticResource NativeDefaultCommandBar}" />
+	<wasm:Style
+		x:Key="NativeDefaultCommandBar"
+		TargetType="CommandBar"
+		BasedOn="{StaticResource XamlCommandBar}" />
+
+	<xamarin:Style
+		TargetType="CommandBar"
+		BasedOn="{StaticResource NativeDefaultCommandBar}" />
 
 	<ios:Style x:Key="NativeDefaultAppBarButton"
 			   TargetType="AppBarButton">
@@ -361,8 +411,14 @@
 					Value="{x:Null}" />
 	</android:Style>
 
-	<not_wasm:Style TargetType="AppBarButton"
-					BasedOn="{StaticResource NativeDefaultAppBarButton}" />
+	<wasm:Style
+		x:Key="NativeDefaultAppBarButton"
+		TargetType="AppBarButton"
+		BasedOn="{StaticResource XamlAppBarButton}" />
+
+	<xamarin:Style
+		TargetType="AppBarButton"
+		BasedOn="{StaticResource NativeDefaultAppBarButton}" />
 
 	<!-- Default native Frame styles -->
 	<ios:Style x:Key="NativeDefaultFrame"
@@ -389,8 +445,15 @@
 		</Setter>
 	</android:Style>
 
-	<not_wasm:Style BasedOn="{StaticResource NativeDefaultFrame}"
-					TargetType="Frame" />
+	<!-- Default native Frame styles -->
+	<wasm:Style
+		x:Key="NativeDefaultFrame"
+		TargetType="Frame"
+		BasedOn="{StaticResource XamlDefaultFrame}" />
+
+	<xamarin:Style
+		TargetType="Frame"
+		BasedOn="{StaticResource NativeDefaultFrame}" />
 
 	<!--
 		Official recommendation: 

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -3307,35 +3307,16 @@
 		</Setter>
 	</xamarin:Style>
 
-	<wasm:Style TargetType="Button"
-				BasedOn="{StaticResource XamlDefaultButton}" />
-
 	<wasm:Style TargetType="ToggleButton"
 				BasedOn="{StaticResource XamlDefaultToggleButton}" />
-
-	<wasm:Style TargetType="CheckBox"
-				BasedOn="{StaticResource XamlDefaultCheckBox}" />
-
-	<wasm:Style TargetType="Slider"
-				BasedOn="{StaticResource XamlDefaultSlider}" />
 
 	<wasm:Style TargetType="RadioButton"
 				BasedOn="{StaticResource XamlDefaultRadioButton}" />
 
-	<wasm:Style TargetType="Frame"
-				BasedOn="{StaticResource XamlDefaultFrame}" />
-
 	<wasm:Style TargetType="TextBox"
 				BasedOn="{StaticResource XamlDefaultTextBox}" />
-
 	<wasm:Style TargetType="PasswordBox"
 				BasedOn="{StaticResource XamlDefaultPasswordBox}" />
-
-	<wasm:Style TargetType="ProgressBar"
-				BasedOn="{StaticResource XamlDefaultProgressBar}" />
-
-	<wasm:Style TargetType="ToggleSwitch"
-				BasedOn="{StaticResource XamlDefaultToggleSwitch}" />
 
 	<!-- Default style for Windows.UI.Xaml.Controls.CheckBox -->
 	<xamarin:Style x:Key="XamlDefaultCheckBox"
@@ -4822,7 +4803,7 @@
 	</xamarin:Style>
 
 	<!-- Default style for Windows.UI.Xaml.Controls.CommandBar -->
-	<not_wasm:Style x:Key="XamlCommandBar"
+	<xamarin:Style x:Key="XamlCommandBar"
 					TargetType="CommandBar">
 		<Setter Property="Background"
 				Value="{ThemeResource SystemControlBackgroundChromeMediumBrush}" />
@@ -6080,7 +6061,7 @@
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
-	</not_wasm:Style>
+	</xamarin:Style>
 
 	<!-- Ellipsis button style for use in Windows.UI.Xaml.Controls.AppBar and Windows.UI.Xaml.Controls.CommandBar -->
 	<xamarin:Style x:Key="EllipsisButton"


### PR DESCRIPTION
## PR Type
- Feature

## What is the current behavior?
No default `NativeXXX` style on wasm

## What is the new behavior?
`NativeXXX` styles aliases over their corresponding `XamlXXX` styles.

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
Internal Issue (If applicable):
https://nventive.visualstudio.com/_workitems/edit/151526