### PR TITLE
[iOS][DatePicker / TimePicker] Fix multiple issues on flyout and selection

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -65,6 +65,9 @@
 * Fix invalid code generation for `x:Name` entries on `Style` in resources
 * [Wasm] Fix incorrect `TextBlock` measure with constrains
 * 151676 [iOS] The keyboard is closing when tap on the webview or toolbar
+* 151655 [TimePicker][iOS] First time you open time picker it initializes the existing value to current time
+* 151656 [TimePicker][iOS] Time picker always shows +1 minute than selected value
+* 151657 [DatePicker][iOS] Date picker flyout displays 1 day earlier than selected value
 
 ## Release 1.44.0
 

--- a/src/Uno.UI/Extensions/NSDateExtensions.iOS.cs
+++ b/src/Uno.UI/Extensions/NSDateExtensions.iOS.cs
@@ -20,9 +20,10 @@ namespace Uno.UI.Extensions
 
 		public static NSDate ToNSDate(this DateTime date)
 		{
-			var reference = new DateTime(2001, 1, 1, 0, 0, 0);
+			var reference = DateTime.SpecifyKind(new DateTime(2001, 1, 1, 0, 0, 0), DateTimeKind.Utc);
+
 			var result = NSDate.FromTimeIntervalSinceReferenceDate(
-				(date - reference).TotalSeconds);
+				(date - reference.ToReferenceLocalTime()).TotalSeconds);
 			return result;
 		}
 
@@ -35,6 +36,31 @@ namespace Uno.UI.Extensions
 		{
 			var offset = TimeSpan.FromSeconds(offsetInSecondsFromGMT);
 			return date.ToTimeSpan().Add(offset);
+		}
+
+		public static DateTime ToReferenceLocalTime(this DateTime time)
+		{
+			if (time.Kind == DateTimeKind.Local)
+			{
+				return time;
+			}
+			else if (time.Kind == DateTimeKind.Utc)
+			{
+				var returnTime = new DateTime(time.Ticks, DateTimeKind.Local);
+				returnTime += TimeZone.CurrentTimeZone.GetUtcOffset(returnTime);
+
+				// We need to know if the date to compare is saving daylight or not to adjust the reference date
+				if (TimeZone.CurrentTimeZone.IsDaylightSavingTime(DateTime.Now))
+				{
+					returnTime += new TimeSpan(1, 0, 0);
+				}
+
+				return returnTime;
+			}
+			else
+			{
+				throw new ArgumentException("The source time zone cannot be determined.");
+			}
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/DatePicker/DatePicker.cs
@@ -203,9 +203,9 @@ namespace Windows.UI.Xaml.Controls
 					MaxYear = MaxYear
 				};
 
-				BindToFlyout("Date");
-				BindToFlyout("MinYear");
-				BindToFlyout("MaxYear");
+				BindToFlyout(nameof(Date));
+				BindToFlyout(nameof(MinYear));
+				BindToFlyout(nameof(MaxYear));
 #endif
 			}
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePicker.cs
@@ -210,6 +210,13 @@ namespace Windows.UI.Xaml.Controls
 			{
 				_thirdTextBlockColumn.Width = isTwelveHour ? "*" : "0";
 			}
+
+#if __IOS__
+			if (_flyoutButton?.Flyout is TimePickerFlyout timePickerFlyout)
+			{
+				timePickerFlyout.Time = Time;
+			}
+#endif
 		}
 
 		/// <summary>

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerFlyout.iOS.cs
@@ -43,7 +43,8 @@ namespace Windows.UI.Xaml.Controls
 			{
 				BorderThickness = Thickness.Empty,
 				HorizontalAlignment = HorizontalAlignment.Stretch,
-				HorizontalContentAlignment = HorizontalAlignment.Stretch
+				HorizontalContentAlignment = HorizontalAlignment.Stretch,
+				Time = Time
 			};
 
 			Content = _timeSelector;

--- a/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TimePicker/TimePickerSelector.iOS.cs
@@ -15,6 +15,7 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private UIDatePicker _picker;
 		private NSDate _initialTime;
+		private NSDate _newDate;
 
 		protected override void OnLoaded()
 		{
@@ -36,6 +37,8 @@ namespace Windows.UI.Xaml.Controls
 			_picker.Calendar = new NSCalendar(NSCalendarType.Gregorian);
 			_picker.Mode = UIDatePickerMode.Time;
 
+			_picker.ValueChanged += OnValueChanged;
+			
 			var parent = _picker.FindFirstParent<FrameworkElement>();
 
 			//Removing the date picker and adding it is what enables the lines to appear. Seems to be a side effect of adding it as a view. 
@@ -44,6 +47,11 @@ namespace Windows.UI.Xaml.Controls
 				parent.RemoveChild(_picker);
 				parent.AddSubview(_picker);
 			}
+		}
+		
+		private void OnValueChanged(object sender, EventArgs e)
+		{
+			_newDate = _picker.Date;
 		}
 
 		public void Initialize()
@@ -68,9 +76,9 @@ namespace Windows.UI.Xaml.Controls
 		{
 			if (_picker != null)
 			{
-				if (_picker.Date != _initialTime)
+				if (_newDate != _initialTime)
 				{
-					var time = _picker.Date.ToTimeSpan(_picker.TimeZone.GetSecondsFromGMT);
+					var time = _newDate.ToTimeSpan();
 
 					if (Time.Hours != time.Hours || Time.Minutes != time.Minutes)
 					{
@@ -102,20 +110,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private void SetPickerTime(TimeSpan time)
 		{
-			if (_picker != null)
-			{
-				// Because the UIDatePicker is set to use LocalTimeZone,
-				// we need to get the offset and apply it to the requested time.
-				var offset = TimeSpan.FromSeconds(_picker.TimeZone.GetSecondsFromGMT);
-
-				// Because the UIDatePicker applies the local timezone offset automatically when we set it,
-				// we need to compensate with a negated offset. This will show the time
-				// as if it was provided with no offset.
-				var timeWithOffset = time.Add(offset.Negate());
-				var nsDate = timeWithOffset.ToNSDate();
-
-				_picker.SetDate(nsDate, animated: false);
-			}
+			_picker?.SetDate(time.ToNSDate(), animated: false);
 		}
 
 		partial void OnClockIdentifierChangedPartialNative(string oldClockIdentifier, string newClockIdentifier)
@@ -140,6 +135,13 @@ namespace Windows.UI.Xaml.Controls
 							: "fr";
 
 			return new NSLocale(localeID);
+		}
+
+		protected override void OnUnloaded()
+		{
+			_picker.ValueChanged -= OnValueChanged;
+
+			base.OnUnloaded();
 		}
 	}
 }


### PR DESCRIPTION
GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

- Bugfix
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When you open a TimePicker flyout on a binded value, it displays the default value instead of the binded one

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
Open a TimePicker flyout shows the binded value

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
https://nventive.visualstudio.com/Umbrella/_workitems/edit/151655
https://nventive.visualstudio.com/Umbrella/_workitems/edit/151656
https://nventive.visualstudio.com/Umbrella/_workitems/edit/151657