### PR TITLE
WASM: flyout is dismissing too fast

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -4,7 +4,7 @@
 
 ### Features
 * Add support for `ChatMessageManager.ShowComposeSmsMessageAsync` (and `ChatMessage` `Body` and `Recipients` properties) on iOS and Android
-* Add support for the following `DisplayInformation` properties on iOS and Android:   
+* Add support for the following `DisplayInformation` properties on iOS and Android:
     - CurrentOrientation
     - LogicalDpi
     - NativeOrientation
@@ -61,8 +61,8 @@
 * Adjust support for `StaticResource.ResourceKey`
 * 151081 [Android] Fix Keyboard not always dismissed when unfocusing a TextBox
 * [WASM] Support `not_wasm` prefix properly. (#784)
-* 151282 [iOS] Fixed Slider not responding on second navigation, fixed RemoveHandler for RoutedEvents removing all instances of handler 
-* 151497 [iOS/Android] Fixed Slider not responding, by ^ RemoveHandler fix for RoutedEvents 
+* 151282 [iOS] Fixed Slider not responding on second navigation, fixed RemoveHandler for RoutedEvents removing all instances of handler
+* 151497 [iOS/Android] Fixed Slider not responding, by ^ RemoveHandler fix for RoutedEvents
 * 151674 [iOS] Add ability to replay a finished video from media player
 * 151524 [Android] Cleaned up Textbox for android to remove keyboard showing/dismissal inconsistencies
 * Fix invalid code generation for `x:Name` entries on `Style` in resources
@@ -76,6 +76,7 @@
 * 151547 Fix animation not applied correctly within transformed hierarchy
 * Setting the `.SelectedValue` on a `Selector` now update the selection and the index
 * [WASM] Fix ListView contents not remeasuring when ItemsSource changes.
+* [WASM] Dismissable popup & flyout is closing when tapping on content.
 
 ## Release 1.44.0
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -373,6 +373,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_ButtonInContent.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Transforms_On_Target.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1779,6 +1783,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_MaxDropdownHeight.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Transforms.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Virtualizing.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_ButtonInContent.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Transforms_On_Target.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Vanilla.xaml.cs">
       <DependentUpon>Flyout_Vanilla.xaml</DependentUpon>
@@ -2688,6 +2693,9 @@
     </Compile>
     <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\ComboBox\ComboBox_Virtualizing.xaml.cs">
       <DependentUpon>ComboBox_Virtualizing.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Flyout\Flyout_ButtonInContent.xaml.cs">
+      <DependentUpon>Flyout_ButtonInContent.xaml</DependentUpon>
     </Compile>
     <Compile Update="C:\src\Uno2\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Flyout\Flyout_Events.xaml.cs">
       <DependentUpon>Flyout_Events.xaml</DependentUpon>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ButtonInContent.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ButtonInContent.xaml
@@ -1,0 +1,38 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Flyout.Flyout_ButtonInContent"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid>
+		<TextBlock x:Name="output" />
+		<Border Background="Orange" HorizontalAlignment="Right">
+			<Button
+				Width="48"
+				Height="48"
+				Margin="0,0,10,0">
+
+				<TextBlock>Here</TextBlock>
+
+				<Button.Flyout>
+					<Flyout Placement="Right">
+						<StackPanel
+							Background="Aquamarine"
+							BorderBrush="DarkBlue"
+							BorderThickness="1">
+
+							<Button Content="Button" Click="Button_Click" />
+
+							<Rectangle Fill="Black" Height="4" />
+
+							<ToggleButton Content="Toggle Here" />
+						</StackPanel>
+					</Flyout>
+				</Button.Flyout>
+			</Button>
+		</Border>
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ButtonInContent.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ButtonInContent.xaml
@@ -29,6 +29,10 @@
 							<Rectangle Fill="Black" Height="4" />
 
 							<ToggleButton Content="Toggle Here" />
+							<TextBlock>
+								Clicking here should
+								not close the flyout
+							</TextBlock>
 						</StackPanel>
 					</Flyout>
 				</Button.Flyout>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ButtonInContent.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Flyout/Flyout_ButtonInContent.xaml.cs
@@ -1,0 +1,20 @@
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Flyout
+{
+	[SampleControlInfo("Flyout", "Flyout_ButtonInContent")]
+	public sealed partial class Flyout_ButtonInContent : Page
+	{
+		public Flyout_ButtonInContent()
+		{
+			this.InitializeComponent();
+		}
+
+		private void Button_Click(object sender, RoutedEventArgs e)
+		{
+			output.Text += "Button clicked\n";
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPresenter.cs
@@ -10,12 +10,34 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override void OnPointerPressed(PointerRoutedEventArgs args)
 		{
-			// Stop the propagation of the pressed
-			// to prevent dismissal of the flyout
-			// when clicking inside it.
+			// All pointer-related should be "eaten" to prevent closing
+			// the flyout when a tap is done in its content
+			args.Handled = true;
+		}
+
+		protected override void OnPointerReleased(PointerRoutedEventArgs args)
+		{
+			// All pointer-related should be "eaten" to prevent closing
+			// the flyout when a tap is done in its content
+			args.Handled = true;
+		}
+
+		protected override void OnTapped(TappedRoutedEventArgs args)
+		{
+			// All pointer-related should be "eaten" to prevent closing
+			// the flyout when a tap is done in its content
+			args.Handled = true;
+		}
+
+		protected override void OnDoubleTapped(DoubleTappedRoutedEventArgs args)
+		{
+			// All pointer-related should be "eaten" to prevent closing
+			// the flyout when a tap is done in its content
 			args.Handled = true;
 		}
 
 		protected override bool CanCreateTemplateWithoutParent { get; } = true;
+
+		internal override bool IsViewHit() => true;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPresenter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Flyout/FlyoutPresenter.cs
@@ -1,14 +1,19 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using Windows.UI.Xaml.Input;
 
 namespace Windows.UI.Xaml.Controls
 {
-    public partial class FlyoutPresenter : ContentControl
-    {
+	public partial class FlyoutPresenter : ContentControl
+	{
 		public FlyoutPresenter()
 		{
+		}
 
+		protected override void OnPointerPressed(PointerRoutedEventArgs args)
+		{
+			// Stop the propagation of the pressed
+			// to prevent dismissal of the flyout
+			// when clicking inside it.
+			args.Handled = true;
 		}
 
 		protected override bool CanCreateTemplateWithoutParent { get; } = true;

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.wasm.cs
@@ -61,23 +61,36 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
+			bool pressed = false;
+
 			if (previousPanel != null)
 			{
-				previousPanel.PointerPressed -= Panel_PointerPressed;
+				previousPanel.PointerPressed -= pointerPressed;
+				previousPanel.PointerReleased -= pointerReleased;
 			}
 			if (newPanel != null)
 			{
-				newPanel.PointerPressed += Panel_PointerPressed;
+				newPanel.PointerPressed += pointerPressed;
+				newPanel.PointerReleased += pointerReleased;
 			}
-		}
 
-		private void Panel_PointerPressed(object sender, Input.PointerRoutedEventArgs e)
-		{
-			if (IsLightDismissEnabled)
+			void pointerPressed(object sender, Input.PointerRoutedEventArgs args)
 			{
-				IsOpen = false;
+				// Both pressed & released must reach
+				// the popup to close it.
+				// (and, obviously, the popup must be light dismiss!)
+				pressed = IsLightDismissEnabled;
+			}
+
+			void pointerReleased(object sender, Input.PointerRoutedEventArgs args)
+			{
+				if (pressed && IsLightDismissEnabled)
+				{
+					// Received the completed sequence
+					// pressed + released: we can close.
+					IsOpen = false;
+				}
 			}
 		}
-
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/Popup.wasm.cs
@@ -61,35 +61,36 @@ namespace Windows.UI.Xaml.Controls
 				}
 			}
 
-			bool pressed = false;
-
 			if (previousPanel != null)
 			{
-				previousPanel.PointerPressed -= pointerPressed;
-				previousPanel.PointerReleased -= pointerReleased;
+				previousPanel.PointerPressed -= OnPanelPointerPressed;
+				previousPanel.PointerReleased -= OnPanelPointerReleased;
 			}
 			if (newPanel != null)
 			{
-				newPanel.PointerPressed += pointerPressed;
-				newPanel.PointerReleased += pointerReleased;
+				newPanel.PointerPressed += OnPanelPointerPressed;
+				newPanel.PointerReleased += OnPanelPointerReleased;
 			}
 
-			void pointerPressed(object sender, Input.PointerRoutedEventArgs args)
-			{
-				// Both pressed & released must reach
-				// the popup to close it.
-				// (and, obviously, the popup must be light dismiss!)
-				pressed = IsLightDismissEnabled;
-			}
+		}
 
-			void pointerReleased(object sender, Input.PointerRoutedEventArgs args)
+		private bool _pressed;
+
+		private void OnPanelPointerPressed(object sender, Input.PointerRoutedEventArgs args)
+		{
+			// Both pressed & released must reach
+			// the popup to close it.
+			// (and, obviously, the popup must be light dismiss!)
+			_pressed = IsLightDismissEnabled;
+		}
+
+		private void OnPanelPointerReleased(object sender, Input.PointerRoutedEventArgs args)
+		{
+			if (_pressed && IsLightDismissEnabled)
 			{
-				if (pressed && IsLightDismissEnabled)
-				{
-					// Received the completed sequence
-					// pressed + released: we can close.
-					IsOpen = false;
-				}
+				// Received the completed sequence
+				// pressed + released: we can close.
+				IsOpen = false;
 			}
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/ButtonBase/ButtonBase.cs
@@ -180,6 +180,7 @@ namespace Windows.UI.Xaml.Controls.Primitives
 			if (IsPointerOver)
 			{
 				OnClick(args); // TODO: Consider ClickMode and mouse pointer button
+				args.Handled = true;
 			}
 
 			IsPointerOver = false;


### PR DESCRIPTION
## Bugfix
A flyout will dismiss too fast.

## What is the current behavior?
The routed event "pointer pressed" will close the flyout popup before
any content can process it.

## What is the new behavior?
The flyout now requires a full _pressed_ + _released_ sequence
(non-handled events) before closing.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [X] Contains **NO** breaking changes: _the new behavior is coherent with UWP_.
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
* https://nventive.visualstudio.com/Umbrella/_workitems/edit/152477
