### PR TITLE
do not merge dependabot PR's until issue #912 is resolved

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -6,3 +6,4 @@ update_configs:
 
     default_labels:
       - "kind/dependency"
+      - "do-not-merge/work-in-progress"


### PR DESCRIPTION
GitHub Issue (If applicable): #912 

## PR Type
What kind of change does this PR introduce?

- Build or CI related changes

## What is the current behavior?

See https://github.com/nventive/Uno/issues/912


## What is the new behavior?

Dependabot will now automatically add the label `do-not-merge/work-in-progress`


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
