### PR TITLE
[Android] ListView - don't reuse non-generated container

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -107,7 +107,7 @@
 * 152504 [Android] Pointer captures weren't informing gestures of capture, fixes Slider capture issue
 * 148896 [iOS] TextBlock CarriageReturns would continue past maxlines property
 * 153594 [Android] EdgeEffect not showing up on listView that contain Headers and Footers
-* #881 [iOS] Support explicitly-defined ListViewItems in ListView.
+* #881 [iOS] [Android] Support explicitly-defined ListViewItems in ListView.
 * #902 [Android] Resource generation now correctly escapes names starting with numbers and names containing a '-' character
 * 154390 Storyboard `Completed` callback were not properly called when there's not children.
 * [iOS] Fix bug where Popup can be hidden if created during initial app launch.

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/BufferViewCache.Android.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/BufferViewCache.Android.cs
@@ -501,6 +501,15 @@ namespace Windows.UI.Xaml.Controls
 				return;
 			}
 
+			var isGenerated = (viewRecord.View as ContentControl)?.IsGeneratedContainer ?? false;
+			if (!isGenerated)
+			{
+				// If it's not a generated container then it must be an item that returned true for IsItemItsOwnContainerOverride (eg an
+				// explicitly-defined ListViewItem), and shouldn't be recycled for a different item.
+				Layout.RemoveView(viewRecord.View);
+				return;
+			}
+
 			NotifyViewRecycled(viewRecord.ViewHolder);
 
 			// Send to intermediate cache


### PR DESCRIPTION
Fixes crash/corrupt views when using explicitly defined ListViewItems.

GitHub Issue (If applicable): #
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
#881 

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
