### PR TITLE
Add invalid caracters checks and replacements in resources generation

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -98,6 +98,7 @@
 * 148896 [iOS] TextBlock CarriageReturns would continue past maxlines property
 * 153594 [Android] EdgeEffect not showing up on listView that contain Headers and Footers
 * #881 [iOS] Support explicitly-defined ListViewItems in ListView.
+* #902 [Android] Resource generation now correctly escapes names starting with numbers and names containing a '-' character
 
 ## Release 1.44.0
 

--- a/src/Uno.UI/Services/AndroidResourceNameEncoder.cs
+++ b/src/Uno.UI/Services/AndroidResourceNameEncoder.cs
@@ -8,9 +8,10 @@ namespace Uno.UI
 {
     internal static class AndroidResourceNameEncoder
     {
+		private const string NumberPrefix = "__";
 		// These characters are not supported on Android, but they're used by the attached property localization syntax.
 		// Example: "MyUid.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name"
-		private static char[] UnsupportedCharacters = new char[] { '[', ']', ':' };
+		private static char[] UnsupportedCharacters = new char[] { '[', ']', ':', '-' };
 
 		/// <summary>
 		/// Encode a resource name to remove characters that are not supported on Android.
@@ -27,6 +28,12 @@ namespace Uno.UI
 				{
 					key = key.Replace(unsupportedCharacter, '_');
 				}
+			}
+
+			//Checks if the keys are starting by a number because they are invalid in C#
+			if (int.TryParse(key.Substring(0,1), out var number))
+			{
+				key = $"{NumberPrefix}{key}";
 			}
 
 			return key;


### PR DESCRIPTION
GitHub Issue : [#902](https://github.com/nventive/Uno/issues/902)

## Improvement

## What is the current behavior?
If a resw resource key starts by a number or contains a dash, the build fails because those are used as is in the generated Resource file for Android and are invalid in C#.

## What is the new behavior?
Those characters are "escaped" in the intermediate file generated by Uno.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)