### PR TITLE
Dev/pako/fix android textbox unfocus

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -60,6 +60,7 @@
 * [WASM] Support `not_wasm` prefix properly. (#784)
 * 151282 [iOS] Fixed Slider not responding on second navigation, fixed RemoveHandler for RoutedEvents removing all instances of handler 
 * 151497 [iOS/Android] Fixed Slider not responding, by ^ RemoveHandler fix for RoutedEvents 
+* 151524 [Android] Cleaned up Textbox for android to remove keyboard showing/dismissal inconsistencies
 
 ## Release 1.44.0
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -469,6 +469,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\Keyboard\Keyboard_Showing_Dismissal.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\RoutedEvents\RoutedEventsPage.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1735,6 +1739,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToggleSwitchControl\ToggleSwitch_IsOn.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\CopyToClipboard\CopyToClipboard.xaml.cs">
       <DependentUpon>CopyToClipboard.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\Keyboard\Keyboard_Showing_Dismissal.xaml.cs">
+      <DependentUpon>Keyboard_Showing_Dismissal.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\Models\CopyToClipboardViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Input\RoutedEvents\RoutedEventsPage.xaml.cs">

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/Keyboard/Keyboard_Showing_Dismissal.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/Keyboard/Keyboard_Showing_Dismissal.xaml
@@ -1,0 +1,22 @@
+﻿<UserControl x:Class="UITests.Shared.Windows_UI_Xaml_Input.Keyboard.Keyboard_Showing_Dismissal"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Input.Keyboard"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<Grid>
+		<StackPanel HorizontalAlignment="Left">
+			<TextBox Width="200"
+					 PlaceholderText="Number"
+					 InputScope="Number" />
+			<TextBox Width="200"
+					 PlaceholderText="Text" />
+			<PasswordBox Width="200" />
+			<Button Content="FocusButton" />
+		</StackPanel>
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/Keyboard/Keyboard_Showing_Dismissal.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Input/Keyboard/Keyboard_Showing_Dismissal.xaml.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Input.Keyboard
+{
+	[SampleControlInfo("Keyboard", "Keyboard_Showing_Dismissal")]
+	public sealed partial class Keyboard_Showing_Dismissal : UserControl
+	{
+		public Keyboard_Showing_Dismissal()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBox/TextBox.Android.cs
@@ -427,6 +427,9 @@ namespace Windows.UI.Xaml.Controls
 
 		private void ProcessFocusChanged(bool hasFocus)
 		{
+			//We get the view token early to avoid nullvalues when the view has already been detached
+			var viewWindowToken = _textBoxView.WindowToken;
+
 			_keyboardDisposable.Disposable = CoreDispatcher.Main
 				//The delay is required because the OnFocusChange method is called when the focus is being changed, not when it has changed.
 				//If the focus is moved from one TextBox to another, the CurrentFocus will be null, meaning we would hide the keyboard when we shouldn't.
@@ -448,8 +451,7 @@ namespace Windows.UI.Xaml.Controls
 						//When a TextBox gains focus, we want to show the keyboard
 						if (hasFocus && needsKeyboard)
 						{
-							inputManager?.ShowSoftInput(_textBoxView, Android.Views.InputMethods.ShowFlags.Forced);
-							inputManager?.ToggleSoftInput(Android.Views.InputMethods.ShowFlags.Forced, Android.Views.InputMethods.HideSoftInputFlags.ImplicitOnly);
+							inputManager?.ShowSoftInput(_textBoxView, Android.Views.InputMethods.ShowFlags.Implicit);
 						}
 
 						//When a TextBox loses focus, we want to dismiss the keyboard if no other view requiring it is focused
@@ -460,8 +462,8 @@ namespace Windows.UI.Xaml.Controls
 
 							//Seems like CurrentFocus can be null if the previously focused element is not part of the view anymore,
 							//resulting in the keyboard not being closed.
-							//We still try to get the Window token from it and it and if we fail, we get it from the TextBox we're currently unfocusing. 
-							inputManager?.HideSoftInputFromWindow(activity?.CurrentFocus?.WindowToken ?? ((View)this).WindowToken, Android.Views.InputMethods.HideSoftInputFlags.None);
+							//We still try to get the Window token from it and if we fail, we get it from the TextBox we're currently unfocusing.
+							inputManager?.HideSoftInputFromWindow(activity?.CurrentFocus?.WindowToken ?? viewWindowToken, Android.Views.InputMethods.HideSoftInputFlags.None);
 						}
 
 						if (hasFocus)


### PR DESCRIPTION
##  Bugfix

## What is the current behavior?
The Android platform is not able to dismiss a keyboard that was shown using the [FORCE](https://developer.android.com/reference/android/view/inputmethod/InputMethodManager.html#SHOW_FORCED) flag. 
We try to force the hide method as well but it does not work when the Navigation already took place.


## What is the new behavior?
Using the [IMPLICIT](https://developer.android.com/reference/android/view/inputmethod/InputMethodManager.html#SHOW_IMPLICIT) flag instead when showing the keyboard to allow Android to dismiss it when needed.

## PR Checklist

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
[151524](https://nventive.visualstudio.com/Umbrella/_workitems/edit/151524)
