### PR TITLE
fixed android keyboard stays open on AppBarButton click

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -80,6 +80,7 @@
 * Setting the `.SelectedValue` on a `Selector` now update the selection and the index
 * [WASM] Fix ListView contents not remeasuring when ItemsSource changes.
 * [WASM] Dismissable popup & flyout is closing when tapping on content.
+* 145374 [Android] fixed android keyboard stays open on AppBarButton click
 
 ## Release 1.44.0
 

--- a/src/Uno.UI/Controls/CommandBarRenderer.Android.cs
+++ b/src/Uno.UI/Controls/CommandBarRenderer.Android.cs
@@ -264,6 +264,8 @@ namespace Uno.UI.Controls
 
 		private void Native_MenuItemClick(object sender, Toolbar.MenuItemClickEventArgs e)
 		{
+			ClearCurrentFocus();
+
 			var hashCode = e.Item.ItemId;
 			var appBarButton = Element.PrimaryCommands
 				.Concat(Element.SecondaryCommands)
@@ -275,6 +277,8 @@ namespace Uno.UI.Controls
 
 		private void Native_NavigationClick(object sender, Toolbar.NavigationClickEventArgs e)
 		{
+			ClearCurrentFocus();
+
 			var navigationCommand = Element.GetValue(NavigationCommandProperty) as AppBarButton;
 			if (navigationCommand != null)
 			{
@@ -283,6 +287,14 @@ namespace Uno.UI.Controls
 			else
 			{
 				SystemNavigationManager.GetForCurrentView().RequestBack();
+			}
+		}
+
+		private void ClearCurrentFocus()
+		{
+			if ((ContextHelper.Current as Activity)?.CurrentFocus is View focused)
+			{
+				focused.ClearFocus();
 			}
 		}
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): #N/A

## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
Currently on android, the keyboard stays open when the user clicks on any `CommandBar` item

## What is the new behavior?
`CommandBar` item on-click handler will attempt to clear focus from the current focused view, in turn causing the keyboard to be closed.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/145374
