### PR TITLE
added MessageDialog to the sample application

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -553,6 +553,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\MessageDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Mkv_Extension.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2068,6 +2072,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\NavigationViewTests\NavigationView_TopNavigation.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_LightDismiss.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_Simple.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\MessageDialog.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressRing.xaml.cs">
       <DependentUpon>ProgressRing.xaml</DependentUpon>
     </Compile>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/MessageDialog.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/MessageDialog.xaml
@@ -1,0 +1,17 @@
+﻿<Page
+	x:Class="UITests.Shared.Windows_UI_Xaml_Controls.Popup.MessageDialog"
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+	<StackPanel>
+		<Button x:Name="WithoutTitle">Without a title. When no commands are specified, a default command is added to the dialog.</Button>
+		<Button x:Name="WithTitle">With a title. When no commands are specified, a default command is added to the dialog.</Button>
+		<Button x:Name="WithOneCommandAndTitle">With a title. A customized command is added to the dialog.</Button>
+		<Button x:Name="WithTwoCommandsAndTitle">With a title. Two customized commands are added to the dialog.</Button>
+		<Button x:Name="WithThreeCommandsAndTitle">With a title. Three customized commands are added to the dialog.</Button>
+	</StackPanel>
+</Page>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/MessageDialog.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Popup/MessageDialog.xaml.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Threading.Tasks;
+using Uno.UI.Samples.Controls;
+using Windows.UI.Popups;
+using Windows.UI.Xaml.Controls;
+
+namespace UITests.Shared.Windows_UI_Xaml_Controls.Popup
+{
+	[SampleControlInfo("Popup", "MessageDialog", description:"The dialog dims the screen behind it and blocks touch events from passing to the app's canvas until the user responds.")]
+	public sealed partial class MessageDialog : Page
+	{
+		private const string _title = "Internet Connectivity";
+
+		public MessageDialog()
+		{
+			this.InitializeComponent();
+
+			WithoutTitle.Tapped += (snd, evt) =>
+			{
+				var messageDialog = new Windows.UI.Popups.MessageDialog("No internet connection has been found.");
+
+				Task.Run(async () => await messageDialog.ShowAsync());
+			};
+
+			WithTitle.Tapped += (snd, evt) =>
+			{
+				var messageDialog = new Windows.UI.Popups.MessageDialog("No internet connection has been found.");
+				messageDialog.Title = "Internet Connectivity";
+
+				Task.Run(async () => await messageDialog.ShowAsync());
+			};
+
+
+			WithOneCommandAndTitle.Tapped += (snd, evt) =>
+			{
+				var messageDialog = new Windows.UI.Popups.MessageDialog("No internet connection has been found.");
+
+				messageDialog.Commands.Add(new UICommand("Acknowledge", new UICommandInvokedHandler(this.CommandInvokedHandler)));
+				messageDialog.Title = "Internet Connectivity";
+
+				Task.Run(async () => await messageDialog.ShowAsync());
+			};
+
+			WithTwoCommandsAndTitle.Tapped += (snd, evt) =>
+			{
+				var messageDialog = new Windows.UI.Popups.MessageDialog("No internet connection has been found.");
+				messageDialog.Title = "Internet Connectivity";
+
+				messageDialog.Commands.Add(new UICommand("Try Again", new UICommandInvokedHandler(this.CommandInvokedHandler)));
+				messageDialog.DefaultCommandIndex = 0;
+
+				messageDialog.Commands.Add(new UICommand("Cancel",new UICommandInvokedHandler(this.CommandInvokedHandler)));
+				messageDialog.DefaultCommandIndex = 1;
+
+				Task.Run(async () => await messageDialog.ShowAsync());
+			};
+
+			WithThreeCommandsAndTitle.Tapped += (snd, evt) =>
+			{
+				var messageDialog = new Windows.UI.Popups.MessageDialog("No internet connection has been found.");
+				messageDialog.Title = "My Cool Title";
+
+				messageDialog.Commands.Add(new UICommand("Try Again", new UICommandInvokedHandler(this.CommandInvokedHandler)));
+				messageDialog.DefaultCommandIndex = 0;
+
+				messageDialog.Commands.Add(new UICommand("Reset Network Settings",new UICommandInvokedHandler(this.CommandInvokedHandler)));
+
+				messageDialog.Commands.Add(new UICommand("Cancel",new UICommandInvokedHandler(this.CommandInvokedHandler)));
+				messageDialog.CancelCommandIndex = 2;
+
+				Task.Run(async () => await messageDialog.ShowAsync());
+			};
+
+		}
+
+		private void CommandInvokedHandler(IUICommand command)
+		{
+		}
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): Progresses #678 but does not resolve it.

## PR Type
What kind of change does this PR introduce?
- Feature

## What is the current behavior?

`MessageDialog` examples missing from the SampleApp

## What is the new behavior?

`MessageDialog` examples added to the SampleApp

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information

![DEC3EB61-C7F1-4910-A47A-2A95C67B4221](https://user-images.githubusercontent.com/127353/58485117-c28bb200-81a6-11e9-9617-6b782def113d.GIF)
