### PR TITLE
configure dependabot to automatically bump dependencies

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+update_configs:
+  - package_manager: "dotnet:nuget"
+    directory: "/"
+    update_schedule: "live"
+
+    default_labels:
+      - "kind/dependency"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?

Humans need to manually track security updates or new releases of dependencies that Uno depends upon.

## What is the new behavior?

This pull-request wires up the configuration `.dependabot/config.yml` and activates the https://dependabot.com robot. The behaviour is documented at https://dependabot.com/docs/config-file/ and there is a config validator at https://dependabot.com/docs/config-file/validator/

The configuration shipped in this pull-request will subscribe to the nuget.org package feed and when updates are pushed there will automatically raise PRs on this repository. These PR's will, of course, trigger CI and then humans can decide if we do or do not want to bump the dependency. Instructions on how to use the bot are included in the pull-request comments.

![image](https://user-images.githubusercontent.com/127353/58212218-79b0a500-7d31-11e9-91da-47f7d9d1dd13.png)

We can also manually trigger dependabot to run by visiting https://app.dependabot.com

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)


## Other information

I've tested this change over at https://github.com/ghuntley/uno/pulls. Here's what we can expect once this PR has been merged.

![image](https://user-images.githubusercontent.com/127353/58212273-964cdd00-7d31-11e9-8db4-bb680ea09ff3.png)

This is the effective running configuration

![image](https://user-images.githubusercontent.com/127353/58212475-428ec380-7d32-11e9-83e5-9a114a185659.png)
