### PR TITLE
Windows.System.Display.DisplayRequest

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -1,6 +1,7 @@
 # Release notes
 
 ## Next version
+* Add support for `Windows.System.Display.DisplayRequest` API on iOS and Android
 * Add support for the following `Windows.System.Power.PowerManager` APIs on iOS and Android:
     - BatteryStatus
     - EnergySaverStatus

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -2691,8 +2691,4 @@
     <PRIResource Include="$(MSBuildThisFileDirectory)UITestsStrings\en-US\NamedResources.resw" />
     <PRIResource Include="$(MSBuildThisFileDirectory)UITestsStrings\en-US\Resources.resw" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="$(MSBuildThisFileDirectory)Windows_System\Power\" />
-    <Folder Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ChatBox\" />
-  </ItemGroup>
 </Project>

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -37,7 +37,11 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="$(MSBuildThisFileDirectory)Windows_System_Power\PowerManager.xaml">
+    <Page Include="$(MSBuildThisFileDirectory)Windows_System\Display\DisplayRequest.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_System\Power\PowerManager.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -1659,7 +1663,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_Storage\StorageFolderTests\Persistence.xaml.cs">
       <DependentUpon>Persistence.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_System_Power\PowerManager.xaml.cs">
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_System\Display\DisplayRequest.xaml.cs">
+      <DependentUpon>DisplayRequest.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_System\Power\PowerManager.xaml.cs">
       <DependentUpon>PowerManager.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI.Xaml_Automation\AutomationProperties_Name.xaml.cs">
@@ -2685,6 +2692,7 @@
     <PRIResource Include="$(MSBuildThisFileDirectory)UITestsStrings\en-US\Resources.resw" />
   </ItemGroup>
   <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)Windows_System\Power\" />
     <Folder Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ChatBox\" />
   </ItemGroup>
 </Project>

--- a/src/SamplesApp/UITests.Shared/Windows_System/Display/DisplayRequest.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_System/Display/DisplayRequest.xaml
@@ -1,0 +1,16 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_System.Display.DisplayRequest"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <StackPanel>
+		<Button Click="RequestActive_Click">RequestActive()</Button>
+		<Button Click="RequestRelease_Click">RequestRelease()</Button>
+		<TextBlock x:Name="ActiveRequestCounter"/>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_System/Display/DisplayRequest.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_System/Display/DisplayRequest.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+using UwpDisplayRequest = Windows.System.Display.DisplayRequest;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_System.Display
+{
+	[SampleControlInfoAttribute("Windows.System", "Display.DisplayRequest",
+		description: "Demonstrates DisplayRequest class to keep screen awake. Make sure to test without debugger attached (that keeps screen on all the time).")]
+	public sealed partial class DisplayRequest : UserControl
+    {
+	    private static int _currentlyActive = 0;
+		private static UwpDisplayRequest _displayRequest = new UwpDisplayRequest();
+
+        public DisplayRequest()
+        {
+            this.InitializeComponent();
+        }
+
+        private void RequestActive_Click(object sender, RoutedEventArgs e)
+        {
+			_displayRequest.RequestActive();
+			ActiveRequestCounter.Text = $"Currently active {(++_currentlyActive).ToString()} request";
+
+		}
+
+        private void RequestRelease_Click(object sender, RoutedEventArgs e)
+        {
+			_displayRequest.RequestRelease();
+			ActiveRequestCounter.Text = $"Currently active {(--_currentlyActive).ToString()} request";
+		}
+    }
+}

--- a/src/SamplesApp/UITests.Shared/Windows_System/Power/PowerManager.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_System/Power/PowerManager.xaml
@@ -1,5 +1,5 @@
 ﻿<UserControl
-    x:Class="UITests.Shared.Windows_System_Power.PowerManager"
+    x:Class="UITests.Shared.Windows_System.Power.PowerManager"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/src/SamplesApp/UITests.Shared/Windows_System/Power/PowerManager.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_System/Power/PowerManager.xaml.cs
@@ -18,9 +18,9 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 using UwpPowerManager = Windows.System.Power.PowerManager;
 
-namespace UITests.Shared.Windows_System_Power
+namespace UITests.Shared.Windows_System.Power
 {
-	[SampleControlInfoAttribute("Windows.System.Power", "PowerManager",
+	[SampleControlInfoAttribute("Windows.System", "Power.PowerManager",
 		description: "Shows properties of Power manager and handles its events")]
 	public sealed partial class PowerManager : UserControl
 	{

--- a/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Display/DisplayRequest.cs
+++ b/src/Uno.UWP/Generated/3.0.0.0/Windows.System.Display/DisplayRequest.cs
@@ -2,12 +2,12 @@
 #pragma warning disable 114 // new keyword hiding
 namespace Windows.System.Display
 {
-	#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+	#if false || false  || NET461 || __WASM__ || __MACOS__
 	[global::Uno.NotImplemented]
 	#endif
 	public  partial class DisplayRequest 
 	{
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public DisplayRequest() 
 		{
@@ -15,14 +15,14 @@ namespace Windows.System.Display
 		}
 		#endif
 		// Forced skipping of method Windows.System.Display.DisplayRequest.DisplayRequest()
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false  || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  void RequestActive()
 		{
 			global::Windows.Foundation.Metadata.ApiInformation.TryRaiseNotImplemented("Windows.System.Display.DisplayRequest", "void DisplayRequest.RequestActive()");
 		}
 		#endif
-		#if __ANDROID__ || __IOS__ || NET461 || __WASM__ || __MACOS__
+		#if false || false  || NET461 || __WASM__ || __MACOS__
 		[global::Uno.NotImplemented]
 		public  void RequestRelease()
 		{

--- a/src/Uno.UWP/System/Display/DisplayRequest.Android.cs
+++ b/src/Uno.UWP/System/Display/DisplayRequest.Android.cs
@@ -1,0 +1,38 @@
+﻿#if __ANDROID__
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Android.App;
+using Android.Views;
+using Uno.UI;
+
+namespace Windows.System.Display
+{
+	public partial class DisplayRequest
+	{
+		partial void ActivateScreenLock()
+		{
+			var activity = GetActivity();
+			activity.Window.AddFlags(WindowManagerFlags.KeepScreenOn);
+		}
+
+		partial void DeactivateScreenLock()
+		{
+			var activity = GetActivity();
+			activity.Window.ClearFlags(WindowManagerFlags.KeepScreenOn);
+		}
+
+		private static Activity GetActivity()
+		{
+			if (ContextHelper.Current is Activity activity)
+			{
+				return activity;
+			}
+			else
+			{
+				throw new InvalidOperationException("Application Activity is not initialized.");
+			}
+		}
+	}
+}
+#endif

--- a/src/Uno.UWP/System/Display/DisplayRequest.cs
+++ b/src/Uno.UWP/System/Display/DisplayRequest.cs
@@ -1,0 +1,50 @@
+﻿#if __ANDROID__ || __IOS__
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Windows.System.Display
+{
+	public partial class DisplayRequest
+	{
+		private static object _syncLock = new object();
+		private static int _globalRequestCount = 0;
+
+		private int _instanceRequestCount = 0;
+
+		public void RequestActive()
+		{
+			lock (_syncLock)
+			{
+				_instanceRequestCount++;
+				_globalRequestCount++;
+				if (_globalRequestCount == 1)
+				{
+					//first global request, activate screen lock
+					ActivateScreenLock();
+				}
+			}
+		}
+
+		public void RequestRelease()
+		{
+			lock (_syncLock)
+			{
+				if (_instanceRequestCount == 0)
+					throw new InvalidOperationException("No active display request to release");
+				_instanceRequestCount--;
+				_globalRequestCount--;
+				if ( _globalRequestCount == 0)
+				{
+					//last global active request, deactivate
+					DeactivateScreenLock();
+				}
+			}
+		}
+
+		partial void ActivateScreenLock();
+
+		partial void DeactivateScreenLock();
+	}
+}
+#endif

--- a/src/Uno.UWP/System/Display/DisplayRequest.cs
+++ b/src/Uno.UWP/System/Display/DisplayRequest.cs
@@ -36,7 +36,7 @@ namespace Windows.System.Display
 				}
 				_instanceRequestCount--;
 				_globalRequestCount--;
-				if ( _globalRequestCount == 0)
+				if (_globalRequestCount == 0)
 				{
 					//last global active request, deactivate
 					DeactivateScreenLock();

--- a/src/Uno.UWP/System/Display/DisplayRequest.cs
+++ b/src/Uno.UWP/System/Display/DisplayRequest.cs
@@ -31,7 +31,9 @@ namespace Windows.System.Display
 			lock (_syncLock)
 			{
 				if (_instanceRequestCount == 0)
+				{
 					throw new InvalidOperationException("No active display request to release");
+				}
 				_instanceRequestCount--;
 				_globalRequestCount--;
 				if ( _globalRequestCount == 0)

--- a/src/Uno.UWP/System/Display/DisplayRequest.iOS.cs
+++ b/src/Uno.UWP/System/Display/DisplayRequest.iOS.cs
@@ -1,0 +1,22 @@
+﻿#if __IOS__
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UIKit;
+
+namespace Windows.System.Display
+{
+	public partial class DisplayRequest
+	{
+		partial void ActivateScreenLock()
+		{
+			UIApplication.SharedApplication.IdleTimerDisabled = true;
+		}
+
+		partial void DeactivateScreenLock()
+		{
+			UIApplication.SharedApplication.IdleTimerDisabled = false;
+		}
+	}
+}
+#endif


### PR DESCRIPTION
GitHub Issue (If applicable): #907 

## PR Type
What kind of change does this PR introduce?

 - Feature -->

## What is the current behavior?
`Windows.System.Display.DisplayRequest` is not implemented


## What is the new behavior?
`Windows.System.Display.DisplayRequest` is implemented on iOS and Android. Its behavior matches UWP and it allows creating multiple instances as well as throws when release is attempted when there is no active request.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
