### PR TITLE
WASM: Fix measuring bug with TextBlock

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -63,6 +63,7 @@
 * 151674 [iOS] Add ability to replay a finished video from media player
 * 151524 [Android] Cleaned up Textbox for android to remove keyboard showing/dismissal inconsistencies
 * Fix invalid code generation for `x:Name` entries on `Style` in resources
+* [Wasm] Fix incorrect `TextBlock` measure with constrains
 
 ## Release 1.44.0
 

--- a/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
+++ b/src/SamplesApp/SamplesApp.UnitTests.Shared/Controls/UITests/Presentation/SampleChooserViewModel.cs
@@ -710,6 +710,17 @@ namespace SampleControl.Presentation
 			{
 				var vm = Activator.CreateInstance(newContent.ViewModelType, fe.Dispatcher);
 				fe.DataContext = vm;
+
+				if(vm is IDisposable disposable)
+				{
+					void Dispose(object snd, RoutedEventArgs e)
+					{
+						fe.Unloaded -= Dispose;
+						disposable.Dispose();
+					}
+
+					fe.Unloaded += Dispose;
+				}
 			}
 
 			var controlContainsSampleControl = (control as UserControl)?.Content is Uno.UI.Samples.Controls.SampleControl;

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -517,6 +517,198 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_FontSize_Changing.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_Simple.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_Simple_databound.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_Supserscript.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock_with_inline_margin.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock_with_margin.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_One.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two_with_Different_Fonts.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two_With_Wrap.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two_With_Wrap_And_Trim.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxWidth_NaN.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxWidth_Wrap.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Simple_Contrained_Horizontal_Center_Wrap.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Simple_Contrained_Horizontal_Center_Wrap2.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Simple_Text.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Simple_Text_Font_Weight_Bold.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlockMultilineInStarStackPanel.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlockSimpleContrainedHorizontalCenterWrap2.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlockTimespan.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Textblocktimespancustomformat.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_CharacterSpacing.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_ConstrainedByContainer.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_FixedWidth_With_DataBound_Run.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_FontWeight.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Hyperlink.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Hyperlink_Touch.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Inlines_TemplatedParent.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_Inlines.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_Multiline.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_TextAlignment.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_TextTrimming.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Multiline_In_StarStackPanel.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Nested_Measure_With_Outer_Alignments.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Padding.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Progressing_Trim.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Run_Inheritance.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Span.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Special_Character.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Style_Inheritance.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_TextAlignment.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_TextTrimming_VerticalAlignment_Stretch.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_UpdatePerformance.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBoxSizeChanging.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBoxSizeChangingInlines.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBox_Size_Changing.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBox_Size_Changing_Inlines.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_IsReadOnly.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1649,6 +1841,7 @@
       <DependentUpon>Picker_Resizable.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Models\ImageWithLateSourceViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\TextBlockViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\TimePickerViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\NavigationViewTests\NavigationView_TopNavigation.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_LightDismiss.xaml.cs" />
@@ -1679,6 +1872,54 @@
       <DependentUpon>Slider_Styled.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Slider\Slider_Transformed.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_FontSize_Changing.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_Simple.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_Simple_databound.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_Supserscript.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock_with_inline_margin.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock_with_margin.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_One.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two_with_Different_Fonts.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two_With_Wrap.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two_With_Wrap_And_Trim.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxWidth_NaN.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxWidth_Wrap.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Simple_Contrained_Horizontal_Center_Wrap.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Simple_Contrained_Horizontal_Center_Wrap2.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Simple_Text.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Simple_Text_Font_Weight_Bold.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlockMultilineInStarStackPanel.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlockSimpleContrainedHorizontalCenterWrap2.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlockTimespan.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Textblocktimespancustomformat.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_CharacterSpacing.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_ConstrainedByContainer.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_FixedWidth_With_DataBound_Run.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_FontWeight.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Hyperlink.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Hyperlink_Touch.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Inlines_TemplatedParent.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_Inlines.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_Multiline.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_TextAlignment.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_TextTrimming.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Multiline_In_StarStackPanel.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Nested_Measure_With_Outer_Alignments.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Padding.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Progressing_Trim.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Run_Inheritance.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Span.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Special_Character.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Style_Inheritance.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_TextAlignment.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_TextTrimming_VerticalAlignment_Stretch.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_UpdatePerformance.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBoxSizeChanging.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBoxSizeChangingInlines.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBox_Size_Changing.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBox_Size_Changing_Inlines.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBox\TextBox_IsReadOnly.xaml.cs">
       <DependentUpon>TextBox_IsReadOnly.xaml</DependentUpon>
     </Compile>
@@ -2376,6 +2617,150 @@
     </Compile>
     <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Lottie\SampleLottieAnimation.xaml.cs">
       <DependentUpon>SampleLottieAnimation.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_FontSize_Changing.xaml.cs">
+      <DependentUpon>Attributed_text_FontSize_Changing.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_Simple.xaml.cs">
+      <DependentUpon>Attributed_text_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_Simple_databound.xaml.cs">
+      <DependentUpon>Attributed_text_Simple_databound.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_Supserscript.xaml.cs">
+      <DependentUpon>Attributed_text_Supserscript.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock.xaml.cs">
+      <DependentUpon>Progressing_TextBlock.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock_with_inline_margin.xaml.cs">
+      <DependentUpon>Progressing_TextBlock_with_inline_margin.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock_with_margin.xaml.cs">
+      <DependentUpon>Progressing_TextBlock_with_margin.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_One.xaml.cs">
+      <DependentUpon>SimpleText_MaxLines_One.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two.xaml.cs">
+      <DependentUpon>SimpleText_MaxLines_Two.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two_with_Different_Fonts.xaml.cs">
+      <DependentUpon>SimpleText_MaxLines_Two_with_Different_Fonts.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two_With_Wrap.xaml.cs">
+      <DependentUpon>SimpleText_MaxLines_Two_With_Wrap.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two_With_Wrap_And_Trim.xaml.cs">
+      <DependentUpon>SimpleText_MaxLines_Two_With_Wrap_And_Trim.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxWidth_NaN.xaml.cs">
+      <DependentUpon>SimpleText_MaxWidth_NaN.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxWidth_Wrap.xaml.cs">
+      <DependentUpon>SimpleText_MaxWidth_Wrap.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\Simple_Contrained_Horizontal_Center_Wrap.xaml.cs">
+      <DependentUpon>Simple_Contrained_Horizontal_Center_Wrap.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\Simple_Contrained_Horizontal_Center_Wrap2.xaml.cs">
+      <DependentUpon>Simple_Contrained_Horizontal_Center_Wrap2.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\Simple_Text.xaml.cs">
+      <DependentUpon>Simple_Text.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\Simple_Text_Font_Weight_Bold.xaml.cs">
+      <DependentUpon>Simple_Text_Font_Weight_Bold.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlockMultilineInStarStackPanel.xaml.cs">
+      <DependentUpon>TextBlockMultilineInStarStackPanel.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlockSimpleContrainedHorizontalCenterWrap2.xaml.cs">
+      <DependentUpon>TextBlockSimpleContrainedHorizontalCenterWrap2.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlockTimespan.xaml.cs">
+      <DependentUpon>TextBlockTimespan.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\Textblocktimespancustomformat.xaml.cs">
+      <DependentUpon>Textblocktimespancustomformat.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_CharacterSpacing.xaml.cs">
+      <DependentUpon>TextBlock_CharacterSpacing.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_ConstrainedByContainer.xaml.cs">
+      <DependentUpon>TextBlock_ConstrainedByContainer.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_FixedWidth_With_DataBound_Run.xaml.cs">
+      <DependentUpon>TextBlock_FixedWidth_With_DataBound_Run.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_FontWeight.xaml.cs">
+      <DependentUpon>TextBlock_FontWeight.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Hyperlink.xaml.cs">
+      <DependentUpon>TextBlock_Hyperlink.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Hyperlink_Touch.xaml.cs">
+      <DependentUpon>TextBlock_Hyperlink_Touch.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Inlines_TemplatedParent.xaml.cs">
+      <DependentUpon>TextBlock_Inlines_TemplatedParent.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_Inlines.xaml.cs">
+      <DependentUpon>TextBlock_LineHeight_Inlines.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_Multiline.xaml.cs">
+      <DependentUpon>TextBlock_LineHeight_Multiline.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_TextAlignment.xaml.cs">
+      <DependentUpon>TextBlock_LineHeight_TextAlignment.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_TextTrimming.xaml.cs">
+      <DependentUpon>TextBlock_LineHeight_TextTrimming.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Multiline_In_StarStackPanel.xaml.cs">
+      <DependentUpon>TextBlock_Multiline_In_StarStackPanel.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Nested_Measure_With_Outer_Alignments.xaml.cs">
+      <DependentUpon>TextBlock_Nested_Measure_With_Outer_Alignments.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Padding.xaml.cs">
+      <DependentUpon>TextBlock_Padding.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Progressing_Trim.xaml.cs">
+      <DependentUpon>TextBlock_Progressing_Trim.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Run_Inheritance.xaml.cs">
+      <DependentUpon>TextBlock_Run_Inheritance.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Span.xaml.cs">
+      <DependentUpon>TextBlock_Span.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Special_Character.xaml.cs">
+      <DependentUpon>TextBlock_Special_Character.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Style_Inheritance.xaml.cs">
+      <DependentUpon>TextBlock_Style_Inheritance.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_TextAlignment.xaml.cs">
+      <DependentUpon>TextBlock_TextAlignment.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_TextTrimming_VerticalAlignment_Stretch.xaml.cs">
+      <DependentUpon>TextBlock_TextTrimming_VerticalAlignment_Stretch.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_UpdatePerformance.xaml.cs">
+      <DependentUpon>TextBlock_UpdatePerformance.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBoxSizeChanging.xaml.cs">
+      <DependentUpon>TextBoxSizeChanging.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBoxSizeChangingInlines.xaml.cs">
+      <DependentUpon>TextBoxSizeChangingInlines.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBox_Size_Changing.xaml.cs">
+      <DependentUpon>TextBox_Size_Changing.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBox_Size_Changing_Inlines.xaml.cs">
+      <DependentUpon>TextBox_Size_Changing_Inlines.xaml</DependentUpon>
     </Compile>
     <Compile Update="C:\s\nv.github\uno-2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml\UIElementTests\Arrange_Performance01.xaml.cs">
       <DependentUpon>Arrange_Performance01.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Models/TextBlockViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Models/TextBlockViewModel.cs
@@ -1,0 +1,111 @@
+﻿using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using Uno.Extensions;
+using Uno.UI.Samples.UITests.Helpers;
+using Windows.UI.Core;
+
+namespace Uno.UI.Samples.Presentation.SamplePages
+{
+	public class TextBlockViewModel : ViewModelBase
+	{
+		private string _currentDate;
+		private long _increasingSize;
+		private string _increasingText;
+		private string _alternatingLongText;
+		private string _alternatingSmallText;
+		private TimeSpan _randomTimeSpan = TimeSpan.FromMinutes(123);
+
+		public TextBlockViewModel(CoreDispatcher dispatcher) : base(dispatcher)
+		{
+			ObserveAlternatingLongText();
+		}
+
+		public string CurrentDate
+		{
+			get => _currentDate;
+			private set
+			{
+				_currentDate = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public long IncreasingSize
+		{
+			get => _increasingSize;
+			private set
+			{
+				_increasingSize = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public string IncreasingText
+		{
+			get => _increasingText;
+			private set
+			{
+				_increasingText = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public string AlternatingLongText
+		{
+			get => _alternatingLongText;
+			private set
+			{
+				_alternatingLongText = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public string AlternatingSmallText
+		{
+			get => _alternatingSmallText;
+			private set
+			{
+				_alternatingSmallText = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		public TimeSpan RandomTimeSpan
+		{
+			get => _randomTimeSpan;
+			private set
+			{
+				_randomTimeSpan = value;
+				RaisePropertyChanged();
+			}
+		}
+
+		private async void ObserveAlternatingLongText()
+		{
+			long i = 0;
+			while(!CT.IsCancellationRequested)
+			{
+				await Task.Delay(TimeSpan.FromSeconds(1));
+				i++;
+				var alternate = i % 2 == 0;
+
+				AlternatingLongText = alternate
+					? ""
+					: "This is a very long line of text that should wrap properly";
+
+				AlternatingSmallText = alternate
+					? ""
+					: "Small text";
+
+				IncreasingText = "This is a very long databound text with a number {0}".InvariantCultureFormat((i * 10) % 200);
+
+				IncreasingSize = (i * 10) % 200;
+
+				CurrentDate = DateTimeOffset.Now.ToString(CultureInfo.InvariantCulture);
+
+				RandomTimeSpan += TimeSpan.FromSeconds(20);
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_FontSize_Changing.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_FontSize_Changing.xaml
@@ -1,0 +1,30 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.Attributed_text_FontSize_Changing" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<TextBlock MaxLines="0" TextWrapping="Wrap">
+		<Run Text="This" FontSize="8" />
+		<Run Text="text" FontSize="10" />
+		<Run Text="should" FontSize="12" />
+		<Run Text="grow" FontSize="32" android:FontFamily="sans-serif" ios:FontFamily="sans-serif" win:FontFamily="Courier" />
+		<Run Text="and" FontSize="14" />
+		<Run Text="grow" FontSize="32" android:FontFamily="monospace" ios:FontFamily="monospace" win:FontFamily="Segoe"  />
+		<Run Text="and" FontSize="14" />
+		<Run Text="grow" FontSize="32" android:FontFamily="monospace" ios:FontFamily="monospace" win:FontFamily="Segoe" FontWeight="Bold" />
+		<Run Text="and" FontSize="14" />
+		<Run Text="grow" FontSize="32" android:FontFamily="sans-serif" ios:FontFamily="sans-serif" win:FontFamily="Courier" FontWeight="Bold" FontStyle="Italic"  />
+		<Run Text="in" FontSize="16" />
+		<Run Text="height" FontSize="18" />
+	</TextBlock>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_FontSize_Changing.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_FontSize_Changing.xaml.cs
@@ -1,0 +1,15 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "Attributed_text_FontSize_Changing", typeof(TextBlockViewModel))]
+	public sealed partial class Attributed_text_FontSize_Changing : UserControl
+	{
+		public Attributed_text_FontSize_Changing()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_Simple.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_Simple.xaml
@@ -1,0 +1,19 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.Attributed_text_Simple" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+		<TextBlock ><Run Text="Test Red" Foreground="Red" /><Run Text=" " /><Run Text="Test Blue" Foreground="Blue" /></TextBlock>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_Simple.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_Simple.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "Attributed_text_Simple")]
+	public sealed partial class Attributed_text_Simple : UserControl
+	{
+		public Attributed_text_Simple()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_Simple_databound.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_Simple_databound.xaml
@@ -1,0 +1,18 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.Attributed_text_Simple_databound" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<TextBlock ><Run Text="Current Date:" Foreground="Red" /><Run Text=" " /><Run Foreground="Blue" Text="{Binding [CurrentDate]}" /></TextBlock>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_Simple_databound.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_Simple_databound.xaml.cs
@@ -1,0 +1,15 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "Attributed_text_Simple_databound", typeof(TextBlockViewModel))]
+	public sealed partial class Attributed_text_Simple_databound : UserControl
+	{
+		public Attributed_text_Simple_databound()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_Supserscript.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_Supserscript.xaml
@@ -1,0 +1,24 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.Attributed_text_Supserscript" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Uno.UI.Samples.Content.UITests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<TextBlock >
+		<Run Text="Hello world" FontSize="30" android:FontFamily="sans-serif" ios:FontFamily="sans-serif" win:FontFamily="Segoe"  />
+		<Run ios:BaseLineAlignment="Superscript" android:BaseLineAlignment="Superscript" Text="md" FontSize="17" android:FontFamily="sans-serif" ios:FontFamily="sans-serif" win:FontFamily="Segoe"/>
+	</TextBlock>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_Supserscript.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Attributed_text_Supserscript.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfoAttribute("TextBlockControl", "Attributed_text_Supserscript")]
+	public sealed partial class Attributed_text_Supserscript : UserControl
+	{
+		public Attributed_text_Supserscript()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Progressing_TextBlock.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Progressing_TextBlock.xaml
@@ -1,0 +1,29 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.Progressing_TextBlock"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="10" FontSize="7" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="20" FontSize="7" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="30" FontSize="7" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="40" FontSize="7" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="50" FontSize="7" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="60" FontSize="7" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="70" FontSize="7" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="80" FontSize="7" />
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Progressing_TextBlock.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Progressing_TextBlock.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "Progressing_TextBlock")]
+	public sealed partial class Progressing_TextBlock : UserControl
+	{
+		public Progressing_TextBlock()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Progressing_TextBlock_with_inline_margin.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Progressing_TextBlock_with_inline_margin.xaml
@@ -1,0 +1,40 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.Progressing_TextBlock_with_inline_margin" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel >
+		<StackPanel.Resources>
+			<Style x:Key="style" TargetType="TextBlock" >
+				<Setter Property="FontSize" Value="7" />
+				<Setter Property="Margin" Value="5" />
+				<Setter Property="TextWrapping" Value="Wrap" />
+				<Setter Property="TextTrimming" Value="CharacterEllipsis" />
+				<Setter Property="MaxLines" Value="3" />
+			</Style>
+		</StackPanel.Resources>
+		<TextBlock Style="{StaticResource style}"><Run Text="The quick brown fox jumps over the lazy dog" FontSize="5" /><Run Text=" and cat" FontSize="8" /></TextBlock>
+		<TextBlock Style="{StaticResource style}" Width="10"><Run Text="The quick brown fox jumps over the lazy dog" FontSize="5" /><Run Text=" and cat" FontSize="8" /></TextBlock>
+		<TextBlock Style="{StaticResource style}" Width="20"><Run Text="The quick brown fox jumps over the lazy dog" FontSize="5" /><Run Text=" and cat" FontSize="8" /></TextBlock>
+		<TextBlock Style="{StaticResource style}" Width="30"><Run Text="The quick brown fox jumps over the lazy dog" FontSize="5" /><Run Text=" and cat" FontSize="8" /></TextBlock>
+		<TextBlock Style="{StaticResource style}" Width="40"><Run Text="The quick brown fox jumps over the lazy dog" FontSize="5" /><Run Text=" and cat" FontSize="8" /></TextBlock>
+		<TextBlock Style="{StaticResource style}" Width="50"><Run Text="The quick brown fox jumps over the lazy dog" FontSize="5" /><Run Text=" and cat" FontSize="8" /></TextBlock>
+		<TextBlock Style="{StaticResource style}" Width="60"><Run Text="The quick brown fox jumps over the lazy dog" FontSize="5" /><Run Text=" and cat" FontSize="8" /></TextBlock>
+		<TextBlock Style="{StaticResource style}" Width="70"><Run Text="The quick brown fox jumps over the lazy dog" FontSize="5" /><Run Text=" and cat" FontSize="8" /></TextBlock>
+		<TextBlock Style="{StaticResource style}" Width="80"><Run Text="The quick brown fox jumps over the lazy dog" FontSize="5" /><Run Text=" and cat" FontSize="8" /></TextBlock>
+		<TextBlock Style="{StaticResource style}" Width="90"><Run Text="The quick brown fox jumps over the lazy dog" FontSize="5" /><Run Text=" and cat" FontSize="8" /></TextBlock>
+		<TextBlock Style="{StaticResource style}" Width="200"><Run Text="The quick brown fox jumps over the lazy dog" FontSize="5" /><Run Text=" and cat" FontSize="8" /></TextBlock>
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Progressing_TextBlock_with_inline_margin.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Progressing_TextBlock_with_inline_margin.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "Progressing_TextBlock_with_inline_margin")]
+	public sealed partial class Progressing_TextBlock_with_inline_margin : UserControl
+	{
+		public Progressing_TextBlock_with_inline_margin()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Progressing_TextBlock_with_margin.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Progressing_TextBlock_with_margin.xaml
@@ -1,0 +1,29 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.Progressing_TextBlock_with_margin"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="10" FontSize="7" Margin="5" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="20" FontSize="7" Margin="5" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="30" FontSize="7" Margin="5" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="40" FontSize="7" Margin="5" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="50" FontSize="7" Margin="5" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="60" FontSize="7" Margin="5" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="70" FontSize="7" Margin="5" />
+		<TextBlock Text="The quick brown fox jumps over the lazy dog" Width="80" FontSize="7" Margin="5" />
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Progressing_TextBlock_with_margin.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Progressing_TextBlock_with_margin.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "Progressing_TextBlock_with_margin")]
+	public sealed partial class Progressing_TextBlock_with_margin : UserControl
+	{
+		public Progressing_TextBlock_with_margin()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_One.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_One.xaml
@@ -1,0 +1,19 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.SimpleText_MaxLines_One"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<TextBlock Text="This is a very very very very long text that should not wrap even though it goes out of the screen" FontSize="20" MaxLines="1"  />
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_One.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_One.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "SimpleText_MaxLines_One")]
+	public sealed partial class SimpleText_MaxLines_One : UserControl
+	{
+		public SimpleText_MaxLines_One()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two.xaml
@@ -1,0 +1,19 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.SimpleText_MaxLines_Two" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<TextBlock Text="This is a very very very very long text that should *not* wrap even though it goes out of the screen" FontSize="20" MaxLines="2"  />
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "SimpleText_MaxLines_Two")]
+	public sealed partial class SimpleText_MaxLines_Two : UserControl
+	{
+		public SimpleText_MaxLines_Two()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml
@@ -1,0 +1,25 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.SimpleText_MaxLines_Two_With_Wrap"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<Grid Width="350">
+		<TextBlock
+			Text="This is a very very very very long text that *should* wrap because it goes out of the screen"
+			FontSize="20"
+			TextWrapping="Wrap"
+			MaxLines="2"  />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "SimpleText_MaxLines_Two_With_Wrap", description: "This sample shows a very long line that should wrap on a maximum of two lines.")]
+	public sealed partial class SimpleText_MaxLines_Two_With_Wrap : UserControl
+	{
+		public SimpleText_MaxLines_Two_With_Wrap()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap_And_Trim.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap_And_Trim.xaml
@@ -1,0 +1,25 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.SimpleText_MaxLines_Two_With_Wrap_And_Trim"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<Grid Width="250">
+		<TextBlock Text="This is a very very very very long text that *should* wrap even because it goes out of the screen. This is a very very very very long text that *should* wrap even because it goes out of the screen. This is a very very very very long text that *should* wrap even because it goes out of the screen."
+				   FontSize="20" 
+				   TextWrapping="Wrap" 
+				   TextTrimming="CharacterEllipsis"
+				   MaxLines="2"  />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap_And_Trim.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap_And_Trim.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "SimpleText_MaxLines_Two_With_Wrap_And_Trim", description: "This sample should show two lines of text ending with an ellipsis.")]
+	public sealed partial class SimpleText_MaxLines_Two_With_Wrap_And_Trim : UserControl
+	{
+		public SimpleText_MaxLines_Two_With_Wrap_And_Trim()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_with_Different_Fonts.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_with_Different_Fonts.xaml
@@ -1,0 +1,30 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.SimpleText_MaxLines_Two_with_Different_Fonts"
+	 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	 xmlns:u="using:Uno.UI.Samples.Controls"
+	 xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	 xmlns:ios="http://uno.ui/ios"
+	 xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	 xmlns:android="http://uno.ui/android"
+	 mc:Ignorable="d ios android"
+	 d:DesignHeight="300"
+	 d:DesignWidth="400">
+
+	<Border Width="250">
+		<TextBlock FontSize="20"
+				   MaxLines="2"
+				   android:FontFamily="sans-serif"
+				   ios:FontFamily="sans-serif"
+				   win:FontFamily="Segoe">
+			<Run Text="ItemDescriptionKey :" />
+			<Run Text="Item description value with is a very very very very very very very very very long text that should wrap"
+				 android:FontFamily="sans-serif-light"
+				 ios:FontFamily="sans-serif-light"
+				 win:FontFamily="Comic Sans MS" />
+		</TextBlock>
+	</Border>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_with_Different_Fonts.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_with_Different_Fonts.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "SimpleText_MaxLines_Two_with_Different_Fonts")]
+	public sealed partial class SimpleText_MaxLines_Two_with_Different_Fonts : UserControl
+	{
+		public SimpleText_MaxLines_Two_with_Different_Fonts()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxWidth_NaN.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxWidth_NaN.xaml
@@ -1,0 +1,28 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Controls.SimpleText_MaxWidth_NaN"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:converters="using:Uno.UI.Samples.Converters"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignWidth="400">
+
+	<UserControl.Resources>
+		<converters:FromNullableBoolToDefaultValueConverter x:Key="DummyConverter"
+															TrueValue="NaN"
+															NullOrFalseValue="NaN" />
+	</UserControl.Resources>
+
+	<StackPanel>
+		<TextBlock HorizontalAlignment="Left"
+					MaxWidth="{Binding Converter={StaticResource DummyConverter}}" 
+					Text="This is my Text that should not wrap" />
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxWidth_NaN.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxWidth_NaN.xaml.cs
@@ -1,0 +1,13 @@
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Controls
+{
+	[SampleControlInfo("TextBlockControl", "SimpleText_MaxWidth_NaN", description: "The following textblock has a MaxWidth of NaN. It should be visible")]
+	public sealed partial class SimpleText_MaxWidth_NaN : UserControl
+	{
+		public SimpleText_MaxWidth_NaN()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxWidth_Wrap.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxWidth_Wrap.xaml
@@ -1,0 +1,51 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Controls.SimpleText_MaxWidth_Wrap" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignWidth="400">
+
+	<StackPanel>
+			<TextBlock Name="MaxWidth_InnerTextBlock"
+					MaxWidth="50" 
+					Text="This is my Text that should wrap" 
+					TextWrapping="Wrap"
+					TextTrimming="WordEllipsis" />
+
+		<Grid>
+			<Border Background="Red">
+				<TextBlock MaxWidth="50" Text="This is my Text that should wrap" TextWrapping="Wrap" TextAlignment="Center" />
+			</Border>
+			<Border BorderBrush="Blue" BorderThickness="1" Width="50" />
+		</Grid>
+		<Grid>
+			<Border Background="Red">
+				<TextBlock MaxWidth="50" Text="This is my Text that should wrap" TextWrapping="Wrap" TextAlignment="Left" />
+			</Border>
+			<Border BorderBrush="Blue" BorderThickness="1" Width="50" />
+		</Grid>
+		<Grid>
+			<Border Background="Red">
+				<TextBlock MaxWidth="50" Text="This is my Text that should wrap" TextWrapping="Wrap" TextAlignment="Right" />
+			</Border>
+			<Border BorderBrush="Blue" BorderThickness="1" Width="50" />
+		</Grid>
+		<Grid  Name="MaxWidth_InnerGrid">
+			<Border  Name="MaxWidth_InnerBorder" Background="Red">
+				<TextBlock MaxWidth="50" 
+						   Text="This is my Text that should wrap" 
+						   TextWrapping="Wrap" 
+						   />
+			</Border>
+			<Border BorderBrush="Blue" BorderThickness="1" Width="50" />
+		</Grid>
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxWidth_Wrap.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxWidth_Wrap.xaml.cs
@@ -1,0 +1,13 @@
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Controls
+{
+	[SampleControlInfo("TextBlockControl", "SimpleText_MaxWidth_Wrap", description: "The following textblock should stay inside the blue rectangle because of its MaxWidth.")]
+	public sealed partial class SimpleText_MaxWidth_Wrap : UserControl
+	{
+		public SimpleText_MaxWidth_Wrap()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Contrained_Horizontal_Center_Wrap.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Contrained_Horizontal_Center_Wrap.xaml
@@ -1,0 +1,44 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.Simple_Contrained_Horizontal_Center_Wrap"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<Grid >
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Button>
+			<Grid>
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="100" />
+				</Grid.ColumnDefinitions>
+				<Grid Height="95">
+					<TextBlock FontSize="20" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" HorizontalAlignment="Center" VerticalAlignment="Bottom" ><Run Text="Those three Words" /></TextBlock>
+				</Grid>
+			</Grid>
+		</Button>
+		<Button Grid.Column="1">
+			<Grid>
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="100" />
+				</Grid.ColumnDefinitions>
+				<Grid Height="95">
+					<TextBlock FontSize="20" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" HorizontalAlignment="Center" VerticalAlignment="Bottom" ><Run Text="Should be visible" /></TextBlock>
+				</Grid>
+			</Grid>
+		</Button>
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Contrained_Horizontal_Center_Wrap.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Contrained_Horizontal_Center_Wrap.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "Simple_Contrained_Horizontal_Center_Wrap")]
+	public sealed partial class Simple_Contrained_Horizontal_Center_Wrap : UserControl
+	{
+		public Simple_Contrained_Horizontal_Center_Wrap()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Contrained_Horizontal_Center_Wrap2.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Contrained_Horizontal_Center_Wrap2.xaml
@@ -1,0 +1,34 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.Simple_Contrained_Horizontal_Center_Wrap2"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<Button Background="Red" >
+		<Button.ContentTemplate>
+			<DataTemplate>
+				<Grid>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="100" />
+					</Grid.ColumnDefinitions>
+					<Grid.RowDefinitions>
+						<RowDefinition Height="auto" />
+					</Grid.RowDefinitions>
+					<TextBlock FontSize="20" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" HorizontalAlignment="Center" VerticalAlignment="Bottom" ><Run Text="Those three Words" /></TextBlock>
+				</Grid>
+			</DataTemplate>
+		</Button.ContentTemplate>
+		Those three Words
+	</Button>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Contrained_Horizontal_Center_Wrap2.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Contrained_Horizontal_Center_Wrap2.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "Simple_Contrained_Horizontal_Center_Wrap2")]
+	public sealed partial class Simple_Contrained_Horizontal_Center_Wrap2 : UserControl
+	{
+		public Simple_Contrained_Horizontal_Center_Wrap2()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Text.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Text.xaml
@@ -1,0 +1,18 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.Simple_Text"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<TextBlock Text="Sample Text" FontWeight="Bold" FontSize="40" />
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Text.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Text.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "Simple_Text")]
+	public sealed partial class Simple_Text : UserControl
+	{
+		public Simple_Text()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Text_Font_Weight_Bold.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Text_Font_Weight_Bold.xaml
@@ -1,0 +1,19 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.Simple_Text_Font_Weight_Bold"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<TextBlock Text="Sample Text" FontSize="40" FontWeight="Bold" FontStyle="Italic" />
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Text_Font_Weight_Bold.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Simple_Text_Font_Weight_Bold.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "Simple_Text_Font_Weight_Bold")]
+	public sealed partial class Simple_Text_Font_Weight_Bold : UserControl
+	{
+		public Simple_Text_Font_Weight_Bold()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlockMultilineInStarStackPanel.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlockMultilineInStarStackPanel.xaml
@@ -1,0 +1,29 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlockMultilineInStarStackPanel"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:xamarin="urn:xamarin"
+	mc:Ignorable="d xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<u:StarStackPanel Orientation="Vertical">
+		<u:StarStackPanel Orientation="Horizontal">
+			<TextBlock VerticalAlignment="Stretch"
+				   MaxLines="0"
+				   TextWrapping="Wrap"
+				   Margin="0,15"
+				   u:StarStackPanel.Size="*">
+			<Run Text="{Binding [AlternatingLongText]}"/>
+			<Run Text="that should wrap on multiple lines"/>
+			</TextBlock>
+			<TextBlock Text="Small Text"
+				   u:StarStackPanel.Size="auto"/>
+		</u:StarStackPanel>
+		<Border Background="Red"/>
+	</u:StarStackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlockMultilineInStarStackPanel.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlockMultilineInStarStackPanel.xaml.cs
@@ -1,0 +1,15 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlockMultilineInStarStackPanel", typeof(TextBlockViewModel), description: "TextBlock_Multiline_In_StarStackPanel")]
+	public sealed partial class TextBlockMultilineInStarStackPanel : UserControl
+	{
+		public TextBlockMultilineInStarStackPanel()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlockSimpleContrainedHorizontalCenterWrap2.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlockSimpleContrainedHorizontalCenterWrap2.xaml
@@ -1,0 +1,30 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlockSimpleContrainedHorizontalCenterWrap2"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<Button Background="Red">
+		<Button.ContentTemplate>
+			<DataTemplate>
+				<Grid>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="100"/>
+					</Grid.ColumnDefinitions>
+					<Grid.RowDefinitions>
+						<RowDefinition Height="auto"/>
+					</Grid.RowDefinitions>
+					<TextBlock FontSize="20" TextWrapping="Wrap" TextTrimming="CharacterEllipsis" HorizontalAlignment="Center" VerticalAlignment="Bottom">
+						<Run Text="Those three Words"/>
+					</TextBlock>
+				</Grid>
+			</DataTemplate>
+		</Button.ContentTemplate>
+
+		Those two Words
+	</Button>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlockSimpleContrainedHorizontalCenterWrap2.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlockSimpleContrainedHorizontalCenterWrap2.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlockSimpleContrainedHorizontalCenterWrap2")]
+	public sealed partial class TextBlockSimpleContrainedHorizontalCenterWrap2 : UserControl
+	{
+		public TextBlockSimpleContrainedHorizontalCenterWrap2()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlockTimespan.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlockTimespan.xaml
@@ -1,0 +1,20 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlockTimespan"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:converters="using:Uno.UI.Samples.Converters"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:xamarin="urn:xamarin"
+	mc:Ignorable="d xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<UserControl.Resources>
+		<converters:StringFormatConverter x:Key="stringFormatConverter" />
+	</UserControl.Resources>
+
+	<TextBlock Text="{Binding [RandomTimeSpan], Converter={StaticResource stringFormatConverter}, ConverterParameter='\{0:h\\:mm}'}" Foreground="Red" />
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlockTimespan.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlockTimespan.xaml.cs
@@ -1,0 +1,15 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlockTimespan", typeof(TextBlockViewModel))]
+	public sealed partial class TextBlockTimespan : UserControl
+	{
+		public TextBlockTimespan()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_CharacterSpacing.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_CharacterSpacing.xaml
@@ -1,0 +1,20 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_CharacterSpacing"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+  <StackPanel>
+	<TextBlock Text="This is my text, CharacterSpacing is in units of 1/1000 of an em" CharacterSpacing="{Binding ElementName=text, Path=Text}" />
+	<TextBox x:Name="text" Text="0" InputScope="Number"/>
+  </StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_CharacterSpacing.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_CharacterSpacing.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_CharacterSpacing")]
+	public sealed partial class TextBlock_CharacterSpacing : UserControl
+	{
+		public TextBlock_CharacterSpacing()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_ConstrainedByContainer.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_ConstrainedByContainer.xaml
@@ -1,0 +1,78 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_ConstrainedByContainer" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<StackPanel>
+
+		<TextBlock Text="All the constrained TextBlocks have the same text :" />
+
+		<TextBlock Text=" Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tristique tellus metus. Vestibulum tellus lorem, varius non gravida vitae, consectetur."
+				   TextWrapping="WrapWholeWords"
+				   FontSize="15" />
+
+		<Rectangle Height="1"
+				   Margin="0,5"
+				   Width="200" 
+				   Fill="Black" />
+
+		<TextBlock Text="The following TextBlock is inside a 20x200 Border. There is enough space for one line of text so it should trim"
+		           TextWrapping="WrapWholeWords"/>
+
+		<Border Height="20"
+				Width="200"
+				Background="Tomato"
+				Margin="0,10">
+			<TextBlock Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tristique tellus metus. Vestibulum tellus lorem, varius non gravida vitae, consectetur."
+			           TextWrapping="WrapWholeWords"
+					   FontSize="15" />
+		</Border>
+		
+		<Rectangle Height="1"
+				   Margin="0,5"
+				   Width="200" 
+				   Fill="Black" />
+
+		<TextBlock Text="The following TextBlock is inside a 40x200 Border. There is enough space for two lines of text so it should wrap and trim"
+		           TextWrapping="WrapWholeWords"/>
+
+		<Border Height="40"
+				Width="200"
+				Background="Tomato"
+				Margin="0,10">
+			<TextBlock Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tristique tellus metus. Vestibulum tellus lorem, varius non gravida vitae, consectetur."
+			           TextWrapping="WrapWholeWords"
+					   FontSize="15" />
+		</Border>
+		
+		<Rectangle Height="1"
+				   Margin="0,5"
+				   Width="200" 
+				   Fill="Black" />
+
+		<TextBlock Text="The following TextBlock is inside a 80x200 Border. There is enough text and space for 4 lines of text but the TextBlock has a MaxLines of 3."
+		           TextWrapping="WrapWholeWords"/>
+
+		<Border Height="80"
+				Width="200"
+				Background="Tomato"
+				Margin="0,10">
+			<TextBlock Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas tristique tellus metus. Vestibulum tellus lorem, varius non gravida vitae, consectetur." 
+					   MaxLines="3"
+					   TextWrapping="WrapWholeWords"
+					   FontSize="15" />
+		</Border>
+		
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_ConstrainedByContainer.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_ConstrainedByContainer.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_ConstrainedByContainer", description: "This samples shows how a TextBlock behaves in a constrained parent")]
+	public sealed partial class TextBlock_ConstrainedByContainer : UserControl
+	{
+		public TextBlock_ConstrainedByContainer()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FixedWidth_With_DataBound_Run.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FixedWidth_With_DataBound_Run.xaml
@@ -1,0 +1,26 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_FixedWidth_With_DataBound_Run" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<StackPanel Orientation="Horizontal">
+		<StackPanel Orientation="Vertical">
+			<Border Background="Red">
+				<TextBlock TextTrimming="CharacterEllipsis" TextWrapping="NoWrap">
+					<Run Text="Static Text - " />
+					<Run Text="{Binding [AlternatingSmallText]}" />
+				</TextBlock>
+			</Border>
+		</StackPanel>
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FixedWidth_With_DataBound_Run.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FixedWidth_With_DataBound_Run.xaml.cs
@@ -1,0 +1,15 @@
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_FixedWidth_With_DataBound_Run", typeof(TextBlockViewModel), description: "Description for sample of TextBlock_FixedWidth_With_DataBound_Run")]
+	public sealed partial class TextBlock_FixedWidth_With_DataBound_Run : UserControl
+	{
+		public TextBlock_FixedWidth_With_DataBound_Run()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FontWeight.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FontWeight.xaml
@@ -1,0 +1,41 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_FontWeight"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel>
+
+		<TextBlock Text="Normal:" />
+		<TextBlock FontSize="20" Text="ExtraBlack" FontWeight="ExtraBlack" />
+		<TextBlock FontSize="20" Text="Black" FontWeight="Black" />
+		<TextBlock FontSize="20" Text="ExtraBold" FontWeight="ExtraBold" />
+		<TextBlock FontSize="20" Text="Bold" FontWeight="Bold" />
+		<TextBlock FontSize="20" Text="SemiBold" FontWeight="SemiBold" />
+		<TextBlock FontSize="20" Text="Medium" FontWeight="Medium" />
+		<TextBlock FontSize="20" Text="Normal" FontWeight="Normal" />
+		<TextBlock FontSize="20" Text="Light" FontWeight="Light" />
+		<TextBlock FontSize="20" Text="SemiLight" FontWeight="SemiLight" />
+		<TextBlock FontSize="20" Text="ExtraLight" FontWeight="ExtraLight" />
+		<TextBlock FontSize="20" Text="Thin" FontWeight="Thin" />
+
+		<TextBlock Text="Italic:" />
+		<TextBlock FontStyle="Italic" FontSize="20" Text="ExtraBlack" FontWeight="ExtraBlack" />
+		<TextBlock FontStyle="Italic" FontSize="20" Text="Black" FontWeight="Black" />
+		<TextBlock FontStyle="Italic" FontSize="20" Text="ExtraBold" FontWeight="ExtraBold" />
+		<TextBlock FontStyle="Italic" FontSize="20" Text="Bold" FontWeight="Bold" />
+		<TextBlock FontStyle="Italic" FontSize="20" Text="SemiBold" FontWeight="SemiBold" />
+		<TextBlock FontStyle="Italic" FontSize="20" Text="Medium" FontWeight="Medium" />
+		<TextBlock FontStyle="Italic" FontSize="20" Text="Normal" FontWeight="Normal" />
+		<TextBlock FontStyle="Italic" FontSize="20" Text="Light" FontWeight="Light" />
+		<TextBlock FontStyle="Italic" FontSize="20" Text="SemiLight" FontWeight="SemiLight" />
+		<TextBlock FontStyle="Italic" FontSize="20" Text="ExtraLight" FontWeight="ExtraLight" />
+		<TextBlock FontStyle="Italic" FontSize="20" Text="Thin" FontWeight="Thin" />
+
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FontWeight.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_FontWeight.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_FontWeight")]
+	public sealed partial class TextBlock_FontWeight : UserControl
+	{
+		public TextBlock_FontWeight()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Hyperlink.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Hyperlink.xaml
@@ -1,0 +1,123 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_Hyperlink"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<ScrollViewer>
+		<StackPanel>
+
+			<TextBlock>
+				<Hyperlink Click="Hyperlink_Click">Normal</Hyperlink>
+			</TextBlock>
+		
+			<TextBlock>
+				<Hyperlink Click="Hyperlink_Click" 
+						   UnderlineStyle="None">Without underline</Hyperlink>
+			</TextBlock>
+
+			<TextBlock>
+				<Underline>
+					<Hyperlink Click="Hyperlink_Click"
+							   UnderlineStyle="None">Removed underline</Hyperlink>
+				</Underline>
+			</TextBlock>
+
+			<TextBlock>
+				<Hyperlink Click="Hyperlink_Click"
+						   UnderlineStyle="None">
+					<Underline>Added underline</Underline>
+				</Hyperlink>
+			</TextBlock>
+
+			<TextBlock>
+				<Span Foreground="Red">
+					<Hyperlink Click="Hyperlink_Click">Red parent</Hyperlink>
+				</Span>
+			</TextBlock>
+
+			<TextBlock>
+				<Hyperlink Click="Hyperlink_Click">
+					<Span Foreground="Red">Red child</Span>
+				</Hyperlink>
+			</TextBlock>
+
+			<TextBlock>
+				<Hyperlink Click="Hyperlink_Click"
+						   Foreground="Red">Red</Hyperlink>
+			</TextBlock>
+		
+			<TextBlock Margin="20">
+				<Hyperlink Click="Hyperlink_Click"
+						   UnderlineStyle="None">
+					<Span>
+						<Run>Normal</Run>
+						<Span FontSize="20">20</Span>
+						<Span Foreground="Red">Red</Span>
+						<Bold>Bold</Bold>
+						<Italic>Italic</Italic>
+						<Underline>Underline</Underline>
+					</Span>
+				</Hyperlink>
+			</TextBlock>
+
+			<TextBlock>
+				<Hyperlink Click="Hyperlink_Click">Click me</Hyperlink>
+			</TextBlock>
+			
+			<TextBlock>
+				<Hyperlink NavigateUri="http://www.nventive.com">http://www.nventive.com</Hyperlink>
+			</TextBlock>
+			
+			<TextBlock>
+				<Hyperlink NavigateUri="http://www.bing.com">Hyperlink to Bing</Hyperlink>
+			</TextBlock>
+
+			<TextBlock>Go to <Hyperlink NavigateUri="http://www.bing.com">Bing</Hyperlink>.</TextBlock>
+
+			<Border Background="LightGray"
+					HorizontalAlignment="Center">
+				<TextBlock Padding="5,10,15,20">Here is an <Hyperlink Click="Hyperlink_Click">hyperlink</Hyperlink> with a padding of 5,10,15,20.</TextBlock>
+			</Border>
+
+			<Border BorderBrush="Red"
+					BorderThickness="2"
+					Width="200">
+				<TextBlock TextWrapping="Wrap">This paragraph contains <Hyperlink Click="Hyperlink_Click">an hyperlink that wraps over multiple lines</Hyperlink>, surrounded by regular text.</TextBlock>
+			</Border>
+			
+			<TextBlock TextWrapping="Wrap"
+					   MaxLines="0">
+				<Hyperlink NavigateUri="http://www.lipsum.com">Lorem ipsum</Hyperlink> dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. <Hyperlink NavigateUri="http://www.lipsum.com">Lorem ipsum</Hyperlink> dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+			</TextBlock>
+
+			<TextBlock TextWrapping="Wrap"
+					   MaxLines="0"
+					   Width="200">
+				First line
+				<LineBreak />Second line
+				<LineBreak /><Hyperlink Click="Hyperlink_Click">Hyperlink</Hyperlink>
+				<LineBreak />Very very very very very very very very very very very very very very very very very very very very very very very very very very very very very very long text with <Hyperlink Click="Hyperlink_Click">an hyperlink</Hyperlink> and <Hyperlink Click="Hyperlink_Click">another hyperlink</Hyperlink>.
+				<LineBreak />Last line
+			</TextBlock>
+
+			<TextBlock x:Name="MyTextBlock" />
+
+			<!-- Hyperlinks that were not on the first line used to not work when TextWrapping="Wrap" and TextTrimming="CharacterEllipsis" were both set. -->
+			<TextBlock MaxLines="0"
+					   TextWrapping="Wrap"					 
+					   TextTrimming="CharacterEllipsis"
+					   Width="200">
+			  <Run Text="Very very very very very very very very very very very very very very very very very long text" />
+			  <!-- No LineBreak -->
+			  <Hyperlink Click="Hyperlink_Click">Hyperlink that's not on first line.</Hyperlink>
+			</TextBlock>
+
+		</StackPanel>
+	</ScrollViewer>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Hyperlink.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Hyperlink.xaml.cs
@@ -1,0 +1,31 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Documents;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_Hyperlink")]
+	public sealed partial class TextBlock_Hyperlink : UserControl
+	{
+		public TextBlock_Hyperlink()
+		{
+			this.InitializeComponent();
+
+			var run1 = new Run { Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, " };
+			var run2 = new Run { Text = "sed do eiusmod tempor " };
+			var run3 = new Run { Text = "incididunt ut labore et dolore magna aliqua." };
+			var hyperlink = new Hyperlink();
+			hyperlink.Inlines.Add(run2);
+			hyperlink.Click += Hyperlink_Click;
+			MyTextBlock.Inlines.Clear();
+			MyTextBlock.Inlines.Add(run1);
+			MyTextBlock.Inlines.Add(hyperlink);
+			MyTextBlock.Inlines.Add(run3);
+		}
+
+		private void Hyperlink_Click(Windows.UI.Xaml.Documents.Hyperlink sender, Windows.UI.Xaml.Documents.HyperlinkClickEventArgs args)
+		{
+			var t = new Windows.UI.Popups.MessageDialog("Hyperlink clicked!").ShowAsync();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Hyperlink_Touch.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Hyperlink_Touch.xaml
@@ -1,0 +1,22 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_Hyperlink_Touch"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel>
+
+		<Button Click="OnClick" Padding="20">
+			<TextBlock>
+				<Run>This button contains an </Run>
+				<Hyperlink Click="OnClick">Hyperlink</Hyperlink>
+			</TextBlock>
+		</Button>
+
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Hyperlink_Touch.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Hyperlink_Touch.xaml.cs
@@ -1,0 +1,20 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_Hyperlink_Touch")]
+	public sealed partial class TextBlock_Hyperlink_Touch : UserControl
+	{
+		public TextBlock_Hyperlink_Touch()
+		{
+			this.InitializeComponent();
+		}
+
+		private void OnClick(object sender, RoutedEventArgs args)
+		{
+			var t = new Windows.UI.Popups.MessageDialog($"Clicked on {sender.GetType().Name}").ShowAsync();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Inlines_TemplatedParent.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Inlines_TemplatedParent.xaml
@@ -1,0 +1,34 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_Inlines_TemplatedParent"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel>
+
+		<TextBlock Text="You should see 'MyContent' in Red, Green and Blue:" />
+
+		<Button Content="MyContent">
+			<Button.Template>
+				<ControlTemplate TargetType="Button">
+					<StackPanel Background="Gray">
+						<ContentPresenter Foreground="Red"
+										  Content="{Binding Content, RelativeSource={RelativeSource TemplatedParent}}" />
+						<TextBlock Foreground="Green"
+								   Text="{Binding Content, RelativeSource={RelativeSource TemplatedParent}}" />
+						<TextBlock>
+							<Run Foreground="Blue"
+								 Text="{Binding Content, RelativeSource={RelativeSource TemplatedParent}}" />
+						</TextBlock>
+					</StackPanel>
+				</ControlTemplate>
+			</Button.Template>
+		</Button>
+
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Inlines_TemplatedParent.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Inlines_TemplatedParent.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_Inlines_TemplatedParent")]
+	public sealed partial class TextBlock_Inlines_TemplatedParent : UserControl
+	{
+		public TextBlock_Inlines_TemplatedParent()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_Inlines.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_Inlines.xaml
@@ -1,0 +1,22 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_LineHeight_Inlines"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<Grid>
+
+		<TextBlock LineHeight="30">
+			<Run Text="Normal" />
+			<Run Text="Bold" FontWeight="Bold" />
+			<Run Text="Italic" FontStyle="Italic" />
+			<Run Text="Red" Foreground="Red" />
+		</TextBlock>
+
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_Inlines.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_Inlines.xaml.cs
@@ -1,0 +1,14 @@
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_LineHeight_Inlines")]
+	public sealed partial class TextBlock_LineHeight_Inlines : UserControl
+	{
+		public TextBlock_LineHeight_Inlines()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_Multiline.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_Multiline.xaml
@@ -1,0 +1,102 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_LineHeight_Multiline" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock Text="FontSize: "/>
+		<TextBox Text="14" x:Name="FontSizeTextBox"/>
+		<TextBlock Text="LineHeight: "/>
+		<TextBox Text="40" x:Name="LineHeightTextBox"/>
+		<ScrollViewer
+			Height="400">
+			<Grid>
+				<StackPanel Orientation="Vertical">
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightGoldenrodYellow"/>
+					<Rectangle Width="200" Height="{Binding ElementName=LineHeightTextBox, Path=Text}" Fill="LightBlue"/>
+				</StackPanel>
+				<Border BorderBrush="Black" BorderThickness="1"
+						Background="#2FD3D3D3"
+				   VerticalAlignment="Top">
+					<TextBlock Width="200"
+				   FontSize="{Binding ElementName=FontSizeTextBox, Path=Text}"
+				   Text="Selfies butcher fixie, knausgaard consequat try-hard accusamus odio quis elit. Accusamus ennui man bun portland, etsy intelligentsia meggings leggings chartreuse incididunt tempor ullamco. Twee knausgaard blog four dollar toast, truffaut scenester shoreditch reprehenderit normcore assumenda flexitarian asymmetrical celiac consequat deep v. +1 blog freegan, listicle yuccie DIY affogato asymmetrical narwhal sriracha 3 wolf moon. Truffaut blue bottle cred seitan. Tote bag ad hoodie keytar wayfarers voluptate. Man braid pinterest gastropub excepteur echo park, plaid umami ennui locavore."
+				   TextWrapping="Wrap"
+				   LineHeight="{Binding ElementName=LineHeightTextBox, Path=Text}"/>
+				</Border>
+			</Grid>
+		</ScrollViewer>
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_Multiline.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_Multiline.xaml.cs
@@ -1,0 +1,14 @@
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_LineHeight_Multiline", description: "Sample illustrating TextBlock.LineHeight property")]
+	public sealed partial class TextBlock_LineHeight_Multiline : UserControl
+	{
+		public TextBlock_LineHeight_Multiline()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_TextAlignment.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_TextAlignment.xaml
@@ -1,0 +1,51 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_LineHeight_TextAlignment"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<Border Background="Tomato">
+			<TextBlock Text="Center Text"
+					   FontWeight="Bold"
+					   Width="300"
+					   FontSize="40"
+					   LineHeight="200"
+					   TextAlignment="Center" />
+		</Border>
+		<Border Background="Cornsilk">
+			<TextBlock Text="Left Text"
+					   FontWeight="Bold"
+					   Width="300"
+					   LineHeight="200"
+					   FontSize="40"
+					   TextAlignment="Left" />
+		</Border>
+		<Border Background="Violet">
+			<TextBlock Text="Right Text"
+					   FontWeight="Bold"
+					   Width="300"
+					   FontSize="40"
+					   TextAlignment="Right"
+					   LineHeight="200" />
+		</Border>
+		<Border Background="CornflowerBlue">
+			<TextBlock Text="Default Text"
+					   FontWeight="Bold"
+					   Width="300"
+					   FontSize="40"
+					   LineHeight="200" />
+		</Border>
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_TextAlignment.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_TextAlignment.xaml.cs
@@ -1,0 +1,15 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_LineHeight_TextAlignment", description: "TextBlock LineHeight TextAlignment Tests")]
+	public sealed partial class TextBlock_LineHeight_TextAlignment : UserControl
+	{
+		public TextBlock_LineHeight_TextAlignment()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_TextTrimming.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_TextTrimming.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_LineHeight_TextTrimming"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<Grid>
+
+		<Border Height="50"
+				Background="Tomato">
+		  <TextBlock LineHeight="15"
+					 FontSize="15"
+					 TextTrimming="CharacterEllipsis"
+					 TextWrapping="Wrap"
+					 Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />
+		</Border>
+
+	</Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_TextTrimming.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_LineHeight_TextTrimming.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_LineHeight_TextTrimming")]
+	public sealed partial class TextBlock_LineHeight_TextTrimming : UserControl
+	{
+		public TextBlock_LineHeight_TextTrimming()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Multiline_In_StarStackPanel.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Multiline_In_StarStackPanel.xaml
@@ -1,0 +1,31 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_Multiline_In_StarStackPanel"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Uno.UI.Samples.Content.UITests"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<u:StarStackPanel Orientation="Vertical">
+		<u:StarStackPanel Orientation="Horizontal" Width="300">
+			<TextBlock VerticalAlignment="Stretch"
+					   MaxLines="0" 
+					   TextWrapping="Wrap"
+					   Margin="0,15" 
+					   u:StarStackPanel.Size="*" ><Run Text="{Binding [AlternatingLongText]}" /><Run Text="that should wrap on multiple lines" /></TextBlock>
+			<TextBlock Text="Small Text" u:StarStackPanel.Size="auto"  />
+		</u:StarStackPanel>
+		<Border Background="Red"  />
+	</u:StarStackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Multiline_In_StarStackPanel.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Multiline_In_StarStackPanel.xaml.cs
@@ -1,0 +1,15 @@
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfoAttribute("TextBlockControl", "TextBlock_Multiline_In_StarStackPanel", typeof(TextBlockViewModel), description: "A multiline textblock that contains data-bound runs that should wrap properly.")]
+	public sealed partial class TextBlock_Multiline_In_StarStackPanel : UserControl
+	{
+		public TextBlock_Multiline_In_StarStackPanel()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Nested_Measure_With_Outer_Alignments.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Nested_Measure_With_Outer_Alignments.xaml
@@ -1,0 +1,42 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_Nested_Measure_With_Outer_Alignments" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="Uno.UI.Samples.Content.UITests.TextBlockControl"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="200"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<u:StarStackPanel Orientation="Horizontal" Sizes="*,*">
+			<Border HorizontalAlignment="Right" BorderBrush="Red" BorderThickness="1">
+				<TextBlock Text="Left text" />
+			</Border>
+			<Border HorizontalAlignment="Left" BorderBrush="Red" BorderThickness="1">
+				<TextBlock Text="Right text" />
+			</Border>
+		</u:StarStackPanel>
+		<TextBlock Text="Both sample texts should be aligned to the center to the control." TextWrapping="Wrap" />
+		<u:StarStackPanel Orientation="Horizontal" Sizes="*,*">
+			<Button HorizontalAlignment="Right" BorderBrush="Red" BorderThickness="1">
+				<StackPanel Orientation="Horizontal">
+					<TextBlock Text="Left text" />
+				</StackPanel>
+			</Button>
+			<Button HorizontalAlignment="Left" BorderBrush="Red" BorderThickness="1">
+				<StackPanel Orientation="Horizontal">
+					<TextBlock Text="Right text" />
+				</StackPanel>
+			</Button>
+		</u:StarStackPanel>
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Nested_Measure_With_Outer_Alignments.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Nested_Measure_With_Outer_Alignments.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_Nested_Measure_With_Outer_Alignments", description: "Demonstrates that TextBlocks inside a StackPanel should return their own width, not the suggested max width. Both lines should be aligned to the center of the screen.")]
+	public sealed partial class TextBlock_Nested_Measure_With_Outer_Alignments : UserControl
+	{
+		public TextBlock_Nested_Measure_With_Outer_Alignments()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Padding.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Padding.xaml
@@ -1,0 +1,36 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_Padding"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<Border Background="CornflowerBlue"
+				Width="200">
+			<TextBlock Text="This is my text"
+					   FontSize="20" />
+		</Border>
+		<Border Background="Bisque"
+				Width="200">
+			<TextBlock Text="This is my text with padding"
+					   Padding="50"
+					   FontSize="20" />
+		</Border>
+		<Border Background="Tomato"
+				Width="200">
+			<TextBlock Text="This is my text with padding and wrap"
+					   Padding="50"
+					   FontSize="20"
+					   TextWrapping="Wrap" />
+		</Border>
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Padding.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Padding.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_Padding")]
+	public sealed partial class TextBlock_Padding : UserControl
+	{
+		public TextBlock_Padding()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Progressing_Trim.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Progressing_Trim.xaml
@@ -1,0 +1,63 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_Progressing_Trim" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignWidth="400">	
+
+	<StackPanel>
+		<StackPanel.Resources>
+			<x:String x:Key="longText">This is a very very very very long text that *should* wrap even because it goes out of the screen</x:String>
+		</StackPanel.Resources>
+		<Grid Width="250" Height="10" BorderBrush="Red" BorderThickness="1">
+			<TextBlock Text="{StaticResource longText}" 
+					   FontSize="20" 
+					   TextWrapping="Wrap"
+					   TextTrimming="CharacterEllipsis" />
+		</Grid>
+		<Grid Width="250" Height="20" BorderBrush="Red" BorderThickness="1">
+			<TextBlock Text="{StaticResource longText}" 
+					   FontSize="20" 
+					   TextWrapping="Wrap"
+					   TextTrimming="CharacterEllipsis" />
+		</Grid>
+		<Grid Width="250" Height="30" BorderBrush="Red" BorderThickness="1">
+			<TextBlock Text="{StaticResource longText}" 
+					   FontSize="20" 
+					   TextWrapping="Wrap"
+					   TextTrimming="CharacterEllipsis" />
+		</Grid>
+		<Grid Width="250" Height="40" BorderBrush="Red" BorderThickness="1">
+			<TextBlock Text="{StaticResource longText}" 
+					   FontSize="20" 
+					   TextWrapping="Wrap"
+					   TextTrimming="CharacterEllipsis" />
+		</Grid>
+		<Grid Width="250" Height="50" BorderBrush="Red" BorderThickness="1">
+			<TextBlock Text="{StaticResource longText}" 
+					   FontSize="20" 
+					   TextWrapping="Wrap"
+					   TextTrimming="CharacterEllipsis" />
+		</Grid>
+		<Grid Width="250" Height="80" BorderBrush="Red" BorderThickness="1">
+			<TextBlock Text="{StaticResource longText}" 
+					   FontSize="20" 
+					   TextWrapping="Wrap"
+					   TextTrimming="CharacterEllipsis" />
+		</Grid>
+		<Grid Width="250" Height="150" BorderBrush="Red" BorderThickness="1">
+			<TextBlock Text="{StaticResource longText}" 
+					   FontSize="20" 
+					   TextWrapping="Wrap"
+					   TextTrimming="CharacterEllipsis" />
+		</Grid>
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Progressing_Trim.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Progressing_Trim.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_Progressing_Trim", description: "Demonstrates that the same text will wrap and trim based on the size of its parent.")]
+	public sealed partial class TextBlock_Progressing_Trim : UserControl
+	{
+		public TextBlock_Progressing_Trim()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Run_Inheritance.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Run_Inheritance.xaml
@@ -1,0 +1,45 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_Run_Inheritance" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="400"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock Foreground="Black">
+			<Run Text="This is Red" Foreground="Red" />
+			<Run Text=" " />
+			<Run Text="Black" />
+		</TextBlock>
+		<TextBlock FontStyle="Normal" >
+			<Run Text="This is Italic" FontStyle="Italic" />
+			<Run Text=" " />
+			<Run Text="This is Normal" />
+		</TextBlock>
+		<TextBlock FontWeight="Normal" >
+			<Run Text="This is Bold" FontWeight="Bold" />
+			<Run Text=" " />
+			<Run Text="This is Normal" />
+		</TextBlock>
+		<TextBlock FontSize="12" >
+			<Run Text="This is Large" FontSize="24" />
+			<Run Text=" " />
+			<Run Text="This is Normal" />
+		</TextBlock>
+		<Button Foreground="Red">
+			<TextBlock>
+				<Run Text="This is Red" />
+				<Run Text="This is Black" Foreground="Black" />
+			</TextBlock>
+		</Button>
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Run_Inheritance.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Run_Inheritance.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_Run_Inheritance", description: "Demonstrates the inheritance of TextBlock properties to its Inlines")]
+	public sealed partial class TextBlock_Run_Inheritance : UserControl
+	{
+		public TextBlock_Run_Inheritance()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Span.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Span.xaml
@@ -1,0 +1,93 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_Span"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<ScrollViewer>
+
+		<StackPanel>
+
+			<TextBlock>TextBlock</TextBlock>
+
+			<!-- Run -->
+			<TextBlock>
+				<Run>Run</Run>
+			</TextBlock>
+
+			<!-- Span -->
+			<TextBlock>
+				<Span>Span</Span>
+			</TextBlock>
+
+			<!-- Underline -->
+			<TextBlock>
+				<Underline>Underline</Underline>
+			</TextBlock>
+
+			<!-- Bold -->
+			<TextBlock>
+				<Bold>Bold</Bold>
+			</TextBlock>
+
+			<!-- Italic -->
+			<TextBlock>
+				<Italic>Italic</Italic>
+			</TextBlock>
+
+			<!-- Hyperlink -->
+			<TextBlock>
+				<Hyperlink>Hyperlink</Hyperlink>
+			</TextBlock>
+
+			<!-- LineBreak -->
+			<TextBlock>
+				<LineBreak />
+			</TextBlock>
+
+			<!-- Samples -->
+			<!-- https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.textblock -->
+			<TextBlock IsTextSelectionEnabled="True" SelectionHighlightColor="Green" FontFamily="Arial">
+				<Run Foreground="Blue" FontWeight="Light" Text="This text demonstrates "></Run>
+				<Span FontWeight="SemiBold">
+					<Run FontStyle="Italic">the use of inlines </Run>
+					<Run Foreground="Red">with formatting.</Run>
+				</Span>
+			</TextBlock>
+
+			<TextBlock>Text can be <Bold>bold</Bold>, <Italic>italic</Italic>, or <Bold><Italic>both</Italic></Bold>.</TextBlock>
+
+			<TextBlock TextWrapping="Wrap"><LineBreak />This text<LineBreak />wraps on<LineBreak />multiple lines<LineBreak />because of<LineBreak />LineBreak tags.<LineBreak /></TextBlock>
+
+			<!-- Property inheritance -->
+			<TextBlock Foreground="Red">
+				<Run>Red</Run>
+				<Span Foreground="Green">
+					<Run>Green</Run>
+					<Span Foreground="Blue">
+						<Run>Blue</Run>
+						<Run Foreground="Yellow">Yellow</Run>
+					</Span>
+				</Span>
+			</TextBlock>
+
+			<!-- DataContext propagation -->
+			<TextBlock DataContext="DataContext">
+				<Run Text="{Binding}" />
+				<Span>
+					<Run Text="{Binding}" />
+					<Span>
+						<Run Text="{Binding}" />
+					</Span>
+				</Span>
+			</TextBlock>
+
+		</StackPanel>
+
+	</ScrollViewer>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Span.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Span.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_Span")]
+	public sealed partial class TextBlock_Span : UserControl
+	{
+		public TextBlock_Span()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Special_Character.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Special_Character.xaml
@@ -1,0 +1,21 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_Special_Character" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<u:StarStackPanel>
+		<TextBlock Text="test Newline :" />
+		<TextBlock Text="REFER&#10;SOMEONE" />
+	</u:StarStackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Special_Character.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Special_Character.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_Special_Character", description: "Sample TextBlock with Special Character")]
+	public sealed partial class TextBlock_Special_Character : UserControl
+	{
+		public TextBlock_Special_Character()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Style_Inheritance.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Style_Inheritance.xaml
@@ -1,0 +1,36 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_Style_Inheritance"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<StackPanel.Resources>
+			<Style x:Key="buttonStyleWithContentTemplate"
+				   TargetType="Button">
+				<Setter Property="Foreground"
+						Value="Red" />
+				<Setter Property="FontSize"
+						Value="20" />
+			</Style>
+			<Style x:Key="TextBlockStyle"
+				   TargetType="TextBlock">
+				<Setter Property="Foreground"
+						Value="Green" />
+			</Style>
+		</StackPanel.Resources>
+		<Button Style="{StaticResource buttonStyleWithContentTemplate}">
+			<TextBlock x:Name="TestTextBlock"
+					   Style="{StaticResource TextBlockStyle}">
+						<Run Text="This Text" />
+						<Run Text=" should be green" />
+			</TextBlock>
+		</Button>
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Style_Inheritance.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_Style_Inheritance.xaml.cs
@@ -1,0 +1,14 @@
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_Style_Inheritance", description: "TextBlock with Run properties inherited by TextBlock style")]
+	public sealed partial class TextBlock_Style_Inheritance : UserControl
+	{
+		public TextBlock_Style_Inheritance()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_TextAlignment.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_TextAlignment.xaml
@@ -1,0 +1,28 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_TextAlignment" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignWidth="400">
+
+
+	<StackPanel Width="250">
+		<TextBlock Text="Some left aligned text" TextAlignment="Left"  />
+		<TextBlock Text="Some right aligned text" TextAlignment="Right"  />
+		<TextBlock Text="Some center aligned text" TextAlignment="Center" />
+		<StackPanel Width="250"
+					Background="Bisque">
+			<TextBlock Text="Some left aligned very long text jsjsjsjsjsjsjsjsjsjsjsjsasasdsadadaksa" TextAlignment="Left" TextWrapping="Wrap"  />
+			<TextBlock Text="Some right aligned very long text jsjsjsjsjsjsjsjsjsjsjsjsasdsdadsdadsaksa" TextAlignment="Right" TextWrapping="Wrap"  />
+			<TextBlock Text="Some center aligned very long text jsjsjsjsjsjsjsjsjsjsjsjsasaasdasdasasdaksa" TextAlignment="Center" TextWrapping="Wrap" />
+		</StackPanel>
+	</StackPanel>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_TextAlignment.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_TextAlignment.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_TextAlignment", description: "Demonstrates the use of the TextAlignment property in a container that imposes an horizontal arrangement size.")]
+	public sealed partial class TextBlock_TextAlignment : UserControl
+	{ 
+		public TextBlock_TextAlignment()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_TextTrimming_VerticalAlignment_Stretch.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_TextTrimming_VerticalAlignment_Stretch.xaml
@@ -1,0 +1,23 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_TextTrimming_VerticalAlignment_Stretch"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<Grid>
+
+		<Border Height="20"
+				Background="Tomato">
+		  <TextBlock FontSize="15"
+					 TextTrimming="CharacterEllipsis"
+					 TextWrapping="Wrap"
+					 Text="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." />
+		</Border>
+
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_TextTrimming_VerticalAlignment_Stretch.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_TextTrimming_VerticalAlignment_Stretch.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_TextTrimming_VerticalAlignment_Stretch")]
+	public sealed partial class TextBlock_TextTrimming_VerticalAlignment_Stretch : UserControl
+	{
+		public TextBlock_TextTrimming_VerticalAlignment_Stretch()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_UpdatePerformance.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_UpdatePerformance.xaml
@@ -1,0 +1,20 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBlock_UpdatePerformance" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<StackPanel>
+		<TextBlock x:Name="text1" />
+		<Button x:Name="text1Button" Content="Simple Text" />
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_UpdatePerformance.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_UpdatePerformance.xaml.cs
@@ -1,0 +1,24 @@
+using Uno.UI.Samples.Controls;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBlock_UpdatePerformance")]
+	public sealed partial class TextBlock_UpdatePerformance : UserControl
+	{
+		public TextBlock_UpdatePerformance()
+		{
+			this.InitializeComponent();
+
+			text1Button.Click += async delegate
+			{
+				for (var i = 0; i < 1000; i++)
+				{
+					text1.Text = i.ToString();
+					await Task.Yield();
+				}
+			};
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBoxSizeChanging.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBoxSizeChanging.xaml
@@ -1,0 +1,18 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBoxSizeChanging"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:local="using:Uno.UI.Samples.Content.UITests.TextBlockControl"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<TextBlock Text="This is a very long text that should wrap progressively even though it container size changes"
+		FontSize="20"
+		MaxLines="0"
+		TextWrapping="Wrap"
+		Width="{Binding [IncreasingSize]}"/>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBoxSizeChanging.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBoxSizeChanging.xaml.cs
@@ -1,0 +1,15 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBoxSizeChanging", typeof(TextBlockViewModel))]
+	public sealed partial class TextBoxSizeChanging : UserControl
+	{
+		public TextBoxSizeChanging()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBoxSizeChangingInlines.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBoxSizeChangingInlines.xaml
@@ -1,0 +1,24 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBoxSizeChangingInlines"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<Grid>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*"/>
+			<ColumnDefinition Width="2*"/>
+		</Grid.ColumnDefinitions>
+		<TextBlock FontSize="20"
+			   MaxLines="0"
+			   HorizontalAlignment="Center"
+			   TextWrapping="Wrap">
+			<Run Text="{Binding [IncreasingText]}"/>
+		</TextBlock>
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBoxSizeChangingInlines.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBoxSizeChangingInlines.xaml.cs
@@ -1,0 +1,15 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBoxSizeChangingInlines", typeof(TextBlockViewModel))]
+	public sealed partial class TextBoxSizeChangingInlines : UserControl
+	{
+		public TextBoxSizeChangingInlines()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBox_Size_Changing.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBox_Size_Changing.xaml
@@ -1,0 +1,19 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBox_Size_Changing" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<TextBlock Text="This is a very long text that should wrap progressively even though it container size changes" FontSize="20" MaxLines="0" TextWrapping="Wrap" Width="{Binding [IncreasingSize]}"  />
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBox_Size_Changing.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBox_Size_Changing.xaml.cs
@@ -1,0 +1,15 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBox_Size_Changing", typeof(TextBlockViewModel))]
+	public sealed partial class TextBox_Size_Changing : UserControl
+	{
+		public TextBox_Size_Changing()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBox_Size_Changing_Inlines.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBox_Size_Changing_Inlines.xaml
@@ -1,0 +1,25 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.TextBox_Size_Changing_Inlines"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<Grid >
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="2*" />
+		</Grid.ColumnDefinitions>
+		<TextBlock FontSize="20" MaxLines="0" HorizontalAlignment="Center" TextWrapping="Wrap"><Run Text="{Binding [IncreasingText]}" /></TextBlock>
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBox_Size_Changing_Inlines.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBox_Size_Changing_Inlines.xaml.cs
@@ -1,0 +1,15 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "TextBox_Size_Changing_Inlines", typeof(TextBlockViewModel))]
+	public sealed partial class TextBox_Size_Changing_Inlines : UserControl
+	{
+		public TextBox_Size_Changing_Inlines()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Textblocktimespancustomformat.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Textblocktimespancustomformat.xaml
@@ -1,0 +1,24 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.Textblocktimespancustomformat"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:converters="using:Uno.UI.Samples.Converters"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+	
+	<UserControl.Resources>
+		<converters:StringFormatConverter x:Key="stringFormatConverter" />
+	</UserControl.Resources>
+
+	<TextBlock Text="{Binding [RandomTimeSpan], Converter={StaticResource stringFormatConverter}, ConverterParameter='\{0:h\\:mm}'}" Foreground="Red"/>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Textblocktimespancustomformat.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/Textblocktimespancustomformat.xaml.cs
@@ -1,0 +1,15 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "Textblocktimespancustomformat", typeof(TextBlockViewModel))]
+	public sealed partial class Textblocktimespancustomformat : UserControl
+	{
+		public Textblocktimespancustomformat()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
+++ b/src/Uno.UI.Wasm/WasmScripts/Uno.UI.js
@@ -1113,8 +1113,8 @@ var Uno;
                         }
                         this.containerElement.appendChild(unconnectedRoot);
                     }
-                    var updatedStyles = {};
-                    for (var i = 0; i < elementStyle.length; i++) {
+                    let updatedStyles = {};
+                    for (let i = 0; i < elementStyle.length; i++) {
                         const key = elementStyle[i];
                         updatedStyles[key] = elementStyle.getPropertyValue(key);
                     }
@@ -1122,12 +1122,14 @@ var Uno;
                     updatedStyles.height = "";
                     // This is required for an unconstrained measure (otherwise the parents size is taken into account)
                     updatedStyles.position = "fixed";
-                    updatedStyles.maxWidth = Number.isFinite(maxWidth) ? maxWidth + "px" : "";
-                    updatedStyles.maxHeight = Number.isFinite(maxHeight) ? maxHeight + "px" : "";
-                    var updatedStyleString = "";
-                    for (var key in updatedStyles) {
+                    updatedStyles["max-width"] = Number.isFinite(maxWidth) ? maxWidth + "px" : "";
+                    updatedStyles["max-height"] = Number.isFinite(maxHeight) ? maxHeight + "px" : "";
+                    let updatedStyleString = "";
+                    for (let key in updatedStyles) {
                         updatedStyleString += key + ": " + updatedStyles[key] + "; ";
                     }
+                    // We use a string to prevent the browser to update the element between
+                    // each style assignation. This way, the browser will update the element only once.
                     elementStyle.cssText = updatedStyleString;
                     if (element instanceof HTMLImageElement) {
                         const imgElement = element;
@@ -1138,7 +1140,7 @@ var Uno;
                         const offsetHeight = element.offsetHeight;
                         const resultWidth = offsetWidth ? offsetWidth : element.clientWidth;
                         const resultHeight = offsetHeight ? offsetHeight : element.clientHeight;
-                        /* +0.5 is added to take rounding into account */
+                        // +0.5 is added to take rounding into account
                         return [resultWidth + 0.5, resultHeight];
                     }
                 }

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -1073,9 +1073,9 @@
 					this.containerElement.appendChild(unconnectedRoot);
 				}
 
-				var updatedStyles = <any>{};
+				let updatedStyles = <any>{};
 
-				for (var i = 0; i < elementStyle.length; i++) {
+				for (let i = 0; i < elementStyle.length; i++) {
 					const key = elementStyle[i];
 					updatedStyles[key] = elementStyle.getPropertyValue(key);
 				}
@@ -1085,15 +1085,17 @@
 
 				// This is required for an unconstrained measure (otherwise the parents size is taken into account)
 				updatedStyles.position = "fixed";
-				updatedStyles.maxWidth = Number.isFinite(maxWidth) ? maxWidth + "px" : "";
-				updatedStyles.maxHeight = Number.isFinite(maxHeight) ? maxHeight + "px" : "";
+				updatedStyles["max-width"] = Number.isFinite(maxWidth) ? maxWidth + "px" : "";
+				updatedStyles["max-height"] = Number.isFinite(maxHeight) ? maxHeight + "px" : "";
 
-				var updatedStyleString = "";
+				let updatedStyleString = "";
 
-				for (var key in updatedStyles) {
+				for (let key in updatedStyles) {
 					updatedStyleString += key + ": " + updatedStyles[key] + "; ";
 				}
 
+				// We use a string to prevent the browser to update the element between
+				// each style assignation. This way, the browser will update the element only once.
 				elementStyle.cssText = updatedStyleString;
 
 				if (element instanceof HTMLImageElement) {
@@ -1107,7 +1109,7 @@
 					const resultWidth = offsetWidth ? offsetWidth : element.clientWidth;
 					const resultHeight = offsetHeight ? offsetHeight : element.clientHeight;
 
-					/* +0.5 is added to take rounding into account */
+					// +0.5 is added to take rounding into account
 					return [resultWidth + 0.5, resultHeight];
 				}
 			}


### PR DESCRIPTION
## Bugfix
Since work on performance, the `TextBlock` on Wasm wasn't measuring correctly
when constrains were applied to it.

## What is the current behavior?
Wrong calculation, caused by an invalid _css instructions_ (need to be `max-width` & `max-height`
but was `maxWidth` & `maxHeight`).

## What is the new behavior?
Correct _css instructions_ are now applied.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
* <https://nventive.visualstudio.com/Umbrella/_workitems/edit/151838> Uno.UI.Banner AppContent TextBlock is not wrapping
