### PR TITLE
iOS CarriageReturns follow MaxLines Textblock Property

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -41,7 +41,6 @@
 * [Wasm] Enable persistence for all ApplicationData folders
 * [Wasm] Add Samples App UI Screenshots diffing tool with previous builds
 * Add `PasswordVault` on supported platfrosm
-* 152504 [Android] Pointer captures weren't informing gestures of capture, fixes Slider capture issue
 * [Android] Updated support libraries to 28.0.0.1 for Android 9
 
 ### Breaking Changes
@@ -82,6 +81,8 @@
 * [WASM] Fix ListView contents not remeasuring when ItemsSource changes.
 * [WASM] Dismissable popup & flyout is closing when tapping on content.
 * 145374 [Android] fixed android keyboard stays open on AppBarButton click
+* 152504 [Android] Pointer captures weren't informing gestures of capture, fixes Slider capture issue
+* 148896 [iOS] TextBlock CarriageReturns would continue past maxlines property 
 
 ## Release 1.44.0
 

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -601,6 +601,14 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\ForcedTextWithCarriageReturn_MaxLines_One.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\ForcedTextWithCarriageReturn_MaxLines_Two.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1997,6 +2005,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_Simple.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_Simple_databound.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_Supserscript.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\ForcedTextWithCarriageReturn_MaxLines_One.xaml.cs">
+      <DependentUpon>ForcedTextWithCarriageReturn_MaxLines_One.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\ForcedTextWithCarriageReturn_MaxLines_Two.xaml.cs">
+      <DependentUpon>ForcedTextWithCarriageReturn_MaxLines_Two.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock_with_inline_margin.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock_with_margin.xaml.cs" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/ForcedTextWithCarriageReturn_MaxLines_One.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/ForcedTextWithCarriageReturn_MaxLines_One.xaml
@@ -1,0 +1,20 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.ForcedTextWithCarriageReturn_MaxLines_One"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<TextBlock x:Name="textBlock1" Text="This is a very very very very long text that should not wrap even though it goes out of the screen but I will be changed onloaded, check xaml.cs" FontSize="20" MaxLines="1" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"  />
+
+</UserControl>
+

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/ForcedTextWithCarriageReturn_MaxLines_One.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/ForcedTextWithCarriageReturn_MaxLines_One.xaml.cs
@@ -1,0 +1,23 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "ForcedTextWithCarriageReturn_MaxLines_One")]
+	public sealed partial class ForcedTextWithCarriageReturn_MaxLines_One : UserControl
+    {
+		public ForcedTextWithCarriageReturn_MaxLines_One()
+        {
+            this.InitializeComponent();
+			this.Loaded += Page_Loaded;
+		}
+
+		private void Page_Loaded(object sender, RoutedEventArgs e)
+		{
+			textBlock1.Text = "This text spans\nmultiple lines.";
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/ForcedTextWithCarriageReturn_MaxLines_Two.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/ForcedTextWithCarriageReturn_MaxLines_Two.xaml
@@ -1,0 +1,20 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.TextBlockControl.ForcedTextWithCarriageReturn_MaxLines_Two"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	xmlns:xamarin="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<TextBlock x:Name="textBlock1" Text="This is a very very very very long text that should not wrap even though it goes out of the screen but I will be changed onloaded, check xaml.cs" FontSize="20" MaxLines="2" TextWrapping="Wrap" TextTrimming="CharacterEllipsis"  />
+
+</UserControl>
+

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/ForcedTextWithCarriageReturn_MaxLines_Two.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/ForcedTextWithCarriageReturn_MaxLines_Two.xaml.cs
@@ -1,0 +1,23 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace Uno.UI.Samples.Content.UITests.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "ForcedTextWithCarriageReturn_MaxLines_Two")]
+	public sealed partial class ForcedTextWithCarriageReturn_MaxLines_Two : UserControl
+	{
+		public ForcedTextWithCarriageReturn_MaxLines_Two()
+		{
+			this.InitializeComponent();
+			this.Loaded += Page_Loaded;
+		}
+
+		private void Page_Loaded(object sender, RoutedEventArgs e)
+		{
+			textBlock1.Text = "This text\nspans\nmultiple lines.";
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.iOS.cs
@@ -40,7 +40,7 @@ namespace Windows.UI.Xaml.Controls
 			CanWrap && CanTrim ||
 			CanWrap && MaxLines != 0;
 
-		private bool CanWrap => TextWrapping != TextWrapping.NoWrap && MaxLines != 1;
+		private bool CanWrap => TextWrapping != TextWrapping.NoWrap;
 
 		private bool CanTrim => TextTrimming != TextTrimming.None;
 


### PR DESCRIPTION


## PR Type
What kind of change does this PR introduce?
 Bugfix 


## What is the current behavior?
iOS Carriage returns would not take the MaxLines Textblock property into consideration


## What is the new behavior?
Fixed: Carriage Returns follow MaxLines Property

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/148896

UserEcho
https://feedback.nventive.com/communities/1/topics/3424-ios-textblockmaxlines-doesnt-work-with-carriage-returns
