### PR TITLE
 Implement StateTrigger precedence as documented by Microsoft

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -55,6 +55,7 @@
 * [Wasm] Restore support for `x:Load` and `x:DeferLoadStrategy`
 * [Wasm] Scrolling bar visibility modes are now supported on most browsers
 * Add `Windows.Globalization.Calendar`
+* Using _State Triggers_ in `VisualStateManager` now follows correct precedence as documented by Microsoft
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_AdaptiveTrigger.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_AdaptiveTrigger.cs
@@ -67,7 +67,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 		{
 			Window.Current.SetWindowSize(new Size(100, 100));
 
-			var sut = new AdaptiveTrigger(); // should always be active
+			var sut = new AdaptiveTrigger {MinWindowWidth = 0};
 
 			var state = new VisualState { Name = "activeState" };
 			state.StateTriggers.Add(sut);

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/VisualStateManagerTests/Given_VisualStateManager.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/VisualStateManagerTests/Given_VisualStateManager.cs
@@ -52,11 +52,15 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.VisualStateManagerTests
 
 			trigger2.Set();
 			dispatcher.ProcessEvents(CoreProcessEventsOption.ProcessAllIfPresent);
+			control.Tag.Should().Be(1);
+
+			trigger1.Unset();
+			dispatcher.ProcessEvents(CoreProcessEventsOption.ProcessAllIfPresent);
 			control.Tag.Should().Be(2);
 
 			trigger2.Unset();
 			dispatcher.ProcessEvents(CoreProcessEventsOption.ProcessAllIfPresent);
-			control.Tag.Should().Be(1);
+			control.Tag.Should().Be(null);
 		}
 
 		[TestMethod]
@@ -111,7 +115,16 @@ namespace Uno.UI.Tests.Windows_UI_Xaml.VisualStateManagerTests
 			trigger2.Set();
 			dispatcher.ProcessEvents(CoreProcessEventsOption.ProcessAllIfPresent);
 
-			completed1Count.Should().Be(0);
+			// Seems weird, but that's normal, it's following documented
+			// precedence. "state2" will be set only after "trigger1" will
+			// be unset.
+			completed1Count.Should().Be(1);
+			completed2Count.Should().Be(0);
+
+			trigger1.Unset();
+			dispatcher.ProcessEvents(CoreProcessEventsOption.ProcessAllIfPresent);
+
+			completed1Count.Should().Be(1);
 			completed2Count.Should().Be(1);
 
 			trigger2.Unset();

--- a/src/Uno.UI/UI/Xaml/AdaptiveTrigger.cs
+++ b/src/Uno.UI/UI/Xaml/AdaptiveTrigger.cs
@@ -27,9 +27,18 @@ namespace Windows.UI.Xaml
 			var mw = MinWindowWidth;
 			var mh = MinWindowHeight;
 
-			var isActive = (w >= mw) && (h >= mh);
-
-			SetActive(isActive);
+			if (mw >= 0 && w >= mw)
+			{
+				SetActivePrecedence(StateTriggerPrecedence.MinWidthTrigger);
+			}
+			else if (mh >= 0 && h > mh)
+			{
+				SetActivePrecedence(StateTriggerPrecedence.MinHeightTrigger);
+			}
+			else
+			{
+				SetActivePrecedence(StateTriggerPrecedence.Inactive);
+			}
 		}
 
 		#region MinWindowHeight DependencyProperty

--- a/src/Uno.UI/UI/Xaml/StateTriggerBase.cs
+++ b/src/Uno.UI/UI/Xaml/StateTriggerBase.cs
@@ -4,6 +4,7 @@ using Uno.Extensions;
 using Uno.Logging;
 using Windows.Foundation;
 using Windows.Foundation.Metadata;
+
 namespace Windows.UI.Xaml
 {
 	public partial class StateTriggerBase : DependencyObject
@@ -21,13 +22,18 @@ namespace Windows.UI.Xaml
 			);
 		}
 
-		protected void SetActive(bool isActive)
+		protected void SetActive(bool active)
 		{
-			if (InternalIsActive == isActive)
+			SetActivePrecedence(active ? StateTriggerPrecedence.CustomTrigger : StateTriggerPrecedence.Inactive);
+		}
+
+		internal void SetActivePrecedence(StateTriggerPrecedence precedence)
+		{
+			if (CurrentPrecedence == precedence)
 			{
 				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 				{
-					this.Log().DebugFormat($"StateTrigger [{GetType().Name}] (owner={Owner?.Owner?.Name ?? "<null>"}/{Owner?.Name ?? "<null>"}) isActive:{isActive} [DUPLICATED: IGNORED]");
+					this.Log().DebugFormat($"StateTrigger [{GetType().Name}] (owner={Owner?.Owner ?? (object)"<null>"}/{Owner ?? (object)"<null>"}) precedence:{precedence} [DUPLICATED: IGNORED]");
 				}
 
 				return; // nothing to do
@@ -35,15 +41,15 @@ namespace Windows.UI.Xaml
 
 			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
 			{
-				this.Log().DebugFormat($"StateTrigger [{GetType().Name}] (owner={Owner?.Owner?.Name ?? "<null>"}/{Owner?.Name ?? "<null>"}) isActive:{isActive}");
+				this.Log().DebugFormat($"StateTrigger [{GetType().Name}] (owner={Owner?.Owner ?? (object)"<null>"}/{Owner ?? (object)"<null>"}) precedence:{precedence}");
 			}
 
-			InternalIsActive = isActive;
+			CurrentPrecedence = precedence;
 
 			Owner?.Owner?.RefreshStateTriggers();
 		}
 
-		internal bool InternalIsActive { get; set; }
+		internal StateTriggerPrecedence CurrentPrecedence { get; set; } = 0;
 
 		internal VisualState Owner => this.GetParent() as VisualState;
 

--- a/src/Uno.UI/UI/Xaml/StateTriggerPrecedence.cs
+++ b/src/Uno.UI/UI/Xaml/StateTriggerPrecedence.cs
@@ -1,0 +1,13 @@
+namespace Windows.UI.Xaml
+{
+	/// <summary>
+	/// Precedence of an active trigger
+	/// </summary>
+	internal enum StateTriggerPrecedence : byte
+	{
+		Inactive = 0,
+		CustomTrigger = 1,
+		MinWidthTrigger = 2,
+		MinHeightTrigger = 3
+	}
+}

--- a/src/Uno.UI/UI/Xaml/VisualState.cs
+++ b/src/Uno.UI/UI/Xaml/VisualState.cs
@@ -14,7 +14,7 @@ namespace Windows.UI.Xaml
 	[ContentProperty(Name = "Storyboard")]
 	public sealed partial class VisualState : DependencyObject
 	{
-        public VisualState()
+		public VisualState()
 		{
 			InitializeBinder();
 			IsAutoPropertyInheritanceEnabled = false;
@@ -137,5 +137,7 @@ namespace Windows.UI.Xaml
 		{
 			Owner?.RefreshStateTriggers();
 		}
+
+		public override string ToString() => Name ?? $"<unnamed state {GetHashCode()}>";
 	}
 }


### PR DESCRIPTION
## Feature
_State Triggers_ used in a `VisualStateManager` will now follow the precedenced as
documented by Microsoft.

## What is the new behavior?
The following precedence is now applied:

<https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.visualstategroup#remarks>

> When using StateTriggers to control visual states, the trigger engine uses the following precedence
> rules to score triggers and determine which trigger, and the corresponding VisualState, will be active:
>
> 1. Custom trigger that derives from StateTriggerBase
> 2. AdaptiveTrigger activated due to MinWindowWidth
> 3. AdaptiveTrigger activated due to MinWindowHeight
>
> If there are multiple active triggers at a time that have a conflict in scoring (i.e. two active custom
> triggers), then the first one declared in the markup file takes precedence.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
