### PR TITLE
[Wasm] Add TextBlock measure caching

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -63,6 +63,7 @@
 * Add support for `FlyoutBase.AttachedFlyout` and `FlyoutBase.ShowAttachedFlyout()`
 * `x:Bind` now supports binding to fields
 * `Grid` positions (`Row`, `RowSpan`, `Column` & `ColumnSpan`) are now behaving like UWP when the result overflows grid rows/columns definition
+* [Wasm] Improve TextBlock measure performance
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -51,7 +51,10 @@ namespace SamplesApp
 		protected override void OnLaunched(LaunchActivatedEventArgs e)
 		{
 			var sw = Stopwatch.StartNew();
-			var n = CoreDispatcher.Main.RunAsync(CoreDispatcherPriority.Idle, () => Console.WriteLine("Done loading " + sw.Elapsed));
+			var n = Windows.UI.Xaml.Window.Current.Dispatcher.RunAsync(
+				CoreDispatcherPriority.Idle,
+				() => Console.WriteLine("Done loading " + sw.Elapsed));
+
 #if DEBUG
 			if (System.Diagnostics.Debugger.IsAttached)
 			{

--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices.WindowsRuntime;
@@ -49,6 +50,8 @@ namespace SamplesApp
 		/// <param name="e">Details about the launch request and process.</param>
 		protected override void OnLaunched(LaunchActivatedEventArgs e)
 		{
+			var sw = Stopwatch.StartNew();
+			var n = CoreDispatcher.Main.RunAsync(CoreDispatcherPriority.Idle, () => Console.WriteLine("Done loading " + sw.Elapsed));
 #if DEBUG
 			if (System.Diagnostics.Debugger.IsAttached)
 			{
@@ -128,7 +131,7 @@ namespace SamplesApp
 						//{ "Windows.UI.Xaml.VisualStateGroup", LogLevel.Debug },
 						//{ "Windows.UI.Xaml.StateTriggerBase", LogLevel.Debug },
 						// { "Windows.UI.Xaml.UIElement", LogLevel.Debug },
-						// { "Windows.UI.Xaml.Setter", LogLevel.Debug },
+						// { "Windows.UI.Xaml.Controls.TextBlock", LogLevel.Debug },
 						   
 						// Layouter specific messages
 						// { "Windows.UI.Xaml.Controls", LogLevel.Debug },

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -3085,9 +3085,6 @@
     <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Simpletwocolumnsplitgrid.xaml.cs">
       <DependentUpon>Simpletwocolumnsplitgrid.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\s\nv.github\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_MeasurePeformance.xaml.cs">
-      <DependentUpon>TextBlock_MeasurePeformance.xaml</DependentUpon>
-    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(MSBuildThisFileDirectory)Assets\cart.png" />

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -961,6 +961,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_MeasurePeformance.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Multiline_In_StarStackPanel.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2369,6 +2373,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_Multiline.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_TextAlignment.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_TextTrimming.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_MeasurePeformance.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Multiline_In_StarStackPanel.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Nested_Measure_With_Outer_Alignments.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Padding.xaml.cs" />
@@ -3079,6 +3084,9 @@
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Simpletwocolumnsplitgrid.xaml.cs">
       <DependentUpon>Simpletwocolumnsplitgrid.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\s\nv.github\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_MeasurePeformance.xaml.cs">
+      <DependentUpon>TextBlock_MeasurePeformance.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_MeasurePeformance.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_MeasurePeformance.xaml
@@ -13,6 +13,7 @@
 		<StackPanel>
 			<TextBlock Text="Measure Performance" />
 			<TextBlock x:Name="result1" />
+			<CheckBox x:Name="measureCacheEnabled" IsChecked="True" Content="Measure Cache Enabled" />
 			<Button Content="Rerun Same Text" Click="Bench_TextMeasure_SameText" />
 		</StackPanel>
     </Grid>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_MeasurePeformance.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_MeasurePeformance.xaml
@@ -1,0 +1,19 @@
+﻿<UserControl
+    x:Class="UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl.TextBlock_MeasurePeformance"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <Grid>
+		<StackPanel>
+			<TextBlock Text="Measure Performance" />
+			<TextBlock x:Name="result1" />
+			<Button Content="Rerun Same Text" Click="Bench_TextMeasure_SameText" />
+		</StackPanel>
+    </Grid>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_MeasurePeformance.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_MeasurePeformance.xaml.cs
@@ -25,10 +25,16 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl
 		public TextBlock_MeasurePeformance()
 		{
 			this.InitializeComponent();
+
+			Bench_TextMeasure_SameText(null, null);
 		}
 
-		private void Bench_TextMeasure_SameText()
+		private void Bench_TextMeasure_SameText(object sender, object parms)
 		{
+#if __WASM__
+			Uno.UI.FeatureConfiguration.TextBlock.IsMeasureCacheEnabled = measureCacheEnabled.IsChecked.Value;
+#endif
+
 			var sw = Stopwatch.StartNew();
 
 			for (int i = 0; i < 300; i++)
@@ -37,7 +43,7 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl
 				tb.Measure(new Size(100, 100));
 			}
 
-			result1.Text = sw.Elapsed;
+			result1.Text = "Bench_TextMeasure_SameText:" + sw.Elapsed;
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_MeasurePeformance.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_MeasurePeformance.xaml.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Uno.UI.Samples.Controls;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The User Control item template is documented at https://go.microsoft.com/fwlink/?LinkId=234236
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.TextBlockControl
+{
+	[SampleControlInfo("TextBlockControl", "MeasurePerformance", ignoreInAutomatedTests: true)]
+	public sealed partial class TextBlock_MeasurePeformance : UserControl
+	{
+		public TextBlock_MeasurePeformance()
+		{
+			this.InitializeComponent();
+		}
+
+		private void Bench_TextMeasure_SameText()
+		{
+			var sw = Stopwatch.StartNew();
+
+			for (int i = 0; i < 300; i++)
+			{
+				var tb = new TextBlock { Text = "42" };
+				tb.Measure(new Size(100, 100));
+			}
+
+			result1.Text = sw.Elapsed;
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Controls/TextBlockTests/Given_TextBlockMeasureCache.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Controls/TextBlockTests/Given_TextBlockMeasureCache.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.Foundation;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml_Controls.TextBlockTests
+{
+	[TestClass]
+	public class Given_TextBlockMeasureCache
+	{
+		[TestMethod]
+		public void When_DefaultTextBlock()
+		{
+			var SUT = new TextBlockMeasureCache();
+
+			var tb = new TextBlock() { Text = "42" };
+
+			Assert.AreEqual(TextWrapping.NoWrap, tb.TextWrapping);
+
+			SUT.CacheMeasure(tb, new Size(100, 100), new Size(20, 10));
+
+			Assert.AreEqual(
+				new Size(20, 10),
+				SUT.FindMeasuredSize(tb, new Size(100, 100)).Value
+			);
+
+			Assert.AreEqual(
+				new Size(20, 10),
+				SUT.FindMeasuredSize(tb, new Size(50, 100)).Value
+			);
+
+			Assert.IsNull(
+				SUT.FindMeasuredSize(tb, new Size(10, 100))
+			);
+		}
+
+		[TestMethod]
+		public void When_DefaultTextBlock_Wrap()
+		{
+			var SUT = new TextBlockMeasureCache();
+
+			var tb = new TextBlock() { Text = "42", TextWrapping = TextWrapping.Wrap };
+
+			SUT.CacheMeasure(tb, new Size(50, 100), new Size(50, 70));
+
+			Assert.AreEqual(
+				new Size(50, 70),
+				SUT.FindMeasuredSize(tb, new Size(50, 100)).Value
+			);
+
+			Assert.AreEqual(
+				new Size(50, 70),
+				SUT.FindMeasuredSize(tb, new Size(50, 70)).Value
+			);
+
+			Assert.IsNull(
+				SUT.FindMeasuredSize(tb, new Size(50, 69))
+			);
+
+			Assert.IsNull(
+				SUT.FindMeasuredSize(tb, new Size(49, 100))
+			);
+
+			Assert.IsNull(
+				SUT.FindMeasuredSize(tb, new Size(50.1, 100))
+			);
+		}
+	}
+}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Controls/TextBlockTests/Given_TextBlockMeasureCache.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Controls/TextBlockTests/Given_TextBlockMeasureCache.cs
@@ -171,5 +171,33 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Controls.TextBlockTests
 				SUT.FindMeasuredSize(tb1, new Size(11, 11))
 			);
 		}
+
+		[TestMethod]
+		public void When_SmallerAvailableSize()
+		{
+			var SUT = new TextBlockMeasureCache();
+
+			var tb = new TextBlock() { Text = "42" };
+
+			Assert.AreEqual(TextWrapping.NoWrap, tb.TextWrapping);
+
+			SUT.CacheMeasure(tb, new Size(0, 0), new Size(0, 0));
+
+			Assert.IsNull(
+				SUT.FindMeasuredSize(tb, new Size(50, 50))
+			);
+
+			SUT.CacheMeasure(tb, new Size(100, 100), new Size(50, 10));
+
+			Assert.AreEqual(
+				new Size(50, 10),
+				SUT.FindMeasuredSize(tb, new Size(100, 100)).Value
+			);
+
+			Assert.AreEqual(
+				new Size(0, 0),
+				SUT.FindMeasuredSize(tb, new Size(0, 0)).Value
+			);
+		}
 	}
 }

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Controls/TextBlockTests/Given_TextBlockMeasureCache.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Controls/TextBlockTests/Given_TextBlockMeasureCache.cs
@@ -13,6 +13,23 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Controls.TextBlockTests
 	[TestClass]
 	public class Given_TextBlockMeasureCache
 	{
+		private int _originalMaxMeasureKeyEntries;
+		private int _originalMaxMeasureSizeKeyEntries;
+
+		[TestInitialize]
+		public void TestInitialize()
+		{
+			_originalMaxMeasureKeyEntries = TextBlockMeasureCache.MaxMeasureKeyEntries;
+			_originalMaxMeasureSizeKeyEntries = TextBlockMeasureCache.MaxMeasureSizeKeyEntries;
+		}
+
+		[TestCleanup]
+		public void TestCleanup()
+		{
+			TextBlockMeasureCache.MaxMeasureKeyEntries = _originalMaxMeasureKeyEntries;
+			TextBlockMeasureCache.MaxMeasureSizeKeyEntries = _originalMaxMeasureSizeKeyEntries;
+		}
+
 		[TestMethod]
 		public void When_DefaultTextBlock()
 		{
@@ -68,6 +85,90 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Controls.TextBlockTests
 
 			Assert.IsNull(
 				SUT.FindMeasuredSize(tb, new Size(50.1, 100))
+			);
+		}
+
+		[TestMethod]
+		public void When_MaxMeasureSizeKeyEntries_Reached()
+		{
+			var SUT = new TextBlockMeasureCache();
+
+			TextBlockMeasureCache.MaxMeasureKeyEntries = 2;
+			TextBlockMeasureCache.MaxMeasureSizeKeyEntries = 2;
+
+			var tb = new TextBlock() { Text = "42", TextWrapping = TextWrapping.Wrap };
+
+			SUT.CacheMeasure(tb, new Size(11, 11), new Size(1, 1));
+			Assert.AreEqual(
+				new Size(1, 1),
+				SUT.FindMeasuredSize(tb, new Size(11, 11)).Value
+			);
+
+			SUT.CacheMeasure(tb, new Size(22, 22), new Size(2, 2));
+			Assert.AreEqual(
+				new Size(1, 1),
+				SUT.FindMeasuredSize(tb, new Size(11, 11)).Value
+			);
+			Assert.AreEqual(
+				new Size(2, 2),
+				SUT.FindMeasuredSize(tb, new Size(22, 22)).Value
+			);
+
+			SUT.CacheMeasure(tb, new Size(33, 33), new Size(3, 3));
+			Assert.IsNull(
+				SUT.FindMeasuredSize(tb, new Size(11, 11))
+			);
+			Assert.AreEqual(
+				new Size(2, 2),
+				SUT.FindMeasuredSize(tb, new Size(22, 22)).Value
+			);
+			Assert.AreEqual(
+				new Size(3, 3),
+				SUT.FindMeasuredSize(tb, new Size(33, 33)).Value
+			);
+		}
+
+		[TestMethod]
+		public void When_MaxMeasureKeyEntries_Reached()
+		{
+			var SUT = new TextBlockMeasureCache();
+
+			TextBlockMeasureCache.MaxMeasureKeyEntries = 2;
+			TextBlockMeasureCache.MaxMeasureSizeKeyEntries = 2;
+
+			var tb1 = new TextBlock() { Text = "42", TextWrapping = TextWrapping.Wrap };
+
+			SUT.CacheMeasure(tb1, new Size(11, 11), new Size(1, 1));
+			Assert.AreEqual(
+				new Size(1, 1),
+				SUT.FindMeasuredSize(tb1, new Size(11, 11)).Value
+			);
+
+			var tb2 = new TextBlock() { Text = "43", TextWrapping = TextWrapping.Wrap };
+
+			SUT.CacheMeasure(tb2, new Size(11, 11), new Size(1, 1));
+			Assert.AreEqual(
+				new Size(1, 1),
+				SUT.FindMeasuredSize(tb2, new Size(11, 11)).Value
+			);
+			Assert.AreEqual(
+				new Size(1, 1),
+				SUT.FindMeasuredSize(tb1, new Size(11, 11)).Value
+			);
+
+			var tb3 = new TextBlock() { Text = "44", TextWrapping = TextWrapping.Wrap };
+
+			SUT.CacheMeasure(tb3, new Size(11, 11), new Size(1, 1));
+			Assert.AreEqual(
+				new Size(1, 1),
+				SUT.FindMeasuredSize(tb3, new Size(11, 11)).Value
+			);
+			Assert.AreEqual(
+				new Size(1, 1),
+				SUT.FindMeasuredSize(tb2, new Size(11, 11)).Value
+			);
+			Assert.IsNull(
+				SUT.FindMeasuredSize(tb1, new Size(11, 11))
 			);
 		}
 	}

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -139,6 +139,14 @@ namespace Uno.UI
 			public static bool IsPoolingEnabled { get; set; } = false;
 		}
 
+		public static class TextBlock
+		{
+			/// <summary>
+			/// Determines if the measure cache is enabled. (WASM only)
+			/// </summary>
+			public static bool IsMeasureCacheEnabled { get; set; } = true;
+		}
+
 		public static class AutomationPeer
 		{
 			/// <summary>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -8,6 +8,8 @@ using Uno.Foundation;
 using System.Linq;
 using Uno.UI.UI.Xaml.Documents;
 using Microsoft.Extensions.Logging;
+using Windows.UI.Text;
+using Windows.UI.Xaml.Media;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -15,8 +17,7 @@ namespace Windows.UI.Xaml.Controls
 	{
 		private const int MaxMeasureCache = 50;
 
-		private int _cacheIndex = 0;
-		private Dictionary<Size, (Size measuredSize, int age)> _measureCache = new Dictionary<Size, (Size, int)>();
+		private static TextBlockMeasureCache _cache = new TextBlockMeasureCache();
 
 		public TextBlock() : base("p")
 		{
@@ -32,51 +33,31 @@ namespace Windows.UI.Xaml.Controls
 
 		partial void InvalidateTextBlockPartial()
 		{
-			if (this.Log().IsEnabled(LogLevel.Debug))
-			{
-				this.Log().LogDebug($"Clearing measure cache");
-			}
-			_measureCache.Clear();
+
 		}
 
 		protected override Size MeasureOverride(Size availableSize)
 		{
-			if (_measureCache.TryGetValue(availableSize, out var result))
+			if (UseInlinesFastPath)
 			{
-				if (this.Log().IsEnabled(LogLevel.Debug))
+				if (_cache.FindMeasuredSize(this, availableSize) is Size desiredSize)
 				{
-					// {0} is used to avoid parsing errors caused by formatting a "{}" in the text
-					this.Log().LogDebug("{0}", $"Measure-cached [{Text}]: {availableSize} -> {result}");
+					return desiredSize;
 				}
-
-				return result.measuredSize;
-			}
-
-			var size = MeasureView(availableSize);
-
-			if (this.Log().IsEnabled(LogLevel.Debug))
-			{
-				this.Log().LogDebug("{0}", $"Measure-new ({_measureCache.Count}) [{Text}]: {availableSize} -> {size}");
-			}
-
-			AddToMeasureCache(availableSize, size);
-			return size;
-		}
-
-		private void AddToMeasureCache(Size availableSize, Size size)
-		{
-			_measureCache[availableSize] = (size, _cacheIndex++);
-
-			if(_measureCache.Count > MaxMeasureCache)
-			{
-				var minValue = _measureCache.Min(p => p.Value.age) + MaxMeasureCache / 2;
-
-				if (this.Log().IsEnabled(LogLevel.Debug))
+				else
 				{
-					this.Log().LogDebug($"Scavenging measure cache (Above {MaxMeasureCache}, {minValue})");
-				}
+					desiredSize = MeasureView(availableSize);
 
-				_measureCache.Remove(r => r.Value.age < minValue);
+					_cache.CacheMeasure(this, availableSize, desiredSize);
+
+					return desiredSize;
+				}
+			}
+			else
+			{
+				var desizedSize = MeasureView(availableSize);
+
+				return desizedSize;
 			}
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureEntry.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureEntry.cs
@@ -1,0 +1,92 @@
+﻿using System.Collections.Generic;
+using Windows.Foundation;
+using Uno;
+using CachedSize = Uno.CachedTuple<double, double>;
+using System;
+
+namespace Windows.UI.Xaml.Controls
+{
+	public partial class TextBlockMeasureCache
+	{
+		class MeasureEntry
+		{
+			private Dictionary<CachedSize, MeasureSizeEntry> _sizes
+				= new Dictionary<CachedSize, MeasureSizeEntry>();
+
+			private LinkedList<CachedSize> _queue = new LinkedList<CachedSize>();
+
+			public LinkedListNode<MeasureKey> ListNode { get; }
+
+			public MeasureEntry(LinkedListNode<MeasureKey> node) => this.ListNode = node;
+
+			public Size? FindMeasuredSize(MeasureKey key, Size availableSize)
+			{
+				if(_sizes.TryGetValue(CachedTuple.Create(availableSize.Width, availableSize.Height), out var sizeEntry))
+				{
+					return sizeEntry.MeasuredSize;
+				}
+				else
+				{
+					if(key.TextWrapping == TextWrapping.NoWrap)
+					{
+						// No wrap, assume any width below the asked available size
+						// is valid.
+						foreach(var keySize in _sizes)
+						{
+							if(keySize.Value.MeasuredSize.Width <= availableSize.Width)
+							{
+								MoveToLast(keySize.Key, keySize.Value);
+								return keySize.Value.MeasuredSize;
+							}
+						}
+					}
+					else
+					{
+						foreach (var keySize in _sizes)
+						{
+							// If text wraps and the available width is the same, any height below the
+							// available size is valid.
+							if (
+								keySize.Key.Item1 == availableSize.Width
+								&& keySize.Value.MeasuredSize.Height <= availableSize.Height
+							)
+							{
+								MoveToLast(keySize.Key, keySize.Value);
+								return keySize.Value.MeasuredSize;
+							}
+						}
+					}
+				}
+				return null;
+			}
+
+			private void MoveToLast(CachedSize key, MeasureSizeEntry value)
+			{
+				if(_queue.Count != 0 && _queue.Last.Value != key)
+				{
+					_queue.Remove(value.ListNode);
+					_queue.AddLast(value.ListNode);
+				}
+			}
+
+			internal void CacheMeasure(Size desiredSize, Size measuredSize)
+			{
+				Scavenge();
+
+				var key = CachedTuple.Create(desiredSize.Width, desiredSize.Height);
+				var node = _queue.AddLast(key);
+				_sizes[key] = new MeasureSizeEntry(measuredSize, node);
+			}
+
+			private void Scavenge()
+			{
+				if (_queue.Count >= MaxMeasureSizeKeyEntries)
+				{
+					_sizes.Remove(_queue.First.Value);
+					_queue.RemoveFirst();
+				}
+			}
+		}
+
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureEntry.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureEntry.cs
@@ -29,11 +29,12 @@ namespace Windows.UI.Xaml.Controls
 				{
 					if(key.TextWrapping == TextWrapping.NoWrap)
 					{
-						// No wrap, assume any width below the asked available size
-						// is valid.
+						// No wrap, assume any measured width below the asked available size
+						// is valid, if the available size is greater.
 						foreach(var keySize in _sizes)
 						{
-							if(keySize.Value.MeasuredSize.Width <= availableSize.Width)
+							if(keySize.Key.Item1 >= availableSize.Width &&
+								keySize.Value.MeasuredSize.Width <= availableSize.Width)
 							{
 								MoveToLast(keySize.Key, keySize.Value);
 								return keySize.Value.MeasuredSize;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureEntry.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureEntry.cs
@@ -6,8 +6,11 @@ using System;
 
 namespace Windows.UI.Xaml.Controls
 {
-	public partial class TextBlockMeasureCache
+	internal partial class TextBlockMeasureCache
 	{
+		/// <summary>
+		/// A set of TextBlock measures for a set of text characteristics
+		/// </summary>
 		class MeasureEntry
 		{
 			private Dictionary<CachedSize, MeasureSizeEntry> _sizes

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureKey.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureKey.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections.Generic;
+using Windows.UI.Text;
+using Windows.UI.Xaml.Media;
+using Uno.Extensions;
+
+namespace Windows.UI.Xaml.Controls
+{
+	public partial class TextBlockMeasureCache
+	{
+		class MeasureKey
+		{
+			public class Comparer : IEqualityComparer<MeasureKey>
+			{
+				public static Comparer Instance { get; } = new Comparer();
+
+				public bool Equals(MeasureKey x, MeasureKey y) =>
+					x.Text == y.Text
+					&& x.FontSize == y.FontSize
+					&& x.FontFamily == y.FontFamily
+					&& x.FontStyle == y.FontStyle
+					&& x.TextWrapping == y.TextWrapping
+					&& x.FontWeight == y.FontWeight
+					&& x.MaxLines == y.MaxLines
+					&& x.TextTrimming == y.TextTrimming
+					&& x.TextAlignment == y.TextAlignment
+					&& x.LineHeight == y.LineHeight
+					&& x.LineStackingStrategy == y.LineStackingStrategy
+					&& x.TextDecorations == y.TextDecorations
+					&& x.CharacterSpacing == y.CharacterSpacing;
+
+				public int GetHashCode(MeasureKey obj)
+					=> obj._hashCode;
+			}
+
+			private readonly int _hashCode;
+
+			public MeasureKey(
+				TextBlock source
+			)
+			{
+				FontStyle = source.FontStyle;
+				TextWrapping = source.TextWrapping;
+				FontWeight = source.FontWeight;
+				Text = source.Text;
+				FontFamily = source.FontFamily;
+				FontSize = source.FontSize;
+				MaxLines = source.MaxLines;
+				TextTrimming = source.TextTrimming;
+				TextAlignment = source.TextAlignment;
+				LineHeight = source.LineHeight;
+				LineStackingStrategy = source.LineStackingStrategy;
+				CharacterSpacing = source.CharacterSpacing;
+				TextDecorations = source.TextDecorations;
+
+				_hashCode = Text?.GetHashCode() ?? 0
+					^ FontFamily.GetHashCode()
+					^ FontSize.GetHashCode();
+			}
+
+			public override int GetHashCode() => _hashCode;
+
+			public override bool Equals(object obj)
+				=> obj is MeasureKey key ? Comparer.Instance.Equals(this, key) : false;
+
+			public FontStyle FontStyle { get; }
+			public TextWrapping TextWrapping { get; }
+			public FontWeight FontWeight { get; }
+			public string Text { get; }
+			public FontFamily FontFamily { get; }
+			public double FontSize { get; }
+			public int MaxLines { get; }
+			public TextTrimming TextTrimming { get; }
+			public TextAlignment TextAlignment { get; }
+			public double LineHeight { get; }
+			public LineStackingStrategy LineStackingStrategy { get; }
+			public int CharacterSpacing { get; }
+			public TextDecorations TextDecorations { get; }
+		}
+
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureKey.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureKey.cs
@@ -5,8 +5,11 @@ using Uno.Extensions;
 
 namespace Windows.UI.Xaml.Controls
 {
-	public partial class TextBlockMeasureCache
+	internal partial class TextBlockMeasureCache
 	{
+		/// <summary>
+		/// Defines text characteristics
+		/// </summary>
 		class MeasureKey
 		{
 			public class Comparer : IEqualityComparer<MeasureKey>

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureSizeEntry.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureSizeEntry.cs
@@ -4,8 +4,11 @@ using Windows.Foundation;
 
 namespace Windows.UI.Xaml.Controls
 {
-	public partial class TextBlockMeasureCache
+	internal partial class TextBlockMeasureCache
 	{
+		/// <summary>
+		/// Result of a single measure
+		/// </summary>
 		class MeasureSizeEntry
 		{
 			public MeasureSizeEntry(Size measuredSize, global::System.Collections.Generic.LinkedListNode<Uno.CachedTuple<double, double>> node)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureSizeEntry.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureSizeEntry.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using Uno;
+using Windows.Foundation;
+
+namespace Windows.UI.Xaml.Controls
+{
+	public partial class TextBlockMeasureCache
+	{
+		class MeasureSizeEntry
+		{
+			public MeasureSizeEntry(Size measuredSize, global::System.Collections.Generic.LinkedListNode<Uno.CachedTuple<double, double>> node)
+			{
+				MeasuredSize = measuredSize;
+				ListNode = node;
+			}
+
+			public Size MeasuredSize { get; }
+			public LinkedListNode<CachedTuple<double, double>> ListNode { get; }
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Windows.Foundation;
+using Windows.UI.Text;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Media;
+using Microsoft.Extensions.Logging;
+using Uno.Extensions;
+using Uno;
+
+namespace Windows.UI.Xaml.Controls
+{
+	public partial class TextBlockMeasureCache
+	{
+		private Dictionary<MeasureKey, MeasureEntry> _entries = new Dictionary<MeasureKey, MeasureEntry>(new MeasureKey.Comparer());
+
+		public void CacheMeasure(TextBlock source, Size availableSize, Size measuredSize)
+		{
+			var key = new MeasureKey(source);
+
+			if (!_entries.TryGetValue(key, out var entry))
+			{
+				_entries[key] = entry = new MeasureEntry();
+			}
+
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				// {0} is used to avoid parsing errors caused by formatting a "{}" in the text
+				this.Log().LogDebug("{0}", $"TextMeasure-new [{source.Text} / {source.TextWrapping} / {source.MaxLines}]: {availableSize} -> {measuredSize}");
+			}
+
+			entry.CacheMeasure(availableSize, measuredSize);
+		}
+
+		public Size? FindMeasuredSize(TextBlock source, Size availableSize)
+		{
+			var key = new MeasureKey(source);
+
+			if (_entries.TryGetValue(key, out var entry))
+			{
+				var measuredSize = entry.FindMeasuredSize(key, availableSize);
+
+				if (this.Log().IsEnabled(LogLevel.Debug))
+				{
+					// {0} is used to avoid parsing errors caused by formatting a "{}" in the text
+					this.Log().LogDebug("{0}", $"TextMeasure-cached [{source.Text} / {source.TextWrapping} / {source.MaxLines}]: {availableSize} -> {measuredSize}");
+				}
+
+				return measuredSize;
+
+			}
+
+			return null;
+		}
+
+		class MeasureEntry
+		{
+			public Dictionary<CachedTuple<double, double>, MeasureSizeEntry> _sizes
+				= new Dictionary<CachedTuple<double, double>, MeasureSizeEntry>();
+
+			public Size? FindMeasuredSize(MeasureKey key, Size availableSize)
+			{
+				if(_sizes.TryGetValue(CachedTuple.Create(availableSize.Width, availableSize.Height), out var sizeEntry))
+				{
+					return sizeEntry.MeasuredSize;
+				}
+				else
+				{
+					if(key.TextWrapping == TextWrapping.NoWrap)
+					{
+						// No wrap, assume any width below the asked available size
+						// is valid.
+						foreach(var keySize in _sizes)
+						{
+							if(keySize.Value.MeasuredSize.Width <= availableSize.Width)
+							{
+								return keySize.Value.MeasuredSize;
+							}
+						}
+					}
+					else
+					{
+						foreach (var keySize in _sizes)
+						{
+							// If text wraps and the available width is the same, any height below the
+							// available size is valid.
+							if (
+								keySize.Key.Item1 == availableSize.Width
+								&& keySize.Value.MeasuredSize.Height <= availableSize.Height
+							)
+							{
+								return keySize.Value.MeasuredSize;
+							}
+						}
+					}
+				}
+				return null;
+			}
+
+			internal void CacheMeasure(Size desiredSize, Size measuredSize)
+			{
+				_sizes[CachedTuple.Create(desiredSize.Width, desiredSize.Height)] = new MeasureSizeEntry(measuredSize);
+			}
+		}
+
+		class MeasureSizeEntry
+		{
+			public MeasureSizeEntry(Size measuredSize) => MeasuredSize = measuredSize;
+
+			public Size MeasuredSize { get; }
+		}
+
+		class MeasureKey
+		{
+			public class Comparer : IEqualityComparer<MeasureKey>
+			{
+				public bool Equals(MeasureKey x, MeasureKey y) =>
+					x.Text == y.Text
+					&& x.FontSize == y.FontSize
+					&& x.FontFamily == y.FontFamily
+					&& x.FontStyle == y.FontStyle
+					&& x.TextWrapping == y.TextWrapping
+					&& x.FontWeight == y.FontWeight
+					&& x.MaxLines == y.MaxLines
+					&& x.TextTrimming == y.TextTrimming
+					&& x.TextAlignment == y.TextAlignment
+					&& x.LineHeight == y.LineHeight
+					&& x.LineStackingStrategy == y.LineStackingStrategy
+					&& x.CharacterSpacing == y.CharacterSpacing;
+
+				public int GetHashCode(MeasureKey obj)
+					=> obj._hashCode;
+			}
+
+			private readonly int _hashCode;
+
+			public MeasureKey(
+				TextBlock source
+			)
+			{
+				FontStyle = source.FontStyle;
+				TextWrapping = source.TextWrapping;
+				FontWeight = source.FontWeight;
+				Text = source.Text;
+				FontFamily = source.FontFamily;
+				FontSize = source.FontSize;
+				MaxLines = source.MaxLines;
+				TextTrimming = source.TextTrimming;
+				TextAlignment = source.TextAlignment;
+				LineHeight = source.LineHeight;
+				LineStackingStrategy = source.LineStackingStrategy;
+				CharacterSpacing = source.CharacterSpacing;
+
+				_hashCode = Text?.GetHashCode() ?? 0
+					^ FontFamily.GetHashCode()
+					^ FontSize.GetHashCode();
+			}
+
+			public FontStyle FontStyle { get; }
+			public TextWrapping TextWrapping { get; }
+			public FontWeight FontWeight { get; }
+			public string Text { get; }
+			public FontFamily FontFamily { get; }
+			public double FontSize { get; }
+			public int MaxLines { get; }
+			public TextTrimming TextTrimming { get; }
+			public TextAlignment TextAlignment { get; }
+			public double LineHeight { get; }
+			public LineStackingStrategy LineStackingStrategy { get; }
+			public int CharacterSpacing { get; }
+		}
+
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using Uno.Extensions;
 using Uno;
 using System.Diagnostics;
+using Uno.UI;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -27,11 +28,6 @@ namespace Windows.UI.Xaml.Controls
 		private LinkedList<MeasureKey> _queue = new LinkedList<MeasureKey>();
 
 		/// <summary>
-		/// Deterimes if the cache is enabled.
-		/// </summary>
-		public static bool IsEnabled { get; set; } = true;
-
-		/// <summary>
 		/// Finds a cached measure for the provided <see cref="TextBlock"/> characteristics
 		/// given an <paramref name="availableSize"/>.
 		/// </summary>
@@ -42,7 +38,7 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var key = new MeasureKey(source);
 
-			if (IsEnabled && _entries.TryGetValue(key, out var entry))
+			if (FeatureConfiguration.TextBlock.IsMeasureCacheEnabled && _entries.TryGetValue(key, out var entry))
 			{
 				var measuredSize = entry.FindMeasuredSize(key, availableSize);
 

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
@@ -13,19 +13,31 @@ using System.Diagnostics;
 
 namespace Windows.UI.Xaml.Controls
 {
-	public partial class TextBlockMeasureCache
+	/// <summary>
+	/// A TextBlock measure cache for non-formatted text.
+	/// </summary>
+	internal partial class TextBlockMeasureCache
 	{
 		internal static int MaxMeasureKeyEntries { get; set; } = 500;
 		internal static int MaxMeasureSizeKeyEntries { get; set; } = 50;
-
-		public static bool IsEnabled { get; set; } = true;
 
 		private static Stopwatch _timer = Stopwatch.StartNew();
 
 		private Dictionary<MeasureKey, MeasureEntry> _entries = new Dictionary<MeasureKey, MeasureEntry>(new MeasureKey.Comparer());
 		private LinkedList<MeasureKey> _queue = new LinkedList<MeasureKey>();
 
+		/// <summary>
+		/// Deterimes if the cache is enabled.
+		/// </summary>
+		public static bool IsEnabled { get; set; } = true;
 
+		/// <summary>
+		/// Finds a cached measure for the provided <see cref="TextBlock"/> characteristics
+		/// given an <paramref name="availableSize"/>.
+		/// </summary>
+		/// <param name="source">The source</param>
+		/// <param name="availableSize">The available size to query</param>
+		/// <returns>An optional <see cref="Size"/> if found.</returns>
 		public Size? FindMeasuredSize(TextBlock source, Size availableSize)
 		{
 			var key = new MeasureKey(source);
@@ -47,6 +59,13 @@ namespace Windows.UI.Xaml.Controls
 			return null;
 		}
 
+		/// <summary>
+		/// Cache a <paramref name="measuredSize"/> for an <paramref name="availableSize"/>, given
+		/// the <paramref name="source"/> charateristics.
+		/// </summary>
+		/// <param name="source"></param>
+		/// <param name="availableSize"></param>
+		/// <param name="measuredSize"></param>
 		public void CacheMeasure(TextBlock source, Size availableSize, Size measuredSize)
 		{
 			var key = new MeasureKey(source);

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -338,6 +338,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <UpToDateCheckInput Remove="UI\Xaml\Controls\TextBlock\TextBlockMeasureCache.cs" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<None Update="Mixins\net461\VisualStatesMixins.tt">
 			<Generator>TextTemplatingFileGenerator</Generator>
 		</None>
@@ -351,9 +355,7 @@
 
 	<Target Name="GetBuiltProjectOutputRecursive" Condition=" '$(TargetFramework)' == 'xamarinios10' " />
 
-	<Target Name="VS16Mac_RemoveSystemMemory"
-					BeforeTargets="ResolveAssemblyReferences"
-					Condition="'$(MSBuildVersion)' &gt;= '16.0' and $([MSBuild]::IsOsPlatform('OSX'))">
+	<Target Name="VS16Mac_RemoveSystemMemory" BeforeTargets="ResolveAssemblyReferences" Condition="'$(MSBuildVersion)' &gt;= '16.0' and $([MSBuild]::IsOsPlatform('OSX'))">
 		<!--
 				VS4Mac seems to process System.Memory differently, and removes
 				the System.Memory local reference if the package is transitively referenced.
@@ -361,21 +363,14 @@
 				is properly adding the local System.Memory to the Reference item group.
 		-->
 		<ItemGroup>
-			<_ReferenceToRemove
-        Include="@(Reference)"
-        Condition="'%(Reference.Identity)'=='System.Memory'" />
+			<_ReferenceToRemove Include="@(Reference)" Condition="'%(Reference.Identity)'=='System.Memory'" />
 			<Reference Remove="@(_ReferenceToRemove)" />
 		</ItemGroup>
 	</Target>
 
-	<Target
-    Name="VS16_RemoveSystemMemory"
-    BeforeTargets="FindReferenceAssembliesForReferences"
-    Condition="'$(MSBuildVersion)' &gt;= '16.0' and ($(IsMonoAndroid) or $(IsXamarinIOS) or $(IsXamarinMac))">
+	<Target Name="VS16_RemoveSystemMemory" BeforeTargets="FindReferenceAssembliesForReferences" Condition="'$(MSBuildVersion)' &gt;= '16.0' and ($(IsMonoAndroid) or $(IsXamarinIOS) or $(IsXamarinMac))">
 		<ItemGroup>
-			<_ReferencePathToRemove
-        Include="@(ReferencePath)"
-        Condition="'%(ReferencePath.NuGetPackageId)'=='System.Memory'" />
+			<_ReferencePathToRemove Include="@(ReferencePath)" Condition="'%(ReferencePath.NuGetPackageId)'=='System.Memory'" />
 			<ReferencePath Remove="@(_ReferencePathToRemove)" />
 		</ItemGroup>
 	</Target>

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -339,6 +339,9 @@
 
 	<ItemGroup>
 	  <UpToDateCheckInput Remove="UI\Xaml\Controls\TextBlock\TextBlockMeasureCache.cs" />
+	  <UpToDateCheckInput Remove="UI\Xaml\Controls\TextBlock\TextBlockMeasureCache.MeasureEntry.cs" />
+	  <UpToDateCheckInput Remove="UI\Xaml\Controls\TextBlock\TextBlockMeasureCache.MeasureKey.cs" />
+	  <UpToDateCheckInput Remove="UI\Xaml\Controls\TextBlock\TextBlockMeasureCache.MeasureSizeEntry.cs" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Uno.UI/Uno.UI.csproj
+++ b/src/Uno.UI/Uno.UI.csproj
@@ -337,19 +337,6 @@
 		</ProjectReference>
 	</ItemGroup>
 
-	<ItemGroup>
-	  <UpToDateCheckInput Remove="UI\Xaml\Controls\TextBlock\TextBlockMeasureCache.cs" />
-	  <UpToDateCheckInput Remove="UI\Xaml\Controls\TextBlock\TextBlockMeasureCache.MeasureEntry.cs" />
-	  <UpToDateCheckInput Remove="UI\Xaml\Controls\TextBlock\TextBlockMeasureCache.MeasureKey.cs" />
-	  <UpToDateCheckInput Remove="UI\Xaml\Controls\TextBlock\TextBlockMeasureCache.MeasureSizeEntry.cs" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<None Update="Mixins\net461\VisualStatesMixins.tt">
-			<Generator>TextTemplatingFileGenerator</Generator>
-		</None>
-	</ItemGroup>
-
 	<Target Name="GetPackagingOutputs" Condition=" '$(TargetFramework)' == 'uap10.0' " />
 
 	<Target Name="GetBuiltProjectOutputRecursive" Condition=" '$(TargetFramework)' == 'xamarinios10' " />


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Feature

## What is the new behavior?
Add basic TextBlock measure caching to reduce the number of JS measureView invocations.

Same text measure time is divided by 2 using the interpreter.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
