### PR TITLE
Avoid producing "Collection was modified"

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -112,6 +112,7 @@
 * 154390 Storyboard `Completed` callback were not properly called when there's not children.
 * [iOS] Fix bug where Popup can be hidden if created during initial app launch.
 * #921 Ensure localization works even if the property isn't defined in XAML
+* [WASM] Using x:Load was causing _Collection was modified_ exception.
 
 ## Release 1.44.0
 

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -16,6 +16,7 @@ using Windows.Foundation;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.System;
+using Uno.Collections;
 using Uno.UI;
 using System.Numerics;
 
@@ -519,7 +520,7 @@ namespace Windows.UI.Xaml
 
 		private Rect _arranged;
 		private string _name;
-		internal List<UIElement> _children = new List<UIElement>();
+		internal IList<UIElement> _children = new MaterializableList<UIElement>();
 
 		public string Name
 		{

--- a/src/Uno.UI/UI/Xaml/UIElementCollection.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElementCollection.wasm.cs
@@ -42,7 +42,7 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override View GetAtIndexCore(int index) => _view._children[index];
 
-		protected override List<View>.Enumerator GetEnumeratorCore() => _view._children.GetEnumerator();
+		protected override List<View>.Enumerator GetEnumeratorCore() => (List<View>.Enumerator)_view._children.GetEnumerator();
 
 		protected override int IndexOfCore(View item) => _view._children.IndexOf(item);
 

--- a/src/Uno.UWP/Collections/MaterializableList.cs
+++ b/src/Uno.UWP/Collections/MaterializableList.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Uno.Collections
+{
+	/// <summary>
+	/// List using a materialized version to enumerate itself to prevent
+	/// "Collection was modified" error.
+	/// </summary>
+	/// <remarks>
+	/// THIS IS NOT THREAD-SAFE. It is designed to be used on
+	/// the UI thread.
+	/// </remarks>
+	public class MaterializableList<T> : IList<T>
+	{
+		private readonly List<T> _listImplementation = new List<T>();
+
+		public IEnumerator<T> GetEnumerator() => Materialized.GetEnumerator();
+
+		IEnumerator IEnumerable.GetEnumerator() => Materialized.GetEnumerator();
+
+		public void Add(T item)
+		{
+			_listImplementation.Add(item);
+			_materialized = null;
+		}
+
+		public void Clear()
+		{
+			_listImplementation.Clear();
+			_materialized = null;
+		}
+
+		public bool Contains(T item) => _listImplementation.Contains(item);
+
+		public void CopyTo(T[] array, int arrayIndex) => _listImplementation.CopyTo(array, arrayIndex);
+
+		public bool Remove(T item)
+		{
+			_materialized = null;
+			return _listImplementation.Remove(item);
+		}
+
+		public int Count => _listImplementation.Count;
+
+		public bool IsReadOnly => false;
+
+		public int IndexOf(T item) => _listImplementation.IndexOf(item);
+
+		public void Insert(int index, T item)
+		{
+			_listImplementation.Insert(index, item);
+			_materialized = null;
+		}
+
+		public void RemoveAt(int index)
+		{
+			_listImplementation.RemoveAt(index);
+			_materialized = null;
+		}
+
+		public T this[int index]
+		{
+			get => _listImplementation[index];
+			set
+			{
+				_listImplementation[index] = value;
+				_materialized = null;
+			}
+		}
+
+		private List<T> _materialized;
+
+		public List<T> Materialized => _materialized ?? (_materialized = _listImplementation.ToList());
+	}
+}


### PR DESCRIPTION
##  Bugfix

Avoid producing "Collection was modified" when the UI is modified during the "loaded" event.

This was mostly caused by the x:Load option.


## What is the current behavior?
Using `x:Load` was causing this kind of problems on Wasm.

## What is the new behavior?
A new `MaterializableList` collection has been create to cache the
materialized version of the list. And this materialized version is used
for enumeration.

This way, the annoying exception _Collection was modified_ won't
be pushed again.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [X] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
