### PR TITLE
Update issue template to add "VS2019"

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,8 +7,8 @@ ISSUES MISSING IMPORTANT INFORMATION MAY BE CLOSED WITHOUT INVESTIGATION.
 <!-- Please uncomment one or more that apply to this issue -->
 
 <!-- - Regression (a behavior that used to work and stopped working in a new release) -->
-<!-- - Bug report (I searched for similar issues and did not find one) -->  
-<!-- - Feature request --> 
+<!-- - Bug report (I searched for similar issues and did not find one) -->
+<!-- - Feature request -->
 <!-- - Sample app request -->
 <!-- - Documentation issue or request -->
 <!-- - Question of Support request => Please do not submit support request here, instead see https://github.com/nventive/Uno/blob/master/README.md#have-questions-feature-requests-issues -->
@@ -29,10 +29,11 @@ For bug reports please provide a *MINIMAL REPRO PROJECT* and the *STEPS TO REPRO
 
 ## Environment
 <!-- For bug reports Check one or more of the following options with "x" -->
-```
-Nuget Package: 
 
-Package Version(s): 
+```
+Nuget Package:
+
+Package Version(s):
 
 Affected platform(s):
 - [ ] iOS
@@ -43,9 +44,8 @@ Affected platform(s):
 
 Visual Studio
 - [ ] 2017 (version: )
-- [ ] 2017 Preview (version: )
+- [ ] 2019 (version: )
 - [ ] for Mac (version: )
 
 Relevant plugins
 - [ ] Resharper (version: )
-```


### PR DESCRIPTION
## PR Type
Maintenance

## What is the new behavior?
Added `VS 2019` in the options, removed `VS 2017 Preview`.
