### PR TITLE
[iOS] Add ability to replay a finished video from media player

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -60,6 +60,7 @@
 * [WASM] Support `not_wasm` prefix properly. (#784)
 * 151282 [iOS] Fixed Slider not responding on second navigation, fixed RemoveHandler for RoutedEvents removing all instances of handler 
 * 151497 [iOS/Android] Fixed Slider not responding, by ^ RemoveHandler fix for RoutedEvents 
+* 151674 [iOS] Add ability to replay a finished video from media player
 * 151524 [Android] Cleaned up Textbox for android to remove keyboard showing/dismissal inconsistencies
 
 ## Release 1.44.0

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
@@ -199,10 +199,12 @@ namespace Windows.Media.Playback
 
 			try
 			{
-				// If we reached the end of media, we need to reset position to 0
 				if (PlaybackSession.PlaybackState == MediaPlaybackState.None)
 				{
-					PlaybackSession.Position = TimeSpan.Zero;
+					// It's AVPlayer default behavior to clear CurrentItem when no next item exists
+					// Solution to this is to reinitialize the source if video was: Ended, Failed or Manually stopped (not paused)
+					// This will also reinitialize all videos in case of source list, but only in one of 3 listed scenarios above
+					InitializeSource();
 				}
 
 				PlaybackSession.PlaybackState = MediaPlaybackState.Buffering;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

 - Bugfix
Add ability to replay an ios video by reintializing the source

<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Video that ended can't be replayed

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
A video can be replayed when ended

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/151674