### PR TITLE
Revert "Bump FluentAssertions from 5.5.0 to 5.6.0"

### DIFF
--- a/src/Uno.UI.Tests.Performance/Uno.UI.Tests.Performance.csproj
+++ b/src/Uno.UI.Tests.Performance/Uno.UI.Tests.Performance.csproj
@@ -36,7 +36,7 @@
       <Version>1.3</Version>
     </PackageReference>
     <PackageReference Include="FluentAssertions">
-      <Version>5.6.0</Version>
+      <Version>5.5.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.10.0</Version>

--- a/src/Uno.UI.Tests/Uno.UI.Tests.csproj
+++ b/src/Uno.UI.Tests/Uno.UI.Tests.csproj
@@ -38,7 +38,7 @@
       <Version>1.3</Version>
     </PackageReference>
     <PackageReference Include="FluentAssertions">
-      <Version>5.6.0</Version>
+      <Version>5.5.0</Version>
     </PackageReference>
     <PackageReference Include="Moq">
       <Version>4.10.0</Version>


### PR DESCRIPTION
Reverts nventive/Uno#895

Branch name breaks versioning,