### PR TITLE
[iOS] Browse Superviews for NeedsKeyboard

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -64,6 +64,7 @@
 * 151524 [Android] Cleaned up Textbox for android to remove keyboard showing/dismissal inconsistencies
 * Fix invalid code generation for `x:Name` entries on `Style` in resources
 * [Wasm] Fix incorrect `TextBlock` measure with constrains
+* 151676 [iOS] The keyboard is closing when tap on the webview or toolbar
 
 ## Release 1.44.0
 

--- a/doc/articles/using-uno-ui.md
+++ b/doc/articles/using-uno-ui.md
@@ -573,5 +573,9 @@ As of iOS 9, the system does not allow iPad applications to dictate their orient
 <true/>
 ```
 
+#### Controlling the Keyboard on iOS
+
+If a view needs to keep the keyboard opened when tapping on it, use the `Uno.UI.Controls.Window.SetNeedsKeyboard` method.
+
 ## Creating/Using Android Activities
 At the root of every Android Uno app lies a `BaseActivity` class that extends from `Android.Support.V7.App.AppCompatActivity` which is part of the [Android v7 AppCompat Support Library](https://developer.android.com/topic/libraries/support-library/features.html#v7-appcompat). If you ever need to create a new Activity within your app or within Uno you must be sure to extend `BaseActivity` and, if you need to apply a Theme to the activity, ensure that the Theme you set is a `Theme.AppCompat` theme (or descendant).

--- a/src/Uno.UI/Controls/Window.iOS.cs
+++ b/src/Uno.UI/Controls/Window.iOS.cs
@@ -296,7 +296,10 @@ namespace Uno.UI.Controls
 
 		private static bool GetNeedsKeyboard(UIView view)
 		{
-			return view != null && _attachedProperties.GetValue(view, NeedsKeyboardAttachedPropertyKey, () => default(bool?)).GetValueOrDefault();
+			var superViews = view.FindSuperviews().ToList();
+			superViews.Insert(0, view);
+
+			return superViews.Any(superView => _attachedProperties.GetValue(superView, NeedsKeyboardAttachedPropertyKey, () => default(bool?)).GetValueOrDefault());
 		}
 
 		private static bool NeedsKeyboard(UIView view)


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one or more that apply to this PR -->

 Bugfix


## What is the current behavior?
On iOS, the keyboard closes even if we set NeedsKeyboard to true on the current view.


## What is the new behavior?
The keyboard stays open when we set that it's needed.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable): https://nventive.visualstudio.com/Umbrella/_workitems/edit/151676
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->