### PR TITLE
Enable Overlay mode of SplitView on WASM as it's now supported

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -55,6 +55,7 @@
 * [Wasm] Restore support for `x:Load` and `x:DeferLoadStrategy`
 * [Wasm] Scrolling bar visibility modes are now supported on most browsers
 * Add `Windows.Globalization.Calendar`
+* [Wasm] Support of overlay mode of the pane
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -2889,9 +2889,7 @@
 						</Grid.ColumnDefinitions>
 
 						<!--Content Area-->
-						<!-- Wasm: Workaround to make SplitView work (only supports Inline mode). -->
 						<Grid x:Name="ContentRoot"
-							  wasm:Grid.Column="1"
 							  Grid.ColumnSpan="2">
 							<Border Child="{TemplateBinding Content}" />
 							<win:Rectangle x:Name="LightDismissLayer"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Feature

## What is the current behavior?
`Overlay` mode of `SPlitView` (`NavigationView`) is not possible using default styles

## What is the new behavior?
It's possible

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable): https://nventive.visualstudio.com/_workitems/edit/154530