### PR TITLE
Prevent grid positions from overflowing the definitions

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -62,6 +62,7 @@
 * Using _State Triggers_ in `VisualStateManager` now follows correct precedence as documented by Microsoft
 * Add support for `FlyoutBase.AttachedFlyout` and `FlyoutBase.ShowAttachedFlyout()`
 * `x:Bind` now supports binding to fields
+* `Grid` positions (`Row`, `RowSpan`, `Column` & `ColumnSpan`) are now behaving like UWP when the result overflows grid rows/columns definition
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -473,6 +473,182 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\CenteredGridinGridwithfixedsizechild.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\CenteredGridinGridwiththreefixedsizechildren.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\CenteredGridinGridwithtwofixedsizechildren.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Databoundwidth.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\GridDataboundGridColumn.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\GridWithColumnSpan.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Auto_Center_Cell.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Auto_Text_Block_Trimming.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_CenteredShapes.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_ColSpan_Bottom.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_DataBound_ColumnRow_Definitions.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_DataBound_RowColumn.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_InsideStackPanel_InsideButton.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_in_GridClipping.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_in_StackPanel.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_left_column_Auto.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_middle_col_auto__bottom_row_auto.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Multi_Column_Span.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_RowSpan_Auto_WithText.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_RowSpan_Right.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Star_Auto_WithTextblock.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Style_Local_Override.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Two_bottom_row_Auto__middle_col_auto.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_attributed_string.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_Fixed_Size.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_MinWidth_MinHeight.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_OutOfRange_Cells.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_Stack_Panel_and_Trimming.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_TextBlock_VerticalAlignment.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_Text_HorizontalAlignment_With_Margin.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_Text_VerticalAlignment_With_Margin.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_three_UserControl_With_5_Margin.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UILabel_TextAlignmentVertical_Bottom.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UserControlMargin.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UserControl_HorizonalAlignment.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UserControl_VerticalAlignment_Fixed_Height.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UserControl_VerticalAlignment_Variable_Height.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UserControl_VerticalAlignment_Variable_Width.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Quadrant_absolute_split.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Quadrant_all_100.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Quadrant_even_split.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Quadrant_uneven_split.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Quad_column_progressing_split.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Simpletwocolumnsplitgrid.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\HorizontalListViewGrouped.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -1923,6 +2099,51 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ChatBox\ChatBox.xaml.cs">
       <DependentUpon>ChatBox.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\CenteredGridinGridwithfixedsizechild.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\CenteredGridinGridwiththreefixedsizechildren.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\CenteredGridinGridwithtwofixedsizechildren.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Databoundwidth.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\GridDataboundGridColumn.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\GridTestViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\GridWithColumnSpan.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Auto_Center_Cell.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Auto_Text_Block_Trimming.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_CenteredShapes.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_ColSpan_Bottom.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_DataBound_ColumnRow_Definitions.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_DataBound_RowColumn.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_InsideStackPanel_InsideButton.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_in_GridClipping.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_in_StackPanel.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_left_column_Auto.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_middle_col_auto__bottom_row_auto.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Multi_Column_Span.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_RowSpan_Auto_WithText.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_RowSpan_Right.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Star_Auto_WithTextblock.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Style_Local_Override.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Two_bottom_row_Auto__middle_col_auto.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_attributed_string.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_Fixed_Size.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_MinWidth_MinHeight.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_OutOfRange_Cells.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_Stack_Panel_and_Trimming.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_TextBlock_VerticalAlignment.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_Text_HorizontalAlignment_With_Margin.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_Text_VerticalAlignment_With_Margin.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_three_UserControl_With_5_Margin.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UILabel_TextAlignmentVertical_Bottom.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UserControlMargin.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UserControl_HorizonalAlignment.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UserControl_VerticalAlignment_Fixed_Height.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UserControl_VerticalAlignment_Variable_Height.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UserControl_VerticalAlignment_Variable_Width.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Quadrant_absolute_split.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Quadrant_all_100.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Quadrant_even_split.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Quadrant_uneven_split.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Quad_column_progressing_split.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Simpletwocolumnsplitgrid.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Alignment_Bigger.xaml.cs">
       <DependentUpon>Image_Stretch_Alignment_Bigger.xaml</DependentUpon>
     </Compile>
@@ -2724,6 +2945,141 @@
     <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml\VisualStateTests\VisualState_AdaptiveTrigger_Storyboard.xaml.cs">
       <DependentUpon>VisualState_AdaptiveTrigger_Storyboard.xaml</DependentUpon>
     </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\CenteredGridinGridwithfixedsizechild.xaml.cs">
+      <DependentUpon>CenteredGridinGridwithfixedsizechild.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\CenteredGridinGridwiththreefixedsizechildren.xaml.cs">
+      <DependentUpon>CenteredGridinGridwiththreefixedsizechildren.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\CenteredGridinGridwithtwofixedsizechildren.xaml.cs">
+      <DependentUpon>CenteredGridinGridwithtwofixedsizechildren.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Databoundwidth.xaml.cs">
+      <DependentUpon>Databoundwidth.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\GridDataboundGridColumn.xaml.cs">
+      <DependentUpon>GridDataboundGridColumn.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\GridWithColumnSpan.xaml.cs">
+      <DependentUpon>GridWithColumnSpan.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Auto_Center_Cell.xaml.cs">
+      <DependentUpon>Grid_Auto_Center_Cell.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Auto_Text_Block_Trimming.xaml.cs">
+      <DependentUpon>Grid_Auto_Text_Block_Trimming.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_CenteredShapes.xaml.cs">
+      <DependentUpon>Grid_CenteredShapes.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_ColSpan_Bottom.xaml.cs">
+      <DependentUpon>Grid_ColSpan_Bottom.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_DataBound_ColumnRow_Definitions.xaml.cs">
+      <DependentUpon>Grid_DataBound_ColumnRow_Definitions.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_DataBound_RowColumn.xaml.cs">
+      <DependentUpon>Grid_DataBound_RowColumn.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_InsideStackPanel_InsideButton.xaml.cs">
+      <DependentUpon>Grid_InsideStackPanel_InsideButton.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_in_GridClipping.xaml.cs">
+      <DependentUpon>Grid_in_GridClipping.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_in_StackPanel.xaml.cs">
+      <DependentUpon>Grid_in_StackPanel.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_left_column_Auto.xaml.cs">
+      <DependentUpon>Grid_left_column_Auto.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_middle_col_auto__bottom_row_auto.xaml.cs">
+      <DependentUpon>Grid_middle_col_auto__bottom_row_auto.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Multi_Column_Span.xaml.cs">
+      <DependentUpon>Grid_Multi_Column_Span.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_RowSpan_Auto_WithText.xaml.cs">
+      <DependentUpon>Grid_RowSpan_Auto_WithText.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_RowSpan_Right.xaml.cs">
+      <DependentUpon>Grid_RowSpan_Right.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Slider_Inner.xaml.cs">
+      <DependentUpon>Grid_Slider_Inner.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Star_Auto_WithTextblock.xaml.cs">
+      <DependentUpon>Grid_Star_Auto_WithTextblock.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Style_Local_Override.xaml.cs">
+      <DependentUpon>Grid_Style_Local_Override.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_Two_bottom_row_Auto__middle_col_auto.xaml.cs">
+      <DependentUpon>Grid_Two_bottom_row_Auto__middle_col_auto.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_attributed_string.xaml.cs">
+      <DependentUpon>Grid_with_attributed_string.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_Fixed_Size.xaml.cs">
+      <DependentUpon>Grid_with_Fixed_Size.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_MinWidth_MinHeight.xaml.cs">
+      <DependentUpon>Grid_with_MinWidth_MinHeight.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_OutOfRange_Cells.xaml.cs">
+      <DependentUpon>Grid_with_OutOfRange_Cells.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_Stack_Panel_and_Trimming.xaml.cs">
+      <DependentUpon>Grid_with_Stack_Panel_and_Trimming.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_TextBlock_VerticalAlignment.xaml.cs">
+      <DependentUpon>Grid_with_TextBlock_VerticalAlignment.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_Text_HorizontalAlignment_With_Margin.xaml.cs">
+      <DependentUpon>Grid_with_Text_HorizontalAlignment_With_Margin.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_Text_VerticalAlignment_With_Margin.xaml.cs">
+      <DependentUpon>Grid_with_Text_VerticalAlignment_With_Margin.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_three_UserControl_With_5_Margin.xaml.cs">
+      <DependentUpon>Grid_with_three_UserControl_With_5_Margin.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UILabel_TextAlignmentVertical_Bottom.xaml.cs">
+      <DependentUpon>Grid_with_UILabel_TextAlignmentVertical_Bottom.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UserControlMargin.xaml.cs">
+      <DependentUpon>Grid_with_UserControlMargin.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UserControl_HorizonalAlignment.xaml.cs">
+      <DependentUpon>Grid_with_UserControl_HorizonalAlignment.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UserControl_VerticalAlignment_Fixed_Height.xaml.cs">
+      <DependentUpon>Grid_with_UserControl_VerticalAlignment_Fixed_Height.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UserControl_VerticalAlignment_Variable_Height.xaml.cs">
+      <DependentUpon>Grid_with_UserControl_VerticalAlignment_Variable_Height.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Grid_with_UserControl_VerticalAlignment_Variable_Width.xaml.cs">
+      <DependentUpon>Grid_with_UserControl_VerticalAlignment_Variable_Width.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Quadrant_absolute_split.xaml.cs">
+      <DependentUpon>Quadrant_absolute_split.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Quadrant_all_100.xaml.cs">
+      <DependentUpon>Quadrant_all_100.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Quadrant_even_split.xaml.cs">
+      <DependentUpon>Quadrant_even_split.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Quadrant_uneven_split.xaml.cs">
+      <DependentUpon>Quadrant_uneven_split.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Quad_column_progressing_split.xaml.cs">
+      <DependentUpon>Quad_column_progressing_split.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Simpletwocolumnsplitgrid.xaml.cs">
+      <DependentUpon>Simpletwocolumnsplitgrid.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <Content Include="$(MSBuildThisFileDirectory)Assets\cart.png" />
@@ -2748,5 +3104,8 @@
   <ItemGroup>
     <PRIResource Include="$(MSBuildThisFileDirectory)UITestsStrings\en-US\NamedResources.resw" />
     <PRIResource Include="$(MSBuildThisFileDirectory)UITestsStrings\en-US\Resources.resw" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ChatBox\" />
   </ItemGroup>
 </Project>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/CenteredGridinGridwithfixedsizechild.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/CenteredGridinGridwithfixedsizechild.xaml
@@ -1,0 +1,20 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.CenteredGridinGridwithfixedsizechild" 
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Cyan">
+		<Grid VerticalAlignment="Center" HorizontalAlignment="Center">
+			<Border Background="Red" Height="50" Width="50" />
+		</Grid>
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/CenteredGridinGridwithfixedsizechild.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/CenteredGridinGridwithfixedsizechild.xaml.cs
@@ -1,0 +1,14 @@
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "CenteredGridinGridwithfixedsizechild")]
+	public sealed partial class CenteredGridinGridwithfixedsizechild : UserControl
+	{
+		public CenteredGridinGridwithfixedsizechild()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/CenteredGridinGridwiththreefixedsizechildren.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/CenteredGridinGridwiththreefixedsizechildren.xaml
@@ -1,0 +1,30 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.CenteredGridinGridwiththreefixedsizechildren"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Cyan">
+		<Grid VerticalAlignment="Center" HorizontalAlignment="Center">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="auto" />
+				<ColumnDefinition Width="auto" />
+			</Grid.ColumnDefinitions>
+			<Grid.RowDefinitions>
+				<RowDefinition Height="auto" />
+				<RowDefinition Height="auto" />
+			</Grid.RowDefinitions>
+			<Border Grid.Column="0" Background="Red" Height="50" Width="50" />
+			<Border Grid.Column="1" Background="Blue" Height="50" Width="50" />
+			<Border Grid.Row="1" Grid.Column="{Binding [GridColumnAlternating]}" Background="Green" Height="50" Width="50" />
+		</Grid>
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/CenteredGridinGridwiththreefixedsizechildren.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/CenteredGridinGridwiththreefixedsizechildren.xaml.cs
@@ -1,0 +1,15 @@
+using UITests.Shared.Windows_UI_Xaml_Controls.GridTestsControl;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfoAttribute("GridTestsControl", "CenteredGridinGridwiththreefixedsizechildren", typeof(GridTestsViewModel))]
+	public sealed partial class CenteredGridinGridwiththreefixedsizechildren : UserControl
+	{
+		public CenteredGridinGridwiththreefixedsizechildren()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/CenteredGridinGridwithtwofixedsizechildren.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/CenteredGridinGridwithtwofixedsizechildren.xaml
@@ -1,0 +1,25 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.CenteredGridinGridwithtwofixedsizechildren"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Cyan">
+		<Grid VerticalAlignment="Center" HorizontalAlignment="Center">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="auto" />
+				<ColumnDefinition Width="auto" />
+			</Grid.ColumnDefinitions>
+			<Border Grid.Column="0" Background="Red" Height="50" Width="50" />
+			<Border Grid.Column="1" Background="Blue" Height="50" Width="50" />
+		</Grid>
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/CenteredGridinGridwithtwofixedsizechildren.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/CenteredGridinGridwithtwofixedsizechildren.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "CenteredGridinGridwithtwofixedsizechildren")]
+	public sealed partial class CenteredGridinGridwithtwofixedsizechildren : UserControl
+	{
+		public CenteredGridinGridwithtwofixedsizechildren()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Databoundwidth.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Databoundwidth.xaml
@@ -1,0 +1,18 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Databoundwidth"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Cyan">
+		<Grid VerticalAlignment="Center" HorizontalAlignment="Stretch" Background="Red" Width="{Binding [GridWidthAlternatingNull]}" Height="50"></Grid>
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Databoundwidth.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Databoundwidth.xaml.cs
@@ -1,0 +1,15 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using UITests.Shared.Windows_UI_Xaml_Controls.GridTestsControl;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Databoundwidth", typeof(GridTestsViewModel))]
+	public sealed partial class Databoundwidth : UserControl
+	{
+		public Databoundwidth()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/GridDataboundGridColumn.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/GridDataboundGridColumn.xaml
@@ -1,0 +1,22 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.GridDataboundGridColumn"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Cyan">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Grid Background="Blue" Grid.Column="{Binding [GridColumnAlternating]}"></Grid>
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/GridDataboundGridColumn.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/GridDataboundGridColumn.xaml.cs
@@ -1,0 +1,15 @@
+using UITests.Shared.Windows_UI_Xaml_Controls.GridTestsControl;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "GridDataboundGridColumn", typeof(GridTestsViewModel))]
+	public sealed partial class GridDataboundGridColumn : UserControl
+	{
+		public GridDataboundGridColumn()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/GridTestViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/GridTestViewModel.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using Windows.UI.Core;
+using Uno.UI.Samples.UITests.Helpers;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.GridTestsControl
+{
+	public class GridTestsViewModel : ViewModelBase
+	{
+		public GridTestsViewModel(CoreDispatcher dispatcher) : base(dispatcher)
+		{
+			ObserveGridColumnAlternating();
+		}
+
+		public long GridColumnAlternating { get; set; }
+
+		public object GridWidthAlternatingNull { get; set; }
+
+		private async void ObserveGridColumnAlternating()
+		{
+			long i = 0;
+			while (!CT.IsCancellationRequested)
+			{
+				await Task.Delay(TimeSpan.FromSeconds(1));
+				i++;
+				GridColumnAlternating = i % 2;
+				GridWidthAlternatingNull = (i % 2) == 0 ? null : (object)50;
+			}
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/GridWithColumnSpan.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/GridWithColumnSpan.xaml
@@ -1,0 +1,49 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.GridWithColumnSpan"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="400"
+	d:DesignWidth="500">
+
+	<controls:SampleControl SampleDescription="The textblock in this test should span on two columns">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<Grid Background="LightBlue">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="200"/>
+						<ColumnDefinition Width="*"/>
+					</Grid.ColumnDefinitions>
+					
+					 <Grid.RowDefinitions>
+						<RowDefinition Height="Auto"/>
+						<RowDefinition Height="Auto"/>
+					</Grid.RowDefinitions>
+					
+					<TextBlock Text="This is a very long text that should span on the two columns of this grid. That means its size should not be limited by anything but the whole grid itself."
+							HorizontalAlignment="Left"
+							Grid.ColumnSpan="2"/>
+					
+					<Border Background="LightGreen"
+							Height="200"
+							VerticalAlignment="Top"
+							HorizontalAlignment="Stretch"
+							Grid.Row="1"/>
+					
+					<Border Background="LightCoral"
+							Height="200"
+							VerticalAlignment="Top"
+							HorizontalAlignment="Stretch"
+							Grid.Column="1"
+							Grid.Row="1"/>					
+				</Grid>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/GridWithColumnSpan.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/GridWithColumnSpan.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "GridWithColumnSpan")]
+	public sealed partial class GridWithColumnSpan : UserControl
+	{
+		public GridWithColumnSpan()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Auto_Center_Cell.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Auto_Center_Cell.xaml
@@ -1,0 +1,36 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_Auto_Center_Cell"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Cyan">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="auto" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="auto" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Border Background="Red" Grid.Column="0" Grid.Row="0" />
+		<Border Background="Green" Grid.Column="1" Grid.Row="0" />
+		<Border Background="Blue" Grid.Column="2" Grid.Row="0" />
+		<Border Background="Yellow" Grid.Column="0" Grid.Row="1" />
+		<TextBlock Text="123" Grid.Column="1" Grid.Row="1" />
+		<Border Background="Violet" Grid.Column="2" Grid.Row="1" />
+		<Border Background="Purple" Grid.Column="0" Grid.Row="2" />
+		<Border Background="RoyalBlue" Grid.Column="1" Grid.Row="2" />
+		<Border Background="Brown" Grid.Column="2" Grid.Row="2" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Auto_Center_Cell.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Auto_Center_Cell.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_Auto_Center_Cell")]
+	public sealed partial class Grid_Auto_Center_Cell : UserControl
+	{
+		public Grid_Auto_Center_Cell()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Auto_Text_Block_Trimming.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Auto_Text_Block_Trimming.xaml
@@ -1,0 +1,25 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_Auto_Text_Block_Trimming"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="#FFFF0000" Height="100" Width="300">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="auto" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="auto" />
+		</Grid.ColumnDefinitions>
+		<TextBlock Text="Small 01" Grid.Row="0" Grid.Column="0" />
+		<TextBlock Text="This is a very long text that should trim at the end because it does not fit" TextTrimming="CharacterEllipsis" FontFamily="Helvetica" FontSize="30" Grid.Row="0" Grid.Column="1" />
+		<TextBlock Text="Small 02" Grid.Row="0" Grid.Column="2" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Auto_Text_Block_Trimming.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Auto_Text_Block_Trimming.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_Auto_Text_Block_Trimming")]
+	public sealed partial class Grid_Auto_Text_Block_Trimming : UserControl
+	{
+		public Grid_Auto_Text_Block_Trimming()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_CenteredShapes.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_CenteredShapes.xaml
@@ -1,0 +1,60 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_CenteredShapes"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<ScrollViewer>
+		<StackPanel>
+			
+			<TextBlock Text="Ellipse and Border inside the Grid are correctly centered" HorizontalAlignment="Center" Margin="5" />
+			<Grid Margin="10">
+				<Ellipse Width="100" Height="100" Fill="LightBlue" HorizontalAlignment="Center" VerticalAlignment="Center" />
+
+				<Border Height="94" Width="94" CornerRadius="47" Background="Red" HorizontalAlignment="Center" VerticalAlignment="Center" />
+			</Grid>
+			
+			<TextBlock Text="Ellipse w/stroke and second Ellipse inside the Grid are correctly centered" HorizontalAlignment="Center" Margin="5" />
+			<Grid>
+				<Ellipse Width="24" Height="24" Stroke="Black" StrokeThickness="2" />
+
+				<Ellipse Width="14" Height="14" Fill="Red" />
+			</Grid>
+			
+			<TextBlock Text="Ellipse w/stroke and second Ellipse inside the Grid are correctly centered" HorizontalAlignment="Center" Margin="5" />
+			<Grid>
+				<Ellipse Width="24" Height="24" Stroke="Black" StrokeThickness="1" />
+
+				<Ellipse Width="14" Height="14" Fill="Red" />
+			</Grid>
+			
+			<TextBlock Text="Ellipse w/stroke and second Ellipse inside the Grid are correctly centered" HorizontalAlignment="Center" Margin="5" />
+			<Grid>
+				<Ellipse Width="50" Height="50" Stroke="Black" StrokeThickness="10" />
+
+				<Ellipse Width="14" Height="14" Fill="Red" />
+			</Grid>
+			
+			<TextBlock Text="Ellipse w/stroke and second Ellipse inside the Grid are correctly centered" HorizontalAlignment="Center" Margin="5" />
+			<Grid>
+				<Ellipse Width="50" Height="25" Stroke="Black" StrokeThickness="2" />
+
+				<Ellipse Width="40" Height="20" Fill="Red" />
+			</Grid>
+			
+			<TextBlock Text="Ellipse and path inside the Grid are correctly centered" HorizontalAlignment="Center" Margin="5" />
+			<Grid>
+				<Ellipse Width="100" Height="100" Fill="LightBlue" HorizontalAlignment="Center" VerticalAlignment="Center" />
+
+				<Path Fill="White" Data="M 9,0 L 7,6 L 0,6 L 6,11 L 4,17 L 9,12 L 14,17 L 12,11 L 18,6 L 11,6 L 9,0"
+					  HorizontalAlignment="Center"
+					  VerticalAlignment="Center" />
+			</Grid>
+			
+		</StackPanel>
+	</ScrollViewer>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_CenteredShapes.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_CenteredShapes.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_CenteredShapes")]
+	public sealed partial class Grid_CenteredShapes : UserControl
+	{
+		public Grid_CenteredShapes()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_ColSpan_Bottom.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_ColSpan_Bottom.xaml
@@ -1,0 +1,28 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_ColSpan_Bottom"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="#FF0000FF" Height="100">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid Background="#FF00FF00" Grid.Column="0" Grid.Row="0" />
+		<Grid Background="#FFFF0000" Grid.Column="1" Grid.Row="0" />
+		<Grid Background="#FF7FFF00" Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_ColSpan_Bottom.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_ColSpan_Bottom.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_ColSpan_Bottom")]
+	public sealed partial class Grid_ColSpan_Bottom : UserControl
+	{
+		public Grid_ColSpan_Bottom()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_DataBound_ColumnRow_Definitions.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_DataBound_ColumnRow_Definitions.xaml
@@ -1,0 +1,39 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_DataBound_ColumnRow_Definitions" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl>
+		<controls:SampleControl.SampleDescription>
+			Demonstrates the behavior of column and row definitions when updated via data binding,
+			having the first row and column alternating in size.
+		</controls:SampleControl.SampleDescription>
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<Grid>
+					<Grid.RowDefinitions>
+						<RowDefinition Height="{Binding Value1, FallbackValue=100, TargetNullValue=100}" />
+						<RowDefinition Height="*" />
+					</Grid.RowDefinitions>
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="{Binding Value2, FallbackValue=100, TargetNullValue=100}" />
+						<ColumnDefinition Width="*" />
+					</Grid.ColumnDefinitions>
+					<Border Background="Red" Grid.Row="0" Grid.Column="0" />
+					<Border Background="Yellow" Grid.Row="1" Grid.Column="0" />
+					<Border Background="Green" Grid.Row="0" Grid.Column="1"/>
+					<Border Background="Blue" Grid.Row="1" Grid.Column="1"/>
+				</Grid>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_DataBound_ColumnRow_Definitions.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_DataBound_ColumnRow_Definitions.xaml.cs
@@ -1,0 +1,81 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Uno.UI.Samples.Controls;
+using Uno.UI.Samples.Helper;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfoAttribute("DefaultCategory", "Grid_DataBound_ColumnRow_Definitions")]
+	public sealed partial class Grid_DataBound_ColumnRow_Definitions : UserControl
+	{
+		private Grid_DataBound_ColumnRow_Definitions_Context _context;
+
+		public Grid_DataBound_ColumnRow_Definitions()
+		{
+			this.InitializeComponent();
+
+			this.RunWhileLoaded(Run);
+		}
+
+		private async Task Run(CancellationToken ct)
+		{
+			await Task.Yield();
+
+			var toggle = false;
+
+			DataContext = _context = new Grid_DataBound_ColumnRow_Definitions_Context();
+
+			while(!ct.IsCancellationRequested)
+			{
+				if(!toggle)
+				{
+					_context.Value1 = 42;
+					_context.Value2 = 12;
+				}
+				else
+				{
+					_context.Value1 = 12;
+					_context.Value2 = 42;
+				}
+
+				toggle = !toggle;
+
+				await Task.Delay(1000);
+			}
+		}
+	}
+
+	public partial class Grid_DataBound_ColumnRow_Definitions_Context : DependencyObject
+	{
+		public Grid_DataBound_ColumnRow_Definitions_Context()
+		{
+		}
+
+		#region Value1 DependencyProperty
+
+		public int Value1
+		{
+			get => (int)GetValue(Value1Property);
+			set => SetValue(Value1Property, value);
+		}
+
+		// Using a DependencyProperty as the backing store for Value1.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty Value1Property =
+			DependencyProperty.Register("Value1", typeof(int), typeof(Grid_DataBound_ColumnRow_Definitions_Context), new PropertyMetadata(0));
+
+		#endregion
+
+		public int Value2
+		{
+			get => (int)GetValue(Value2Property);
+			set => SetValue(Value2Property, value);
+		}
+
+		// Using a DependencyProperty as the backing store for Value2.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty Value2Property =
+			DependencyProperty.Register("Value2", typeof(int), typeof(Grid_DataBound_ColumnRow_Definitions_Context), new PropertyMetadata(0));
+
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_DataBound_RowColumn.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_DataBound_RowColumn.xaml
@@ -1,0 +1,58 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_DataBound_RowColumn" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl>
+		<controls:SampleControl.SampleDescription>
+			This sample demonstrates the ability for Grid children to change their Grid.[Row|Column]. The
+			Yellow square should appear and disappear, and should move in diagonal.
+		</controls:SampleControl.SampleDescription>
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<Grid>
+					<Grid.RowDefinitions>
+						<RowDefinition Height="auto" />
+						<RowDefinition Height="*" />
+					</Grid.RowDefinitions>
+					<StackPanel>
+						<TextBlock>
+							<Run Text="DataContext=" /><Run Text="{Binding}" />
+						</TextBlock>
+						<TextBlock>
+							<Run Text="CurrentRow=" /><Run Text="{Binding CurrentRow}" />
+						</TextBlock>
+						<TextBlock>
+							<Run Text="CurrentColumn=" /><Run Text="{Binding CurrentColumn}" />
+						</TextBlock>
+					</StackPanel>
+					<Grid Grid.Row="1" x:Name="InnerGrid">
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="*" />
+						</Grid.ColumnDefinitions>
+						<Grid.RowDefinitions>
+							<RowDefinition Height="*" />
+							<RowDefinition Height="*" />
+							<RowDefinition Height="*" />
+							<RowDefinition Height="*" />
+							<RowDefinition Height="*" />
+						</Grid.RowDefinitions>
+						<Border Background="Red" Grid.Row="{Binding CurrentRow}" />
+						<Border Background="Blue" Grid.Column="{Binding CurrentColumn}" />
+					</Grid>
+				</Grid>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_DataBound_RowColumn.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_DataBound_RowColumn.xaml.cs
@@ -1,0 +1,81 @@
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Helper;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Media;
+using Windows.UI;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_DataBound_RowColumn")]
+	public sealed partial class Grid_DataBound_RowColumn : UserControl
+	{
+		public Grid_DataBound_RowColumn()
+		{
+			this.InitializeComponent();
+
+			var controlData = new Grid_DataBound_RowColumn_Data();
+			DataContext = controlData;
+
+			this.RunWhileLoaded(
+				async ct =>
+				{
+					var border = new Border();
+					border.Background = new SolidColorBrush(Colors.Yellow);
+					border.SetBinding(Grid.RowProperty, new Windows.UI.Xaml.Data.Binding { Path = new PropertyPath("CurrentRow") });
+					border.SetBinding(Grid.ColumnProperty, new Windows.UI.Xaml.Data.Binding { Path = new PropertyPath("CurrentColumn") });
+
+					for (int i = 0; !ct.IsCancellationRequested; i++)
+					{
+						var panel = (Panel)FindName("InnerGrid");
+
+						if (panel != null)
+						{
+							controlData.CurrentColumn = i % 3;
+							controlData.CurrentRow = i % 5;
+
+							if ((i % 3) == 0)
+							{
+								if (border.Parent == null)
+								{
+									panel.Children.Add(border);
+								}
+								else
+								{
+									panel.Children.Remove(border);
+								}
+							}
+						}
+
+						await Task.Delay(1000);
+					}
+				}
+			);
+		}
+	}
+
+	public partial class Grid_DataBound_RowColumn_Data : DependencyObject
+	{
+		public int CurrentColumn
+		{
+			get => (int)this.GetValue(CurrentColumnProperty);
+			set => this.SetValue(CurrentColumnProperty, value);
+		}
+
+		// Using a DependencyProperty as the backing store for CurrentColumn.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty CurrentColumnProperty =
+			DependencyProperty.Register("CurrentColumn", typeof(int), typeof(Grid_DataBound_RowColumn_Data), new PropertyMetadata(0));
+
+		public int CurrentRow
+		{
+			get => (int)this.GetValue(CurrentRowProperty);
+			set => this.SetValue(CurrentRowProperty, value);
+		}
+
+		// Using a DependencyProperty as the backing store for CurrentColumn.  This enables animation, styling, binding, etc...
+		public static readonly DependencyProperty CurrentRowProperty =
+			DependencyProperty.Register("CurrentRow", typeof(int), typeof(Grid_DataBound_RowColumn_Data), new PropertyMetadata(0));
+
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_InsideStackPanel_InsideButton.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_InsideStackPanel_InsideButton.xaml
@@ -1,0 +1,182 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_InsideStackPanel_InsideButton"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<UserControl.Resources>
+		<Style x:Key="DefaultButtonGridTest" TargetType="Button">
+			<Setter Property="Template">
+				<Setter.Value>
+					<ControlTemplate TargetType="Button">
+						<Grid x:Name="RootGrid"
+						  Background="Transparent">
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroup x:Name="CommonStates">
+									<VisualState x:Name="Normal" />
+									<VisualState x:Name="PointerOver">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity"
+																	   Storyboard.TargetName="ContentPresenter">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																	Value="0.85" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Pressed">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity"
+																	   Storyboard.TargetName="ContentPresenter">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																	Value="0.75" />
+											</ObjectAnimationUsingKeyFrames>
+											<win:PointerDownThemeAnimation Storyboard.TargetName="RootGrid" />
+										</Storyboard>
+									</VisualState>
+									<VisualState x:Name="Disabled">
+										<Storyboard>
+											<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Opacity"
+																	   Storyboard.TargetName="ContentPresenter">
+												<DiscreteObjectKeyFrame KeyTime="0"
+																	Value="0.25" />
+											</ObjectAnimationUsingKeyFrames>
+										</Storyboard>
+									</VisualState>
+								</VisualStateGroup>
+							</VisualStateManager.VisualStateGroups>
+							<Border x:Name="BorderElement"/>
+							<ContentPresenter x:Name="ContentPresenter"
+										  AutomationProperties.AccessibilityView="Raw"
+										  ContentTemplate="{TemplateBinding ContentTemplate}"
+										  ContentTransitions="{TemplateBinding ContentTransitions}"
+										  Content="{TemplateBinding Content}"
+										  HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+										  Margin="{TemplateBinding Padding}"
+										  VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
+						</Grid>
+					</ControlTemplate>
+				</Setter.Value>
+			</Setter>
+		</Style>
+	</UserControl.Resources>
+
+	<controls:SampleControl SampleDescription="The top part should be exactly the same as the bottom">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel>
+					<TextBlock Text="Using a Grid as Content of a Button" />
+					<Border Background="Gray"
+							BorderThickness="0,0,1,0"
+							BorderBrush="LightGray"
+							VerticalAlignment="Top"
+							HorizontalAlignment="Stretch"
+							Height="100">
+						<u:StarStackPanel Orientation="Horizontal"
+								  HorizontalAlignment="Center"
+								  VerticalAlignment="Stretch">
+							<Button Margin="0,0,10,0"
+									Style="{StaticResource DefaultButtonGridTest}">
+								<Grid MinHeight="40"
+									 MinWidth="60">
+									<TextBlock Text="Theatres"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center"
+											   Foreground="White" />
+									<Border Background="Orange"
+											MinHeight="5"
+											VerticalAlignment="Bottom"/>
+								</Grid>
+							</Button>
+							<Button Margin="0,0,10,0"
+									Style="{StaticResource DefaultButtonGridTest}">
+								<Grid MinHeight="40"
+									  MinWidth="60">
+									<TextBlock Text="Movies"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center"
+											   Foreground="White" />
+									<Border Background="Orange"
+											MinHeight="5"
+										VerticalAlignment="Bottom"/>
+								</Grid>
+							</Button>
+							<Button Margin="0,0,10,0"
+									Style="{StaticResource DefaultButtonGridTest}">
+								<Grid MinHeight="40"
+									  MinWidth="60">
+									<TextBlock Text="MEDIA"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center"
+											   Foreground="White" />
+									<Border Background="Orange"
+											MinHeight="5"
+											VerticalAlignment="Bottom"/>
+								</Grid>
+							</Button>
+						</u:StarStackPanel>
+					</Border>
+					<TextBlock Text="Using a superposition panel as content of button" />
+					<Border Background="Gray"
+							BorderThickness="0,0,1,0"
+							BorderBrush="LightGray"
+							VerticalAlignment="Top"
+							HorizontalAlignment="Stretch"
+							Height="100">
+						<u:StarStackPanel Orientation="Horizontal"
+										  HorizontalAlignment="Center"
+										  VerticalAlignment="Stretch">
+							<Button Margin="0,0,10,0"
+									Style="{StaticResource DefaultButtonGridTest}">
+								<Grid MinHeight="40"
+													  MinWidth="60">
+									<TextBlock Text="Theatres"
+											   HorizontalAlignment="Center"
+											   VerticalAlignment="Center"
+											   Foreground="White" />
+									<Border Background="Orange"
+											MinHeight="5"
+											VerticalAlignment="Bottom"/>
+								</Grid>
+							</Button>
+							<Button Margin="0,0,10,0"
+									Style="{StaticResource DefaultButtonGridTest}">
+								<Grid MinHeight="40"
+													  MinWidth="60">
+									<TextBlock Text="Movies"
+									   HorizontalAlignment="Center"
+									   VerticalAlignment="Center"
+									   Foreground="White" />
+									<Border Background="Orange"
+									MinHeight="5"
+										VerticalAlignment="Bottom"/>
+								</Grid>
+							</Button>
+							<Button Margin="0,0,10,0"
+									Style="{StaticResource DefaultButtonGridTest}">
+								<Grid MinHeight="40"
+													  MinWidth="60">
+									<TextBlock Text="MEDIA"
+									   HorizontalAlignment="Center"
+									   VerticalAlignment="Center"
+									   Foreground="White" />
+									<Border Background="Orange"
+										MinHeight="5"
+										VerticalAlignment="Bottom"/>
+								</Grid>
+							</Button>
+						</u:StarStackPanel>
+					</Border>
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_InsideStackPanel_InsideButton.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_InsideStackPanel_InsideButton.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_InsideStackPanel_InsideButton")]
+	public sealed partial class Grid_InsideStackPanel_InsideButton : UserControl
+	{
+		public Grid_InsideStackPanel_InsideButton()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Multi_Column_Span.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Multi_Column_Span.xaml
@@ -1,0 +1,157 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_Multi_Column_Span"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:u="using:Uno.UI.Samples.Controls"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl>
+		<controls:SampleControl.Resources>
+			<Style x:Key="GridTestStyle" TargetType="Border">
+				<Setter Property="Height" Value="30"/>
+				<Setter Property="Width" Value="50"/>
+				<Setter Property="Background" Value="Blue"/>
+				<Setter Property="BorderBrush" Value="White"/>
+				<Setter Property="BorderThickness" Value="1"/>
+				<Setter Property="HorizontalAlignment" Value="Center"/>
+				<Setter Property="VerticalAlignment" Value="Center"/>
+			</Style>
+		</controls:SampleControl.Resources>
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<Grid 
+					HorizontalAlignment="Center"
+					VerticalAlignment="Center"
+					Width="300"
+					Height="400">
+
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="Auto"/>
+						<ColumnDefinition Width="Auto"/>
+						<ColumnDefinition Width="Auto"/>
+						<ColumnDefinition Width="Auto"/>
+					</Grid.ColumnDefinitions>
+					<Grid.RowDefinitions>
+						<RowDefinition Height="Auto"/>
+						<RowDefinition Height="Auto"/>
+						<RowDefinition Height="Auto"/>
+						<RowDefinition Height="Auto"/>
+					</Grid.RowDefinitions>
+
+					<StackPanel Grid.Column="0"
+						Grid.ColumnSpan="4"
+						Grid.Row="0"
+						HorizontalAlignment="Center"
+						Margin="0,0,0,20">
+						<TextBlock Text="Text spans multiple columns"
+						   HorizontalAlignment="Center"/>
+
+						<Border Height="50"
+						Width="150"
+								Background="Red"/>
+					</StackPanel>
+
+					<Border
+					Grid.Column="0"
+					Grid.Row="1"
+					Style="{StaticResource GridTestStyle}">
+						<TextBlock Text="1"/>
+					</Border>
+					<Border
+					Grid.Column="1"
+					Grid.Row="1"
+					Style="{StaticResource GridTestStyle}">
+						<TextBlock Text="2"/>
+					</Border>
+					<Border
+					Grid.Column="2"
+					Grid.Row="1"
+					Style="{StaticResource GridTestStyle}">
+						<TextBlock Text="3"/>
+					</Border>
+					<Border
+					Grid.Column="3"
+					Grid.Row="1"
+					Style="{StaticResource GridTestStyle}">
+						<TextBlock Text="3a"/>
+					</Border>
+					<Border
+					Grid.Column="0"
+					Grid.Row="2"
+					Style="{StaticResource GridTestStyle}">
+						<TextBlock Text="4"/>
+					</Border>
+					<Border
+					Grid.Column="1"
+					Grid.Row="2"
+					Style="{StaticResource GridTestStyle}">
+						<TextBlock Text="5"/>
+					</Border>
+					<Border
+					Grid.Column="2"
+					Grid.Row="2"
+					Style="{StaticResource GridTestStyle}">
+						<TextBlock Text="6"/>
+					</Border>
+					<Border
+					Grid.Column="3"
+					Grid.Row="2"
+					Style="{StaticResource GridTestStyle}">
+						<TextBlock Text="6a"/>
+					</Border>
+					<Border
+					Grid.Column="0"
+					Grid.Row="3"
+					Style="{StaticResource GridTestStyle}">
+						<TextBlock Text="7"/>
+					</Border>
+					<Border
+					Grid.Column="1"
+					Grid.Row="3"
+					Style="{StaticResource GridTestStyle}">
+						<TextBlock Text="8"/>
+					</Border>
+					<Border
+					Grid.Column="2"
+					Grid.Row="3"
+					Style="{StaticResource GridTestStyle}">
+						<TextBlock Text="9"/>
+					</Border>
+					<Border
+					Grid.Column="3"
+					Grid.Row="3"
+					Style="{StaticResource GridTestStyle}">
+						<TextBlock Text="9a"/>
+					</Border>
+					<Border
+					Grid.Column="0"
+					Grid.Row="3"
+					Style="{StaticResource GridTestStyle}">
+						<TextBlock Text="7"/>
+					</Border>
+					<Border
+					Grid.Column="1"
+					Grid.Row="3"
+					Style="{StaticResource GridTestStyle}">
+						<TextBlock Text="8"/>
+					</Border>
+					<Border
+					Grid.Column="2"
+					Grid.Row="3"
+					Style="{StaticResource GridTestStyle}">
+						<TextBlock Text="9"/>
+					</Border>
+
+				</Grid>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Multi_Column_Span.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Multi_Column_Span.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_Multi_Column_Span")]
+	public sealed partial class Grid_Multi_Column_Span : UserControl
+	{
+		public Grid_Multi_Column_Span()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_RowSpan_Auto_WithText.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_RowSpan_Auto_WithText.xaml
@@ -1,0 +1,27 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_RowSpan_Auto_WithText"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="#FF0000FF">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="100" />
+			<ColumnDefinition Width="300" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid Background="Red" Grid.Column="1" Grid.Row="0" />
+		<TextBlock Text="This is a block of text that should span" Grid.ColumnSpan="2" Grid.Column="0" Grid.Row="0" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_RowSpan_Auto_WithText.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_RowSpan_Auto_WithText.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_RowSpan_Auto_WithText")]
+	public sealed partial class Grid_RowSpan_Auto_WithText : UserControl
+	{
+		public Grid_RowSpan_Auto_WithText()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_RowSpan_Right.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_RowSpan_Right.xaml
@@ -1,0 +1,28 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_RowSpan_Right"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="#FF0000FF" Height="100">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid Background="#FF00FF00" Grid.Column="0" Grid.Row="0" />
+		<Grid Background="#FFFF0000" Grid.Column="0" Grid.Row="1" />
+		<Grid Background="#FF7FFF00" Grid.Column="1" Grid.Row="0" Grid.RowSpan="2" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_RowSpan_Right.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_RowSpan_Right.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_RowSpan_Right")]
+	public sealed partial class Grid_RowSpan_Right : UserControl
+	{
+		public Grid_RowSpan_Right()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Star_Auto_WithTextblock.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Star_Auto_WithTextblock.xaml
@@ -1,0 +1,45 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_Star_Auto_WithTextblock"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Grid_Star_Auto_WithTextblock. Should be able to see the Orange circle completely">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<Grid Background="Cyan"
+					  Width="400">
+					<Grid.ColumnDefinitions>
+						<ColumnDefinition Width="*" />
+						<ColumnDefinition Width="auto" />
+					</Grid.ColumnDefinitions>
+					<StackPanel VerticalAlignment="Center">
+						<TextBlock Text="This is a very long text and should be able to see the Orange circle completely" />
+					</StackPanel>
+					<Grid Grid.Column="1">
+				<!-- Placeholder picture -->
+						<Border Background="Red"
+							   Height="58"
+							   Width="58" />
+
+						<!-- Profile picture -->
+						<Border Margin="0,0,3,0"
+								Width="50"
+								Height="50"
+								Background="Orange"
+								CornerRadius="25">
+						</Border>
+					</Grid>
+				</Grid>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Star_Auto_WithTextblock.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Star_Auto_WithTextblock.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_Star_Auto_WithTextblock")]
+	public sealed partial class Grid_Star_Auto_WithTextblock : UserControl
+	{
+		public Grid_Star_Auto_WithTextblock()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Style_Local_Override.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Style_Local_Override.xaml
@@ -1,0 +1,36 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_Style_Local_Override"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Cyan">
+		<Grid.Resources>
+			<Style x:Key="panelStyle" TargetType="Grid">
+				<Setter Property="Background" Value="Red" />
+			</Style>
+		</Grid.Resources>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Grid Background="Blue" Style="{StaticResource panelStyle}" Grid.Column="0" Grid.Row="0">
+			<TextBlock Text="Should be blue" TextWrapping="Wrap" />
+		</Grid>
+		<Grid Style="{StaticResource panelStyle}" Background="Blue" Grid.Column="1" Grid.Row="0">
+			<TextBlock Text="Should be blue too" TextWrapping="Wrap" />
+		</Grid>
+		<Grid Style="{StaticResource panelStyle}" Grid.Column="2" Grid.Row="0">
+			<TextBlock Text="Should be Red" TextWrapping="Wrap" />
+		</Grid>
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Style_Local_Override.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Style_Local_Override.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_Style_Local_Override")]
+	public sealed partial class Grid_Style_Local_Override : UserControl
+	{
+		public Grid_Style_Local_Override()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Two_bottom_row_Auto__middle_col_auto.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Two_bottom_row_Auto__middle_col_auto.xaml
@@ -1,0 +1,36 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_Two_bottom_row_Auto__middle_col_auto"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Cyan">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="auto" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="auto" />
+			<RowDefinition Height="auto" />
+		</Grid.RowDefinitions>
+		<Border Background="Red" Grid.Row="0" Grid.Column="0" />
+		<Border Background="Green" Grid.Row="0" Grid.Column="1" />
+		<Border Background="Blue" Grid.Row="0" Grid.Column="2" />
+		<Border Background="Yellow" Grid.Row="1" Grid.Column="0" />
+		<TextBlock Text="1,1" Grid.Row="1" Grid.Column="1" />
+		<Border Background="Violet" Grid.Row="1" Grid.Column="2" />
+		<Border Background="Purple" Grid.Row="2" Grid.Column="0" />
+		<Border Background="RoyalBlue" Grid.Row="2" Grid.Column="1" />
+		<TextBlock Text="2,2" Grid.Row="2" Grid.Column="2" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Two_bottom_row_Auto__middle_col_auto.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_Two_bottom_row_Auto__middle_col_auto.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_Two_bottom_row_Auto__middle_col_auto")]
+	public sealed partial class Grid_Two_bottom_row_Auto__middle_col_auto : UserControl
+	{
+		public Grid_Two_bottom_row_Auto__middle_col_auto()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_in_GridClipping.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_in_GridClipping.xaml
@@ -1,0 +1,54 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_in_GridClipping" 
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="All Text should be visible">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<StackPanel>
+					<Grid Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Center" Width="500">
+						<Grid>
+							<Grid.RowDefinitions>
+								<RowDefinition />
+								<RowDefinition />
+							</Grid.RowDefinitions>
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="50"/>
+								<ColumnDefinition Width="*"/>
+							</Grid.ColumnDefinitions>
+							<TextBlock Text="First Row Should Be Visible" Grid.Row="0" FontSize="22" />
+							<TextBlock Text="First Row Should Be Visible Aswell" Grid.Row="1" FontSize="22" Margin="0,12,0,0"/>
+							<TextBlock Text="Second Row should be visible" FontSize="14" Grid.Column="1" />
+							<TextBlock Text="Second Row should be visible Aswell" FontSize="14" Grid.Row="1" Grid.Column="1" Margin="0,12,0,0"/>
+						</Grid>
+					</Grid>
+					<TextBlock Text="Under here is how it should behave" Margin ="20"/>
+					<Grid Grid.Row="1" HorizontalAlignment="Center" VerticalAlignment="Center" Width="500">
+						<Grid.RowDefinitions>
+							<RowDefinition />
+							<RowDefinition />
+						</Grid.RowDefinitions>
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="50"/>
+							<ColumnDefinition Width="*"/>
+						</Grid.ColumnDefinitions>
+						<TextBlock Text="First Row Should Be Visible" Grid.Row="0" FontSize="22" />
+						<TextBlock Text="First Row Should Be Visible Aswell" Grid.Row="1" FontSize="22" Margin="0,12,0,0"/>
+						<TextBlock Text="Second Row should be visible" FontSize="14" Grid.Column="1" />
+						<TextBlock Text="Second Row should be visible Aswell" FontSize="14" Grid.Row="1" Grid.Column="1" Margin="0,12,0,0"/>
+					</Grid>
+				</StackPanel>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_in_GridClipping.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_in_GridClipping.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfoAttribute("GridTestsControl", "Grid_in_GridClipping")]
+	public sealed partial class Grid_in_GridClipping : UserControl
+	{
+		public Grid_in_GridClipping()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_in_StackPanel.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_in_StackPanel.xaml
@@ -1,0 +1,42 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_in_StackPanel"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<StackPanel Orientation="Vertical">
+		<Grid>
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto" />
+				<RowDefinition Height="*" />
+			</Grid.RowDefinitions>
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto" />
+				<ColumnDefinition Width="*" />
+			</Grid.ColumnDefinitions>
+
+			<Border Background="CornflowerBlue"
+					MinHeight="30"
+					MinWidth="20"/>
+
+			<Border Grid.Column="1"
+					Background="LimeGreen"
+					MaxWidth="30"
+					MinHeight="40"/>
+
+			<Border Grid.Row="1"
+					Background="Tomato"
+					MinHeight="40" />
+
+			<Border Grid.Column="1"
+					Grid.Row="1"
+					Background="Purple"
+					Height="50"
+					MaxWidth="60" />
+		</Grid>
+	</StackPanel>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_in_StackPanel.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_in_StackPanel.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfoAttribute("GridTestsControl", "Grid_in_StackPanel")]
+	public sealed partial class Grid_in_StackPanel : UserControl
+	{
+		public Grid_in_StackPanel()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_left_column_Auto.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_left_column_Auto.xaml
@@ -1,0 +1,28 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_left_column_Auto"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Cyan">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="auto" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<TextBlock Text="0,0" Grid.Row="0" Grid.Column="0" Grid.RowSpan="2" />
+		<Border Background="Blue" Grid.Row="0" Grid.Column="1" />
+		<Border Background="Yellow" Grid.Row="1" Grid.Column="1" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_left_column_Auto.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_left_column_Auto.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_left_column_Auto")]
+	public sealed partial class Grid_left_column_Auto : UserControl
+	{
+		public Grid_left_column_Auto()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_middle_col_auto__bottom_row_auto.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_middle_col_auto__bottom_row_auto.xaml
@@ -1,0 +1,36 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_middle_col_auto__bottom_row_auto"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Cyan">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="auto" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="*" />
+			<RowDefinition Height="auto" />
+		</Grid.RowDefinitions>
+		<Border Background="Red" Grid.Row="0" Grid.Column="0" />
+		<Border Background="Green" Grid.Row="0" Grid.Column="1" />
+		<Border Background="Blue" Grid.Row="0" Grid.Column="2" />
+		<Border Background="Yellow" Grid.Row="1" Grid.Column="0" />
+		<TextBlock Text="1,1" Grid.Row="1" Grid.Column="1" />
+		<Border Background="Violet" Grid.Row="1" Grid.Column="2" />
+		<Border Background="Purple" Grid.Row="2" Grid.Column="0" />
+		<Border Background="RoyalBlue" Grid.Row="2" Grid.Column="1" />
+		<TextBlock Text="2,2" Grid.Row="2" Grid.Column="2" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_middle_col_auto__bottom_row_auto.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_middle_col_auto__bottom_row_auto.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_middle_col_auto__bottom_row_auto")]
+	public sealed partial class Grid_middle_col_auto__bottom_row_auto : UserControl
+	{
+		public Grid_middle_col_auto__bottom_row_auto()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Fixed_Size.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Fixed_Size.xaml
@@ -1,0 +1,30 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_with_Fixed_Size"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Grid with fixed size but aligned to bottom, its content should be able to stretch">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<Grid Height="100"
+							VerticalAlignment="Bottom"
+							Background="Red">
+					<Border Background="DeepPink"
+									VerticalAlignment="Stretch"
+									HorizontalAlignment="Stretch">
+						<TextBlock Text="Test" />
+					</Border>
+				</Grid>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Fixed_Size.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Fixed_Size.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_with_Fixed_Size")]
+	public sealed partial class Grid_with_Fixed_Size : UserControl
+	{
+		public Grid_with_Fixed_Size()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_MinWidth_MinHeight.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_MinWidth_MinHeight.xaml
@@ -1,0 +1,818 @@
+﻿<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_with_MinWidth_MinHeight"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	mc:Ignorable="d"
+	d:DesignHeight="300"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="Grid with MinWidth and MinHeight and VerticalAlignment Top and HorizontalAlignment Center. Star Children should at least take the min size.">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<ScrollViewer>
+					<StackPanel>
+						<!-- Multiple Rows and Columns With Auto and Star sizes -->
+						<Grid Margin="0,5"
+									MinWidth="198"
+									MinHeight="160"
+									Padding="6"
+									BorderThickness="2"
+									BorderBrush="Red"
+									HorizontalAlignment="Center"
+									VerticalAlignment="Top"
+									Background="Blue">
+							<Grid.RowDefinitions>
+								<RowDefinition Height="*" />
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="*" />
+							</Grid.RowDefinitions>
+
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="*" />
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="*" />
+							</Grid.ColumnDefinitions>
+
+							<Rectangle Fill="DeepPink"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Column="1"
+										 Fill="LightBlue"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Column="2"
+										 Fill="Orange"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="1"
+										 Fill="LightGreen"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="1"
+										 Grid.Column="1"
+										 Fill="Yellow"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="1"
+										 Grid.Column="2"
+										 Fill="Red"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="2"
+										 Fill="LightSeaGreen"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="2"
+										 Grid.Column="1"
+										 Fill="PaleVioletRed"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="2"
+										 Grid.Column="2"
+										 Fill="Lime"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Column="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Column="2"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="1"
+										 Grid.Column="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="1"
+										 Grid.Column="2"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="2"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="2"
+										 Grid.Column="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="2"
+										 Grid.Column="2"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+						</Grid>
+
+						<!-- Two Rows and Columns With Star sizes -->
+						<Grid Margin="0,5"
+								MinWidth="198"
+								MinHeight="100"
+								Padding="6"
+								BorderThickness="2"
+								BorderBrush="Red"
+								HorizontalAlignment="Center"
+								VerticalAlignment="Top"
+								Background="Blue">
+							<Grid.RowDefinitions>
+								<RowDefinition Height="*" />
+								<RowDefinition Height="*" />
+							</Grid.RowDefinitions>
+
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="*" />
+								<ColumnDefinition Width="*" />
+							</Grid.ColumnDefinitions>
+
+							<Rectangle Fill="DeepPink"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Column="1"
+										 Fill="LightSeaGreen"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Column="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<Rectangle Grid.Row="1"
+										 Fill="Orange"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="1"
+										 Grid.Column="1"
+										 Fill="Yellow"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Grid.Row="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="1"
+										 Grid.Column="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+						</Grid>
+
+						<!-- Multiple Rows and Columns With Auto and Star sizes With RowSpan and ColumnSpan -->
+						<Grid Margin="0,5"
+								MinWidth="198"
+								MinHeight="100"
+								Padding="6"
+								BorderThickness="2"
+								BorderBrush="Red"
+								HorizontalAlignment="Center"
+								VerticalAlignment="Top"
+								Background="Blue">
+							<Grid.RowDefinitions>
+								<RowDefinition Height="*" />
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="*" />
+							</Grid.RowDefinitions>
+
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="*" />
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="*" />
+							</Grid.ColumnDefinitions>
+
+							<Rectangle Grid.ColumnSpan="2"
+										 Fill="DeepPink"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Column="2"
+										 Fill="LightBlue"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="1"
+										 Grid.RowSpan="2"
+										 Fill="Orange"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="1"
+										 Grid.Column="1"
+										 Grid.ColumnSpan="2"
+										 Fill="Yellow"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="2"
+										 Grid.Column="1"
+										 Grid.ColumnSpan="2"
+										 Fill="LightGreen"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Column="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Column="2"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="1"
+										 Grid.Column="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="1"
+										 Grid.Column="2"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="2"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="2"
+										 Grid.Column="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="2"
+										 Grid.Column="2"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+						</Grid>
+
+						<!-- Two Rows With Star sizes -->
+						<Grid Margin="0,5"
+								MinWidth="198"
+								MinHeight="100"
+								Padding="6"
+								BorderThickness="2"
+								BorderBrush="Red"
+								Background="Blue"
+								HorizontalAlignment="Center"
+								VerticalAlignment="Top">
+							<Grid.RowDefinitions>
+								<RowDefinition Height="*" />
+								<RowDefinition Height="*" />
+							</Grid.RowDefinitions>
+
+							<Rectangle Fill="DeepPink"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="1"
+										 Fill="LightSeaGreen"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+						</Grid>
+
+						<!-- Two Columns With Star sizes -->
+						<Grid Margin="0,5"
+								MinWidth="198"
+								MinHeight="100"
+								Padding="6"
+								BorderThickness="2"
+								BorderBrush="Red"
+								Background="Blue"
+								HorizontalAlignment="Center"
+								VerticalAlignment="Top">
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="*" />
+								<ColumnDefinition Width="*" />
+							</Grid.ColumnDefinitions>
+
+							<Rectangle Fill="DeepPink"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Column="1"
+										 Fill="LightSeaGreen"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Column="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+						</Grid>
+
+						<!-- Two Rows With Auto and Star sizes -->
+						<Grid Margin="0,5"
+								MinWidth="198"
+								MinHeight="100"
+								Padding="6"
+								BorderThickness="2"
+								BorderBrush="Red"
+								Background="Blue"
+								HorizontalAlignment="Center"
+								VerticalAlignment="Top">
+							<Grid.RowDefinitions>
+								<RowDefinition Height="*" />
+								<RowDefinition Height="Auto" />
+							</Grid.RowDefinitions>
+
+							<Rectangle Fill="DeepPink"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="1"
+										 Fill="LightSeaGreen"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+						</Grid>
+
+						<!-- Two Cloumns With Auto and Star sizes -->
+						<Grid Margin="0,5"
+								MinWidth="198"
+								MinHeight="100"
+								Padding="6"
+								BorderThickness="2"
+								BorderBrush="Red"
+								Background="Blue"
+								HorizontalAlignment="Center"
+								VerticalAlignment="Top">
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="*" />
+								<ColumnDefinition Width="Auto" />
+							</Grid.ColumnDefinitions>
+
+							<Rectangle Fill="DeepPink"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Column="1"
+										 Fill="LightSeaGreen"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Column="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+						</Grid>
+
+						<!-- Two Rows With Auto sizes -->
+						<Grid Margin="0,5"
+								MinWidth="198"
+								MinHeight="100"
+								Padding="6"
+								BorderThickness="2"
+								BorderBrush="Red"
+								Background="Blue"
+								HorizontalAlignment="Center"
+								VerticalAlignment="Top">
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
+							</Grid.RowDefinitions>
+
+							<Rectangle Fill="DeepPink"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="1"
+										 Fill="LightSeaGreen"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+						</Grid>
+
+						<!-- Two Columns With Auto sizes -->
+						<Grid Margin="0,5"
+								MinWidth="198"
+								MinHeight="100"
+								Padding="6"
+								BorderThickness="2"
+								BorderBrush="Red"
+								Background="Blue"
+								HorizontalAlignment="Center"
+								VerticalAlignment="Top">
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="Auto" />
+							</Grid.ColumnDefinitions>
+
+							<Rectangle Fill="DeepPink"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Column="1"
+										 Fill="LightSeaGreen"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Column="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+						</Grid>
+
+						<!-- Three Rows and Columns With Auto sizes -->
+						<Grid Margin="0,5"
+								MinWidth="198"
+								MinHeight="100"
+								Padding="6"
+								BorderThickness="2"
+								BorderBrush="Red"
+								HorizontalAlignment="Center"
+								VerticalAlignment="Top"
+								Background="Blue">
+							<Grid.RowDefinitions>
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
+								<RowDefinition Height="Auto" />
+							</Grid.RowDefinitions>
+
+							<Grid.ColumnDefinitions>
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="Auto" />
+								<ColumnDefinition Width="Auto" />
+							</Grid.ColumnDefinitions>
+
+							<Rectangle Fill="DeepPink"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Column="1"
+										 Fill="LightSeaGreen"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Column="2"
+										 Fill="LightBlue"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Column="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Column="2"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<Rectangle Grid.Row="1"
+										 Fill="Orange"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="1"
+										 Grid.Column="1"
+										 Fill="Yellow"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="1"
+										 Grid.Column="2"
+										 Fill="LightGreen"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Grid.Row="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="1"
+										 Grid.Column="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="1"
+										 Grid.Column="2"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<Rectangle Grid.Row="2"
+										 Fill="PaleTurquoise"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="2"
+										 Grid.Column="1"
+										 Fill="PaleVioletRed"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<Rectangle Grid.Row="2"
+										 Grid.Column="2"
+										 Fill="PapayaWhip"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Grid.Row="2"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="2"
+										 Grid.Column="1"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+
+							<TextBlock Grid.Row="2"
+										 Grid.Column="2"
+										 Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+						</Grid>
+
+						<!-- Superposition with one element stretched and the other centered -->
+						<Grid Margin="0,5"
+								MinWidth="80"
+								MinHeight="80"
+								Padding="6"
+								BorderThickness="2"
+								BorderBrush="Red"
+								Background="Blue"
+								HorizontalAlignment="Center"
+								VerticalAlignment="Top">
+							<Rectangle Fill="Orange"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+						</Grid>
+
+						<!-- Grid with MinWidth only and superposition with one element stretched and the other centered -->
+						<Grid Margin="0,5"
+								MinWidth="80"
+								Padding="6"
+								BorderThickness="2"
+								BorderBrush="Red"
+								Background="Green"
+								HorizontalAlignment="Center"
+								VerticalAlignment="Top">
+							<Rectangle Fill="Orange"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+						</Grid>
+
+						<!-- Grid with MinHeight only and superposition with one element stretched and the other centered -->
+						<Grid Margin="0,5"
+								MinHeight="80"
+								Padding="6"
+								BorderThickness="2"
+								BorderBrush="Red"
+								Background="Cyan"
+								HorizontalAlignment="Center"
+								VerticalAlignment="Top">
+							<Rectangle Fill="Orange"
+										 VerticalAlignment="Stretch"
+										 HorizontalAlignment="Stretch" />
+
+							<TextBlock Text="test"
+										 FontSize="15"
+										 FontWeight="Bold"
+										 Foreground="White"
+										 HorizontalAlignment="Center"
+										 VerticalAlignment="Center" />
+						</Grid>
+					</StackPanel>
+				</ScrollViewer>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_MinWidth_MinHeight.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_MinWidth_MinHeight.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_with_MinWidth_MinHeight")]
+	public sealed partial class Grid_with_MinWidth_MinHeight : UserControl
+	{
+		public Grid_with_MinWidth_MinHeight()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_OutOfRange_Cells.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_OutOfRange_Cells.xaml
@@ -1,0 +1,37 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.GridTestsControl.Grid_with_OutOfRange_Cells"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<Grid Width="375" Height="300">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="125" />
+			<RowDefinition Height="125" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="125" />
+			<ColumnDefinition Width="125" />
+			<ColumnDefinition Width="125" />
+		</Grid.ColumnDefinitions>
+
+		<Border Grid.Row="0" Grid.Column="0" Background="Beige" />
+		<Border Grid.Row="0" Grid.Column="1" Background="LavenderBlush" />
+		<Border Grid.Row="0" Grid.Column="2" Background="Beige" />
+		<Border Grid.Row="1" Grid.Column="0" Background="LavenderBlush" />
+		<Border Grid.Row="1" Grid.Column="1" Background="Beige" />
+		<Border Grid.Row="1" Grid.Column="2" Background="LavenderBlush" />
+
+		<TextBlock Grid.Row="-1" Grid.Column="-1">-1,-1 (UWP: 0,1)</TextBlock>
+		<TextBlock Grid.Row="-1" Grid.Column="1">-1,1 (UWP: 1,0)</TextBlock>
+		<TextBlock Grid.Row="1" Grid.Column="-1">0,-1 (UWP: 1,1)</TextBlock>
+		<TextBlock Grid.Row="0" Grid.Column="3">0,3</TextBlock>
+		<TextBlock Grid.Row="2" Grid.Column="2">2,2 (UWP: 2,1)</TextBlock>
+		<TextBlock Grid.ColumnSpan="-1" VerticalAlignment="Bottom">0,0;span=-1</TextBlock>
+		<TextBlock Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="3" VerticalAlignment="Bottom" TextAlignment="Center">1,1;span=3</TextBlock>
+
+	</Grid>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_OutOfRange_Cells.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_OutOfRange_Cells.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_with_OutOfRange_Cells")]
+	public sealed partial class Grid_with_OutOfRange_Cells : Page
+	{
+		public Grid_with_OutOfRange_Cells()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Stack_Panel_and_Trimming.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Stack_Panel_and_Trimming.xaml
@@ -1,0 +1,27 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_with_Stack_Panel_and_Trimming"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="#FFFF0000" Width="300" >
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="auto" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="auto" />
+		</Grid.ColumnDefinitions>
+		<TextBlock Text="Small 01" Grid.Column="0" Grid.Row="0" x:Name="TrimmedLeft"  />
+		<StackPanel x:Name="InnerStack" Grid.Column="1" Grid.Row="0" >
+			<TextBlock x:Name="TrimmedMiddle" Text="This is a veeery loooong text that should trim at the end because it does not fit" FontFamily="Helvetica" FontSize="30" TextTrimming="CharacterEllipsis" />
+		</StackPanel>
+		<TextBlock Text="Small 02" Grid.Column="2" Grid.Row="0" x:Name="TrimmedRight" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Stack_Panel_and_Trimming.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Stack_Panel_and_Trimming.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_with_Stack_Panel_and_Trimming")]
+	public sealed partial class Grid_with_Stack_Panel_and_Trimming : UserControl
+	{
+		public Grid_with_Stack_Panel_and_Trimming()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_TextBlock_VerticalAlignment.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_TextBlock_VerticalAlignment.xaml
@@ -1,0 +1,33 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_with_TextBlock_VerticalAlignment"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="2000"
+	d:DesignWidth="400">
+
+	<controls:SampleControl SampleDescription="The TextBlock and its Border should be aligned to the bottom of the Grid">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<Grid VerticalAlignment="Top"
+						  HorizontalAlignment="Stretch"
+						  Background="Red"
+						  Height="60">
+						<Border VerticalAlignment="Bottom"
+								Background="DeepPink">
+							<TextBlock Text="Text aligned to the bottom"
+									   VerticalAlignment="Bottom"
+									   HorizontalAlignment="Center"
+									   TextAlignment="Center" />
+						</Border>
+					</Grid>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_TextBlock_VerticalAlignment.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_TextBlock_VerticalAlignment.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_with_TextBlock_VerticalAlignment")]
+	public sealed partial class Grid_with_TextBlock_VerticalAlignment : UserControl
+	{
+		public Grid_with_TextBlock_VerticalAlignment()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Text_HorizontalAlignment_With_Margin.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Text_HorizontalAlignment_With_Margin.xaml
@@ -1,0 +1,35 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_with_Text_HorizontalAlignment_With_Margin"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Cyan">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Border HorizontalAlignment="Left" Background="Red" Grid.Column="0" Grid.Row="0" Margin="5">
+			<TextBlock Text="Top" />
+		</Border>
+		<Border HorizontalAlignment="Center" Background="Red" Grid.Column="1" Grid.Row="0" Margin="5">
+			<TextBlock Text="Center" />
+		</Border>
+		<Border HorizontalAlignment="Right" Background="Red" Grid.Column="2" Grid.Row="0" Margin="5">
+			<TextBlock Text="Bottom" />
+		</Border>
+		<Border HorizontalAlignment="Stretch" Background="Red" Grid.Column="3" Grid.Row="0" Margin="5">
+			<TextBlock Text="Stretch" />
+		</Border>
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Text_HorizontalAlignment_With_Margin.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Text_HorizontalAlignment_With_Margin.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_with_Text_HorizontalAlignment_With_Margin")]
+	public sealed partial class Grid_with_Text_HorizontalAlignment_With_Margin : UserControl
+	{
+		public Grid_with_Text_HorizontalAlignment_With_Margin()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Text_VerticalAlignment_With_Margin.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Text_VerticalAlignment_With_Margin.xaml
@@ -1,0 +1,35 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_with_Text_VerticalAlignment_With_Margin"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Cyan">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Border VerticalAlignment="Top" Background="Red" Grid.Column="0" Grid.Row="0" Margin="5">
+			<TextBlock Text="Top" />
+		</Border>
+		<Border VerticalAlignment="Center" Background="Red" Grid.Column="1" Grid.Row="0" Margin="5">
+			<TextBlock Text="Center" />
+		</Border>
+		<Border VerticalAlignment="Bottom" Background="Red" Grid.Column="2" Grid.Row="0" Margin="5">
+			<TextBlock Text="Bottom" />
+		</Border>
+		<Border VerticalAlignment="Stretch" Background="Red" Grid.Column="3" Grid.Row="0" Margin="5">
+			<TextBlock Text="Stretch" />
+		</Border>
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Text_VerticalAlignment_With_Margin.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_Text_VerticalAlignment_With_Margin.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_with_Text_VerticalAlignment_With_Margin")]
+	public sealed partial class Grid_with_Text_VerticalAlignment_With_Margin : UserControl
+	{
+		public Grid_with_Text_VerticalAlignment_With_Margin()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UILabel_TextAlignmentVertical_Bottom.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UILabel_TextAlignmentVertical_Bottom.xaml
@@ -1,0 +1,25 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_with_UILabel_TextAlignmentVertical_Bottom"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="#FFFF0000">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<TextBlock Margin="10" Text="pAqqj|" VerticalAlignment="Bottom" HorizontalAlignment="Left" TextTrimming="CharacterEllipsis" FontSize="15" FontFamily="Helvetica" ios:TextAlignment="Center" Grid.Column="0" Grid.Row="0"  />
+		<TextBlock Margin="10" Text="pAqqj|" VerticalAlignment="Bottom" HorizontalAlignment="Center" TextTrimming="CharacterEllipsis" FontSize="15" FontFamily="Helvetica" ios:TextAlignment="Center" Grid.Column="1" Grid.Row="0"  />
+		<TextBlock Margin="10" Text="pAqqj|" VerticalAlignment="Bottom" HorizontalAlignment="Right" TextTrimming="CharacterEllipsis" FontSize="15" FontFamily="Helvetica" ios:TextAlignment="Center" Grid.Column="2" Grid.Row="0" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UILabel_TextAlignmentVertical_Bottom.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UILabel_TextAlignmentVertical_Bottom.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_with_UILabel_TextAlignmentVertical_Bottom")]
+	public sealed partial class Grid_with_UILabel_TextAlignmentVertical_Bottom : UserControl
+	{
+		public Grid_with_UILabel_TextAlignmentVertical_Bottom()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControlMargin.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControlMargin.xaml
@@ -1,0 +1,18 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_with_UserControlMargin"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Red">
+		<UserControl Background="Green" Margin="5" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControlMargin.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControlMargin.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_with_UserControlMargin")]
+	public sealed partial class Grid_with_UserControlMargin : UserControl
+	{
+		public Grid_with_UserControlMargin()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_HorizonalAlignment.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_HorizonalAlignment.xaml
@@ -1,0 +1,25 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_with_UserControl_HorizonalAlignment"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Red">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<UserControl HorizontalAlignment="Center" Background="Green" Width="50" Grid.Column="0" Grid.Row="0" />
+		<UserControl HorizontalAlignment="Left" Background="Yellow" Width="50" Grid.Column="1" Grid.Row="0" />
+		<UserControl HorizontalAlignment="Right" Background="Purple" Width="50" Grid.Column="2" Grid.Row="0" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_HorizonalAlignment.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_HorizonalAlignment.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_with_UserControl_HorizonalAlignment")]
+	public sealed partial class Grid_with_UserControl_HorizonalAlignment : UserControl
+	{
+		public Grid_with_UserControl_HorizonalAlignment()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_VerticalAlignment_Fixed_Height.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_VerticalAlignment_Fixed_Height.xaml
@@ -1,0 +1,25 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_with_UserControl_VerticalAlignment_Fixed_Height"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Red">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<UserControl VerticalAlignment="Center" Background="Green" Height="50" Grid.Column="0" Grid.Row="0" />
+		<UserControl VerticalAlignment="Top" Background="Yellow" Height="50" Grid.Column="1" Grid.Row="0" />
+		<UserControl VerticalAlignment="Bottom" Background="Purple" Height="50" Grid.Column="2" Grid.Row="0" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_VerticalAlignment_Fixed_Height.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_VerticalAlignment_Fixed_Height.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_with_UserControl_VerticalAlignment_Fixed_Height")]
+	public sealed partial class Grid_with_UserControl_VerticalAlignment_Fixed_Height : UserControl
+	{
+		public Grid_with_UserControl_VerticalAlignment_Fixed_Height()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_VerticalAlignment_Variable_Height.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_VerticalAlignment_Variable_Height.xaml
@@ -1,0 +1,31 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_with_UserControl_VerticalAlignment_Variable_Height"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Red">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<UserControl VerticalAlignment="Center" Background="Green" Grid.Column="0" Grid.Row="0" x:Name="MyUserControl_VerticalAlignedCenter" >
+			<TextBlock Text="Center" />
+		</UserControl>
+		<UserControl VerticalAlignment="Top" Background="Yellow" Grid.Column="1" Grid.Row="0" x:Name="MyUserControl_VerticalAlignedTop" >
+			<TextBlock Text="Top" />
+		</UserControl>
+		<UserControl VerticalAlignment="Bottom" Background="Purple" Grid.Column="2" Grid.Row="0" x:Name="MyUserControl_VerticalAlignedBottom" >
+			<TextBlock Text="Bottom" />
+		</UserControl>
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_VerticalAlignment_Variable_Height.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_VerticalAlignment_Variable_Height.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_with_UserControl_VerticalAlignment_Variable_Height")]
+	public sealed partial class Grid_with_UserControl_VerticalAlignment_Variable_Height : UserControl
+	{
+		public Grid_with_UserControl_VerticalAlignment_Variable_Height()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_VerticalAlignment_Variable_Width.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_VerticalAlignment_Variable_Width.xaml
@@ -1,0 +1,31 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_with_UserControl_VerticalAlignment_Variable_Width"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Red">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<UserControl HorizontalAlignment="Center" Background="Green" Grid.Column="0" Grid.Row="0">
+			<TextBlock Text="Center" />
+		</UserControl>
+		<UserControl HorizontalAlignment="Left" Background="Yellow" Grid.Column="1" Grid.Row="0">
+			<TextBlock Text="Left" />
+		</UserControl>
+		<UserControl HorizontalAlignment="Right" Background="Purple" Grid.Column="2" Grid.Row="0">
+			<TextBlock Text="Right" />
+		</UserControl>
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_VerticalAlignment_Variable_Width.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_UserControl_VerticalAlignment_Variable_Width.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_with_UserControl_VerticalAlignment_Variable_Width")]
+	public sealed partial class Grid_with_UserControl_VerticalAlignment_Variable_Width : UserControl
+	{
+		public Grid_with_UserControl_VerticalAlignment_Variable_Width()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_attributed_string.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_attributed_string.xaml
@@ -1,0 +1,23 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_with_attributed_string"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Cyan">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="auto" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<TextBlock Grid.Column="0" Grid.Row="0" Grid.RowSpan="2"><Run Text="Text Red" Foreground="Red" /><Run Text=" " /><Run Text="Test Blue" Foreground="Blue" /></TextBlock>
+		<Border Background="Yellow" Grid.Row="0" Grid.Column="1" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_attributed_string.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_attributed_string.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_with_attributed_string")]
+	public sealed partial class Grid_with_attributed_string : UserControl
+	{
+		public Grid_with_attributed_string()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_three_UserControl_With_5_Margin.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_three_UserControl_With_5_Margin.xaml
@@ -1,0 +1,25 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Grid_with_three_UserControl_With_5_Margin"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="Red">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="50" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<UserControl Background="Green" Margin="5" Grid.Column="0" Grid.Row="0" />
+		<UserControl Background="Blue" Margin="5" Grid.Column="1" Grid.Row="0" />
+		<UserControl Background="Yellow" Margin="5" Grid.Column="2" Grid.Row="0" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_three_UserControl_With_5_Margin.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Grid_with_three_UserControl_With_5_Margin.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Grid_with_three_UserControl_With_5_Margin")]
+	public sealed partial class Grid_with_three_UserControl_With_5_Margin : UserControl
+	{
+		public Grid_with_three_UserControl_With_5_Margin()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quad_column_progressing_split.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quad_column_progressing_split.xaml
@@ -1,0 +1,30 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Quad_column_progressing_split"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="#FFFF0000" Height="100">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="1*" />
+			<ColumnDefinition Width="2*" />
+			<ColumnDefinition Width="3*" />
+			<ColumnDefinition Width="4*" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid Background="#FF00FF00" Grid.Column="0" Grid.Row="0" />
+		<Grid Background="#FFFF0000" Grid.Column="1" Grid.Row="0" />
+		<Grid Background="#FF7FFF00" Grid.Column="2" Grid.Row="0" />
+		<Grid Background="#FFFFFF00" Grid.Column="3" Grid.Row="0" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quad_column_progressing_split.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quad_column_progressing_split.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Quad_column_progressing_split")]
+	public sealed partial class Quad_column_progressing_split : UserControl
+	{
+		public Quad_column_progressing_split()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_absolute_split.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_absolute_split.xaml
@@ -1,0 +1,29 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Quadrant_absolute_split"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="#FFFF0000">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="100" />
+			<ColumnDefinition Width="2*" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="100" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid Background="#FF00FF00" Grid.Column="0" Grid.Row="0" />
+		<Grid Background="#FFFF0000" Grid.Column="1" Grid.Row="0" />
+		<Grid Background="#FF7FFF00" Grid.Column="0" Grid.Row="1" />
+		<Grid Background="#FFFFFF00" Grid.Column="1" Grid.Row="1" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_absolute_split.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_absolute_split.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Quadrant_absolute_split")]
+	public sealed partial class Quadrant_absolute_split : UserControl
+	{
+		public Quadrant_absolute_split()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_all_100.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_all_100.xaml
@@ -1,0 +1,29 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Quadrant_all_100"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="#FF0000FF" Height="100">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="100" />
+			<ColumnDefinition Width="100" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="100" />
+			<RowDefinition Height="100" />
+		</Grid.RowDefinitions>
+		<Grid Background="#FF00FF00" Grid.Column="0" Grid.Row="0" />
+		<Grid Background="#FFFF0000" Grid.Column="1" Grid.Row="0" />
+		<Grid Background="#FF7FFF00" Grid.Column="0" Grid.Row="1" />
+		<Grid Background="#FFFFFF00" Grid.Column="1" Grid.Row="1" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_all_100.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_all_100.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Quadrant_all_100")]
+	public sealed partial class Quadrant_all_100 : UserControl
+	{
+		public Quadrant_all_100()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_even_split.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_even_split.xaml
@@ -1,0 +1,29 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Quadrant_even_split"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="#FFFF0000" Height="100">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid Background="#FF00FF00" Grid.Column="0" Grid.Row="0" />
+		<Grid Background="#FFFF0000" Grid.Column="1" Grid.Row="0" />
+		<Grid Background="#FF7FFF00" Grid.Column="0" Grid.Row="1" />
+		<Grid Background="#FFFFFF00" Grid.Column="1" Grid.Row="1" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_even_split.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_even_split.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Quadrant_even_split")]
+	public sealed partial class Quadrant_even_split : UserControl
+	{
+		public Quadrant_even_split()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_uneven_split.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_uneven_split.xaml
@@ -1,0 +1,29 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Quadrant_uneven_split"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="#FFFF0000" Height="100">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="2*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="2*" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid Background="#FF00FF00" Grid.Column="0" Grid.Row="0" />
+		<Grid Background="#FFFF0000" Grid.Column="1" Grid.Row="0" />
+		<Grid Background="#FF7FFF00" Grid.Column="0" Grid.Row="1" />
+		<Grid Background="#FFFFFF00" Grid.Column="1" Grid.Row="1" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_uneven_split.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Quadrant_uneven_split.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Quadrant_uneven_split")]
+	public sealed partial class Quadrant_uneven_split : UserControl
+	{
+		public Quadrant_uneven_split()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Simpletwocolumnsplitgrid.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Simpletwocolumnsplitgrid.xaml
@@ -1,0 +1,23 @@
+<UserControl
+	x:Class="Uno.UI.Samples.Content.UITests.GridTestsControl.Simpletwocolumnsplitgrid"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	xmlns:ios="http://uno.ui/ios"
+	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:android="http://uno.ui/android"
+	mc:Ignorable="d ios android"
+	d:DesignHeight="3000"
+	d:DesignWidth="400">
+
+	<Grid Background="#FFFF0000" Height="100">
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="*" />
+			<ColumnDefinition Width="*" />
+		</Grid.ColumnDefinitions>
+		<Grid Background="#00FF00" Grid.Column="0" Grid.Row="0" />
+		<Grid Background="#FF0000" Grid.Column="1" Grid.Row="0" />
+	</Grid>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Simpletwocolumnsplitgrid.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/Simpletwocolumnsplitgrid.xaml.cs
@@ -1,0 +1,14 @@
+using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Samples.Content.UITests.GridTestsControl
+{
+	[SampleControlInfo("GridTestsControl", "Simpletwocolumnsplitgrid")]
+	public sealed partial class Simpletwocolumnsplitgrid : UserControl
+	{
+		public Simpletwocolumnsplitgrid()
+		{
+			this.InitializeComponent();
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.FastPaths.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.FastPaths.cs
@@ -84,7 +84,7 @@ namespace Windows.UI.Xaml.Controls
 				size.Width = pixelWidth;
 			}
 
-			var positions = GetPositions();
+			var positions = GetPositions(1, rows.Length);
 
 			using (positions.Subscription)
 			{
@@ -131,7 +131,7 @@ namespace Windows.UI.Xaml.Controls
 				size.Height = pixelHeight;
 			}
 
-			var positions = GetPositions();
+			var positions = GetPositions(columns.Length, 1);
 			using (positions.Subscription)
 			{
 				var measureChild = GetDirectMeasureChild();

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.Layout.cs
@@ -922,26 +922,26 @@ namespace Windows.UI.Xaml.Controls
 				var column = Grid.GetColumn(c.View);
 				var columnSpan = Grid.GetColumnSpan(c.View);
 
-				if (column < 0)
-				{
-					column = 0;
-				}
-				else if (column == 0)
+				if (column == 0)
 				{
 					// Ok: nothing to check
+				}
+				else if (column < 0)
+				{
+					column = 0;
 				}
 				else if (column >= numberOfColumns)
 				{
 					column = numberOfColumns - 1;
 				}
 
-				if (columnSpan < 1)
-				{
-					columnSpan = 1;
-				}
-				else if (columnSpan == 1)
+				if (columnSpan == 1)
 				{
 					// Ok: nothing to check
+				}
+				else if (columnSpan < 1)
+				{
+					columnSpan = 1;
 				}
 				else if (column + columnSpan > numberOfColumns)
 				{
@@ -951,26 +951,26 @@ namespace Windows.UI.Xaml.Controls
 				var row = Grid.GetRow(c.View);
 				var rowSpan = Grid.GetRowSpan(c.View);
 
-				if (row < 0)
-				{
-					row = 0;
-				}
-				else if (row == 0)
+				if (row == 0)
 				{
 					// Ok: nothing to check
 				}
-				if (row >= numberOfRows)
+				else if (row < 0)
+				{
+					row = 0;
+				}
+				else if (row >= numberOfRows)
 				{
 					row = numberOfRows - 1;
 				}
 
-				if (rowSpan < 1)
-				{
-					rowSpan = 1;
-				}
-				else if (rowSpan == 1)
+				if (rowSpan == 1)
 				{
 					// Ok: nothing to check
+				}
+				else if (rowSpan < 1)
+				{
+					rowSpan = 1;
 				}
 				else if (row + rowSpan > numberOfRows)
 				{


### PR DESCRIPTION
## Bugfix
Setting grid positions were causing out-of-range exceptions

## What is the new behavior?
Like UWP, the position is now "clamped" to defined rows and columns.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [X] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
