### PR TITLE
Fixed Span.Slice overflow errors in Grid layouting

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -71,6 +71,7 @@
 * 151656 [TimePicker][iOS] Time picker always shows +1 minute than selected value
 * 151657 [DatePicker][iOS] Date picker flyout displays 1 day earlier than selected value
 * 151547 Fix animation not applied correctly within transformed hierarchy
+* Fixed overflow errors in Grid.Row/Column and Grid.RowSpan may fail in the Grid layouter.
 
 ## Release 1.44.0
 

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid.cs
@@ -926,6 +926,44 @@ namespace Uno.UI.Tests.GridTests
 		}
 
 		[TestMethod]
+		public void When_Row_Out_Of_Range()
+		{
+			var SUT = new Grid();
+
+			SUT.RowDefinitions.Add(new RowDefinition { Height = "5" });
+			SUT.RowDefinitions.Add(new RowDefinition { Height = "5" });
+			SUT.ColumnDefinitions.Add(new ColumnDefinition { Width = "5" });
+			SUT.ColumnDefinitions.Add(new ColumnDefinition { Width = "5" });
+
+			SUT.AddChild(new View { RequestedDesiredSize = new Windows.Foundation.Size(100, 100) });
+			SUT.AddChild(new View { RequestedDesiredSize = new Windows.Foundation.Size(100, 100) })
+				.GridRow(3);
+
+			SUT.Measure(new Windows.Foundation.Size(100, 1000));
+			var measuredSize = SUT.DesiredSize;
+			SUT.Arrange(new Windows.Foundation.Rect(0, 0, 100, 1000));
+		}
+
+		[TestMethod]
+		public void When_Column_Out_Of_Range()
+		{
+			var SUT = new Grid();
+
+			SUT.RowDefinitions.Add(new RowDefinition { Height = "5" });
+			SUT.RowDefinitions.Add(new RowDefinition { Height = "5" });
+			SUT.ColumnDefinitions.Add(new ColumnDefinition { Width = "5" });
+			SUT.ColumnDefinitions.Add(new ColumnDefinition { Width = "5" });
+
+			SUT.AddChild(new View { RequestedDesiredSize = new Windows.Foundation.Size(100, 100) });
+			SUT.AddChild(new View { RequestedDesiredSize = new Windows.Foundation.Size(100, 100) })
+				.GridColumn(3);
+
+			SUT.Measure(new Windows.Foundation.Size(100, 1000));
+			var measuredSize = SUT.DesiredSize;
+			SUT.Arrange(new Windows.Foundation.Rect(0, 0, 100, 1000));
+		}
+
+		[TestMethod]
 		public void When_RowSpan_Out_Of_Range()
 		{
 			var SUT = new Grid();
@@ -950,6 +988,24 @@ namespace Uno.UI.Tests.GridTests
 
 			SUT.ColumnDefinitions.Add(new ColumnDefinition { Width = "*" });
 			SUT.ColumnDefinitions.Add(new ColumnDefinition { Width = "*" });
+
+			SUT.AddChild(new View { RequestedDesiredSize = new Windows.Foundation.Size(100, 100) });
+			SUT.AddChild(new View { RequestedDesiredSize = new Windows.Foundation.Size(100, 100) })
+				.GridPosition(0, 1)
+				.GridColumnSpan(3);
+
+			SUT.Measure(new Windows.Foundation.Size(1000, 100));
+			var measuredSize = SUT.DesiredSize;
+			SUT.Arrange(new Windows.Foundation.Rect(0, 0, 1000, 100));
+		}
+
+		[TestMethod]
+		public void When_ColumnSpan_With_AutoColumn_Out_Of_Range()
+		{
+			var SUT = new Grid();
+
+			SUT.ColumnDefinitions.Add(new ColumnDefinition { Width = "*" });
+			SUT.ColumnDefinitions.Add(new ColumnDefinition { Width = "auto" });
 
 			SUT.AddChild(new View { RequestedDesiredSize = new Windows.Foundation.Size(100, 100) });
 			SUT.AddChild(new View { RequestedDesiredSize = new Windows.Foundation.Size(100, 100) })

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
@@ -265,8 +265,8 @@ namespace Windows.UI.Xaml.Controls
 			foreach (var child in Children)
 			{
 				var gridPosition = childrenToPositionsMap[child];
-				var x = offset.X + calculatedPixelColumns.Slice(0, gridPosition.Column).Sum(cs => cs.MinValue);
-				var y = offset.Y + calculatedPixelRows.Slice(0, gridPosition.Row).Sum(cs => cs.MinValue);
+				var x = offset.X + calculatedPixelColumns.SliceClamped(0, gridPosition.Column).Sum(cs => cs.MinValue);
+				var y = offset.Y + calculatedPixelRows.SliceClamped(0, gridPosition.Row).Sum(cs => cs.MinValue);
 
 				Span<double> calculatedPixelColumnsMinValue = stackalloc double[calculatedPixelColumns.Length];
 				calculatedPixelColumns.SelectToSpan(calculatedPixelColumnsMinValue, cs => cs.MinValue);
@@ -805,7 +805,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private static int AutoSizeCount(int index, int span, Span<GridSize> sizes)
 		{
-			return sizes.Slice(index, span).Count(s => s.IsAuto);
+			return sizes.SliceClamped(index, span).Count(s => s.IsAuto);
 		}
 
 		/// <summary>
@@ -813,7 +813,7 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		private static int StarSizeComparer(int index, int span, Span<GridSize> sizes)
 		{
-			return Math.Min(1, sizes.Slice(index, span).Count(s => s.IsStarSize));
+			return Math.Min(1, sizes.SliceClamped(index, span).Count(s => s.IsStarSize));
 		}
 
 		private static bool IsPixelSize(int index, int span, Span<GridSize> sizes)


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Overflow in `Grid.Row`/`Column` and `Grid.RowSpan` may fail in the `Grid` layouter.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
https://nventive.visualstudio.com/Umbrella/_workitems/edit/151919