### PR TITLE
Fix invalid code generation for `x:Name` entries on `Style` in resources

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -62,6 +62,7 @@
 * 151497 [iOS/Android] Fixed Slider not responding, by ^ RemoveHandler fix for RoutedEvents 
 * 151674 [iOS] Add ability to replay a finished video from media player
 * 151524 [Android] Cleaned up Textbox for android to remove keyboard showing/dismissal inconsistencies
+* Fix invalid code generation for `x:Name` entries on `Style` in resources
 
 ## Release 1.44.0
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -859,6 +859,15 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				{
 					foreach (var namedResource in namedResources)
 					{
+						if (namedResource.Value.Type.Name == "Style")
+						{
+							// Styles are handled differently for now, and there's no variable generated
+							// for those entries. Skip the ApplyCompiledBindings for those. See
+							// ImportResourceDictionary handling of x:Name for more details.
+							continue;
+						}
+
+
 						writer.AppendFormatInvariant($"{namedResource.Key}.ApplyCompiledBindings();");
 					}
 				}

--- a/src/SourceGenerators/XamlGenerationTests/VSM.Test.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/VSM.Test.xaml
@@ -139,4 +139,3 @@
 	</Grid>
 
 </UserControl>
-    

--- a/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
+++ b/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
@@ -13,8 +13,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Uno.SourceGenerationTasks"/>
-		<PackageReference Include="Uno.Core.Build"/>
+		<PackageReference Include="Uno.SourceGenerationTasks" />
+		<PackageReference Include="Uno.Core.Build" />
 	</ItemGroup>
 	
 	<PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
@@ -51,6 +51,7 @@
 
 	<ItemGroup>
 	  <None Remove="NonDPAssignableTest.xaml" />
+	  <None Remove="xNameResources.xaml" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/SourceGenerators/XamlGenerationTests/xNameResources.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/xNameResources.xaml
@@ -1,4 +1,4 @@
-<UserControl x:Class="XamlGenerationTests.Shared.XBindUserControl"
+﻿<UserControl x:Class="XamlGenerationTests.Shared.xNameResources"
 			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 			 xmlns:local="using:XamlGenerationTests.Shared"
@@ -10,17 +10,9 @@
 			 Background="Blue">
 
 	<UserControl.Resources>
-		<DataTemplate x:Key="Test" x:DataType="local:MyType">
-			<Border Background="{x:Bind Value}" />
-		</DataTemplate>
 		<Style x:Name="rectangleStyle"  TargetType="Rectangle">
 			<Setter Property="Width" Value="{StaticResource SwatchSize}"/>
 			<Setter Property="Height" Value="{StaticResource SwatchSize}"/>
 		</Style>
 	</UserControl.Resources>
-
-	<Grid>
-		<TextBlock Text="{x:Bind Test}" />
-		<TextBlock Text="{x:Bind TypeProperty.Value, FallbackValue=42}" />
-	</Grid>
 </UserControl>


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Using `x:Name` on a style results in invalid generated code.

## What is the new behavior?
The generated code is now valid.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)