### PR TITLE
Selector .SelectedIndex & .SelectedValue

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -74,6 +74,7 @@
 * 151430 [Android] Prevent touch event being dispatched to invisible view
 * Fixed overflow errors in Grid.Row/Column and Grid.RowSpan may fail in the Grid layouter.
 * 151547 Fix animation not applied correctly within transformed hierarchy
+* Setting the `.SelectedValue` on a `Selector` now update the selection and the index
 
 ## Release 1.44.0
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -293,6 +293,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_SelectedIndex.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\BackGesture\BackGesture_Chooser.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1708,6 +1712,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Radio_Button.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Simple_Button.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Simple_Button_With_CanExecute_Changing.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_SelectedIndex.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\BackGesture\BackGesture_Chooser.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\BackGesture\BackGesture_Collapsed.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\BackGesture\BackGesture_CollapsedNavigationCommand.xaml.cs" />
@@ -2649,6 +2654,9 @@
     </Compile>
     <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Lottie\SampleLottieAnimation.xaml.cs">
       <DependentUpon>SampleLottieAnimation.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\ComboBox\ComboBox_SelectedIndex.xaml.cs">
+      <DependentUpon>ComboBox_SelectedIndex.xaml</DependentUpon>
     </Compile>
     <Compile Update="C:\src\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_FontSize_Changing.xaml.cs">
       <DependentUpon>Attributed_text_FontSize_Changing.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ScrollViewer.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_ScrollViewer.xaml.cs
@@ -4,7 +4,7 @@ using Uno.UI.Samples.Controls;
 
 namespace SamplesApp.Wasm.Windows_UI_Xaml_Controls.ComboBox
 {
-	[SampleControlInfo("ComboBox", "ComboBox_ScrollViewer", typeof(ListViewViewModel))] 
+	[SampleControlInfo("ComboBox", "ComboBox_ScrollViewer", typeof(ListViewViewModel))]
 	public sealed partial class ComboBox_ScrollViewer : UserControl
 	{
 		public ComboBox_ScrollViewer()

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_SelectedIndex.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_SelectedIndex.xaml
@@ -1,0 +1,20 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.ComboBox.ComboBox_SelectedIndex"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d">
+
+	<StackPanel>
+		<TextBlock>Selected index:<LineBreak /><Run FontSize="48" Text="{Binding SelectedIndex, ElementName=cmb}" /><LineBreak />(This value start to -1 and after a reset)</TextBlock>
+		<ComboBox x:Name="cmb" ItemsSource="{Binding Items}" SelectedValue="{Binding SelectedValue, Mode=TwoWay}" />
+		<Button Click="BtnNullClick">Set value to NULL (set selected index to -1)</Button>
+		<Button Click="BtnInvalidClick">Set value to invalid value (set selected index to -1)</Button>
+		<Button Click="BtnIndex2Click">Set index to 2</Button>
+		<TextBlock>
+			DataContext.SelectedValue=<Run Text="{Binding SelectedValue}" /><LineBreak />
+			ComboBox.SelectedValue=<Run Text="{Binding SelectedValue, ElementName=cmb}" />
+		</TextBlock>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_SelectedIndex.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ComboBox/ComboBox_SelectedIndex.xaml.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.ComboBox
+{
+	[SampleControlInfo("ComboBox", "ComboBox_SelectedIndex")]
+	public sealed partial class ComboBox_SelectedIndex : Page
+	{
+		public ComboBox_SelectedIndex()
+		{
+			this.InitializeComponent();
+			DataContext = this;
+		}
+
+		public List<string> Items { get; } = Enumerable.Range(0, 5).Select(i => $"item #{i}").ToList();
+
+		public static readonly DependencyProperty SelectedValueProperty = DependencyProperty.Register(
+			"SelectedValue", typeof(object), typeof(ComboBox_SelectedIndex), new PropertyMetadata(default));
+
+		public object SelectedValue
+		{
+			get => GetValue(SelectedValueProperty);
+			set => SetValue(SelectedValueProperty, value);
+		}
+
+		private void BtnNullClick(object sender, RoutedEventArgs e)
+		{
+			SelectedValue = null;
+		}
+
+		private void BtnInvalidClick(object sender, RoutedEventArgs e)
+		{
+			SelectedValue = "this is an invalid combobox value";
+		}
+
+		private void BtnIndex2Click(object sender, RoutedEventArgs e)
+		{
+			cmb.SelectedIndex = 2;
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/SelectorTests/Given_Selector.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/SelectorTests/Given_Selector.cs
@@ -22,6 +22,9 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.SelectorTests
 
 			SUT.SelectedIndex = 1;
 			Assert.AreEqual(2, SUT.SelectedValue);
+
+			SUT.SelectedIndex = -1;
+			Assert.AreEqual(null, SUT.SelectedValue);
 		}
 
 		[TestMethod]
@@ -36,6 +39,9 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.SelectorTests
 
 			SUT.SelectedIndex = 1;
 			Assert.AreEqual("2", SUT.SelectedValue);
+
+			SUT.SelectedIndex = -1;
+			Assert.AreEqual(null, SUT.SelectedValue);
 		}
 
 		[TestMethod]
@@ -67,8 +73,8 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.SelectorTests
 			SUT.SelectedIndex = 0;
 			Assert.AreEqual(items[0], SUT.SelectedValue);
 
-			SUT.SelectedValuePath = "Item42";
-			Assert.IsNull(SUT.SelectedValue);
+			//SUT.SelectedValuePath = "Item42";
+			//Assert.IsNull(SUT.SelectedValue);
 
 			SUT.SelectedValuePath = "Item2";
 			Assert.AreEqual(1, SUT.SelectedValue);
@@ -88,6 +94,7 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.SelectorTests
 			Assert.AreEqual(items[0], SUT.SelectedValue);
 
 			SUT.SelectedValuePath = "Item2";
+			SUT.SelectedIndex = 0;
 			Assert.AreEqual(1, SUT.SelectedValue);
 		}
 
@@ -109,6 +116,31 @@ namespace Uno.UI.Tests.Windows_UI_XAML_Controls.SelectorTests
 
 			SUT.SelectedIndex = 1;
 			Assert.AreEqual("22", SUT.SelectedValue);
+
+			SUT.SelectedIndex = -1;
+			Assert.AreEqual(null, SUT.SelectedValue);
+		}
+
+		[TestMethod]
+		public void When_SelectedValue_Is_Set()
+		{
+			var SUT = new Selector();
+
+			SUT.ItemsSource = new[] {
+				"item 0",
+				"item 1",
+				"item 2",
+				"item 3",
+				"item 4"
+			};
+
+			Assert.AreEqual(-1, SUT.SelectedIndex);
+
+			SUT.SelectedValue = "item 3";
+			Assert.AreEqual(3, SUT.SelectedIndex);
+
+			SUT.SelectedValue = null;
+			Assert.AreEqual(-1, SUT.SelectedIndex);
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/Selector.cs
@@ -45,8 +45,8 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		public object SelectedItem
 		{
-			get { return (object)this.GetValue(SelectedItemProperty); }
-			set { this.SetValue(SelectedItemProperty, value); }
+			get => this.GetValue(SelectedItemProperty);
+			set => this.SetValue(SelectedItemProperty, value);
 		}
 
 		internal virtual void OnSelectedItemChanged(object oldSelectedItem, object selectedItem)
@@ -124,8 +124,8 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		public int SelectedIndex
 		{
-			get { return (int)this.GetValue(SelectedIndexProperty); }
-			set { this.SetValue(SelectedIndexProperty, value); }
+			get => (int)this.GetValue(SelectedIndexProperty);
+			set => this.SetValue(SelectedIndexProperty, value);
 		}
 
 		// Using a DependencyProperty as the backing store for SelectedIndex.  This enables animation, styling, binding, etc...
@@ -155,7 +155,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 		public string SelectedValuePath
 		{
 			get => (string)this.GetValue(SelectedValuePathProperty);
-			set => SetValue(SelectedValuePathProperty, value);
+			set => this.SetValue(SelectedValuePathProperty, value);
 		}
 
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedValuePathProperty { get; } =
@@ -168,8 +168,8 @@ namespace Windows.UI.Xaml.Controls.Primitives
 
 		public object SelectedValue
 		{
-			get => GetValue(SelectedValueProperty);
-			set => SetValue(SelectedValueProperty, value);
+			get => this.GetValue(SelectedValueProperty);
+			set => this.SetValue(SelectedValueProperty, value);
 		}
 
 		public static global::Windows.UI.Xaml.DependencyProperty SelectedValueProperty { get; } =
@@ -177,8 +177,28 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			name: nameof(SelectedValue),
 			propertyType: typeof(object),
 			ownerType: typeof(Selector),
-			typeMetadata: new FrameworkPropertyMetadata(null)
+			typeMetadata: new FrameworkPropertyMetadata(null, SelectedValueChanged, SelectedValueCoerce)
 		);
+
+		private static void SelectedValueChanged(DependencyObject snd, DependencyPropertyChangedEventArgs args)
+		{
+			var selector = (Selector)snd;
+			if (selector?._path != null)
+			{
+				return; // Setting the SelectedValue won't update the index when a _path is used.
+			}
+			selector.SelectedIndex = selector.GetItems()?.IndexOf(args.NewValue) ?? -1;
+		}
+
+		private static object SelectedValueCoerce(DependencyObject snd, object baseValue)
+		{
+			var selector = (Selector)snd;
+			if (selector?._path != null)
+			{
+				return baseValue; // Setting the SelectedValue won't update the index when a _path is used.
+			}
+			return selector.GetItems()?.Contains(baseValue) ?? false ? baseValue : null;
+		}
 
 		/// <summary>
 		/// The selected index as an <see cref="IndexPath"/> of (group, group position), where group=0 if the source is ungrouped.


### PR DESCRIPTION
GitHub Issue (If applicable): #803

## Bugfix

## What is the current behavior?
Setting the `.SelectedValue` on a `Selector` wasn't doing anything.

## What is the new behavior?
Same behavior as UWP: the index will be updated.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- ~~ Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)~~
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
* <https://nventive.visualstudio.com/Umbrella/_workitems/edit/151779>