### PR TITLE
bumped copyright date from 2018 to 2019

### DIFF
--- a/src/Common/GlobalAssemblyInfo.cs
+++ b/src/Common/GlobalAssemblyInfo.cs
@@ -24,7 +24,7 @@ using System.Security;
 [assembly: AssemblyConfiguration("Release")]
 #endif
 
-[assembly: AssemblyCopyright("Copyright (C) 2009-2018 nVentive.")]
+[assembly: AssemblyCopyright("Copyright (C) 2009-2019 nVentive.")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
GitHub Issue (If applicable): n/a

## PR Type
What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes)

## What is the current behavior?

2009-2018

## What is the new behavior?

2009-2019

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)


## Other information

MSDN - https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assemblycopyrightattribute?redirectedfrom=MSDN&view=netframework-4.8
