### PR TITLE
Update the support libraries for Android 9

### DIFF
--- a/build/Uno.UI.nuspec
+++ b/build/Uno.UI.nuspec
@@ -27,9 +27,9 @@
 
       <!-- Android 9.0 -->
       <group targetFramework="MonoAndroid90">
-        <dependency id="Xamarin.Android.Support.v4" version="26.1.0.1" />
-        <dependency id="Xamarin.Android.Support.v7.AppCompat" version="26.1.0.1" />
-        <dependency id="Xamarin.Android.Support.v7.RecyclerView" version="26.1.0.1" />
+        <dependency id="Xamarin.Android.Support.v4" version="28.0.0.1" />
+        <dependency id="Xamarin.Android.Support.v7.AppCompat" version="28.0.0.1" />
+        <dependency id="Xamarin.Android.Support.v7.RecyclerView" version="28.0.0.1" />
         <dependency id="Uno.SourceGenerationTasks" version="1.31.0-dev.285" />
         <dependency id="Uno.Core" version="1.28.0-dev.86" />
         <dependency id="Uno.Core.Build" version="1.28.0-dev.86" />

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -42,6 +42,7 @@
 * [Wasm] Add Samples App UI Screenshots diffing tool with previous builds
 * Add `PasswordVault` on supported platfrosm
 * 152504 [Android] Pointer captures weren't informing gestures of capture, fixes Slider capture issue
+* [Android] Updated support libraries to 28.0.0.1 for Android 9
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.

--- a/src/SamplesApp/SamplesApp.Droid/Properties/AndroidManifest.xml
+++ b/src/SamplesApp/SamplesApp.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="SamplesApp" android:versionCode="1" android:versionName="1.0">
-  <uses-sdk android:minSdkVersion="16" />
+  <uses-sdk android:minSdkVersion="16"  android:targetSdkVersion="28"/>
   <application android:label="SamplesApp"></application>
 </manifest>

--- a/src/SourceGenerators/XamlGenerationTests.Core/XamlGenerationTests.Core.csproj
+++ b/src/SourceGenerators/XamlGenerationTests.Core/XamlGenerationTests.Core.csproj
@@ -35,13 +35,13 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.Android.Support.v4">
-			<Version>26.1.0.1</Version>
+			<Version>28.0.0.1</Version>
 		</PackageReference>
 		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-			<Version>26.1.0.1</Version>
+			<Version>28.0.0.1</Version>
 		</PackageReference>
 		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-			<Version>26.1.0.1</Version>
+			<Version>28.0.0.1</Version>
 		</PackageReference>
 	</ItemGroup>
 

--- a/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
+++ b/src/SourceGenerators/XamlGenerationTests/XamlGenerationTests.csproj
@@ -35,13 +35,13 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.Android.Support.v4">
-			<Version>26.1.0.1</Version>
+			<Version>28.0.0.1</Version>
 		</PackageReference>
 		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-			<Version>26.1.0.1</Version>
+			<Version>28.0.0.1</Version>
 		</PackageReference>
 		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-			<Version>26.1.0.1</Version>
+			<Version>28.0.0.1</Version>
 		</PackageReference>
 	</ItemGroup>
 

--- a/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
+++ b/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
@@ -13,6 +13,11 @@
 		<IsBindingProject Condition="'$(TargetFramework)' == 'MonoAndroid80' or '$(TargetFramework)' == 'MonoAndroid90'">true</IsBindingProject>
 		<_isWindows>$([MSBuild]::IsOsPlatform(Windows))</_isWindows>
 	</PropertyGroup>
+
+	<!--Workaround because this variable is missing by default. See https://github.com/xamarin/xamarin-android/issues/2452 -->
+	<PropertyGroup>
+		<AndroidSdkBuildToolsVersion Condition="'$(AndroidSdkBuildToolsVersion)' == ''">28.0.3</AndroidSdkBuildToolsVersion>
+	</PropertyGroup>
 	
 	<ItemGroup>
 		<PackageReference Include="Xamarin.Build.Download" Version="0.4.9" />
@@ -29,10 +34,10 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.Android.Support.v4">
-			<Version>26.1.0.1</Version>
+			<Version>28.0.0.1</Version>
 		</PackageReference>
 		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-			<Version>26.1.0.1</Version>
+			<Version>28.0.0.1</Version>
 		</PackageReference>
 	</ItemGroup>
 

--- a/src/Uno.UI.Maps/Uno.UI.Maps.csproj
+++ b/src/Uno.UI.Maps/Uno.UI.Maps.csproj
@@ -35,7 +35,7 @@
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.GooglePlayServices.Location" Version="60.1142.0" />
 		<PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="60.1142.0" />
-		<PackageReference Include="Xamarin.Android.Support.v4" Version="26.1.0.1" PrivateAssets="none" />
+		<PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.1" PrivateAssets="none" />
 	</ItemGroup>
 
 	<Import Project="..\Uno.CrossTargetting.props" />

--- a/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
+++ b/src/Uno.UI.RuntimeTests/Uno.UI.RuntimeTests.csproj
@@ -9,7 +9,13 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <DefineConstants>$(DefineConstants);__WASM__</DefineConstants>
   </PropertyGroup>
-
+	
+	<!--Workaround to prevent build to fail because the project has too many dependencies when checking support libraries versions. 
+	(Introduced with support libraries 28.0.0.1) -->
+	<PropertyGroup>
+		<XamarinAndroidSupportSkipVerifyVersions>true</XamarinAndroidSupportSkipVerifyVersions>
+	</PropertyGroup>
+	
 	<ItemGroup>
 		<PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
 		<PackageReference Include="Uno.SourceGenerationTasks" />

--- a/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
+++ b/src/Uno.UI.Toolkit/Uno.UI.Toolkit.csproj
@@ -14,6 +14,12 @@
 		<Deterministic>true</Deterministic>
 	</PropertyGroup>
 
+	<!--Workaround to prevent build to fail because the project has too many dependencies when checking support libraries versions. 
+	(Introduced with support libraries 28.0.0.1) -->
+	<PropertyGroup>
+		<XamarinAndroidSupportSkipVerifyVersions>true</XamarinAndroidSupportSkipVerifyVersions>
+	</PropertyGroup>
+
 	<Import Project="..\Uno.CrossTargetting.props" />
 	<ItemGroup>
 	  <Compile Include="..\Uno.UI\Behaviors\VisibleBoundsPadding.cs" Link="VisibleBoundsPadding.cs" />
@@ -47,15 +53,15 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.Android.Support.v4">
-			<Version>26.1.0.1</Version>
+			<Version>28.0.0.1</Version>
 			<PrivateAssets>none</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-			<Version>26.1.0.1</Version>
+			<Version>28.0.0.1</Version>
 			<PrivateAssets>none</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView">
-			<Version>26.1.0.1</Version>
+			<Version>28.0.0.1</Version>
 			<PrivateAssets>none</PrivateAssets>
 		</PackageReference>
 	</ItemGroup>
@@ -86,7 +92,6 @@
 
 	<!-- Override existing target, this project cannot be published -->
 	<Target Name="Publish" />
-
 	<PropertyGroup>
 		<UnoUIGeneratorsBinPath>..\SourceGenerators\Uno.UI.SourceGenerators\bin\$(Configuration)</UnoUIGeneratorsBinPath>
 	</PropertyGroup>

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -169,13 +169,13 @@
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
-		<PackageReference Include="Xamarin.Android.Support.v4" Version="26.1.0.1">
+		<PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.1">
 			<PrivateAssets>none</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="26.1.0.1">
+		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.1">
 			<PrivateAssets>none</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="26.1.0.1">
+		<PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="28.0.0.1">
 			<PrivateAssets>none</PrivateAssets>
 		</PackageReference>
 	</ItemGroup>

--- a/src/Uno.UWP/Uno.csproj
+++ b/src/Uno.UWP/Uno.csproj
@@ -49,11 +49,11 @@
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid90'">
 		<PackageReference Include="Xamarin.Android.Support.v4">
-			<Version>26.1.0.1</Version>
+			<Version>28.0.0.1</Version>
 			<PrivateAssets>none</PrivateAssets>
 		</PackageReference>
 		<PackageReference Include="Xamarin.Android.Support.v7.AppCompat">
-			<Version>26.1.0.1</Version>
+			<Version>28.0.0.1</Version>
 			<PrivateAssets>none</PrivateAssets>
 		</PackageReference>
 	</ItemGroup>


### PR DESCRIPTION
##  Libraries Update : 


## What is the current behavior?
Compiling for Android 9 uses support libraries for API 26 (26.1.0.1)


## What is the new behavior?
Compiling for Android 9 uses support libraries for API 28 (28.0.0.1)


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
[132095](https://nventive.visualstudio.com/Umbrella/_workitems/edit/132095)
