### PR TITLE
Fix VisualStateTrigger ignoring height constraints if width constraint passed

### DIFF
--- a/src/Uno.UI.Tests/Windows_UI_Xaml/Given_AdaptiveTrigger.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/Given_AdaptiveTrigger.cs
@@ -77,5 +77,54 @@ namespace Uno.UI.Tests.Windows_UI_Xaml
 
 			group.CurrentState.Should().Be(state);
 		}
+
+		[TestMethod]
+		public void When_SingleWithTwoConstraints_FailingWidth()
+		{
+			Window.Current.SetWindowSize(new Size(100, 100));
+
+			var sut = new AdaptiveTrigger { MinWindowWidth = 101, MinWindowHeight = 42};
+
+			var state = new VisualState { Name = "activeState" };
+			state.StateTriggers.Add(sut);
+
+			var group = new VisualStateGroup();
+			group.States.Add(state);
+
+			group.CurrentState.Should().Be(null);
+		}
+
+		[TestMethod]
+		public void When_SingleWithTwoConstraints_FailingHeight()
+		{
+			Window.Current.SetWindowSize(new Size(100, 100));
+
+			var sut = new AdaptiveTrigger { MinWindowWidth = 42, MinWindowHeight = 101 };
+
+			var state = new VisualState { Name = "activeState" };
+			state.StateTriggers.Add(sut);
+
+			var group = new VisualStateGroup();
+			group.States.Add(state);
+
+			group.CurrentState.Should().Be(null);
+		}
+
+		[TestMethod]
+		public void When_SingleNoConstraints()
+		{
+			Window.Current.SetWindowSize(new Size(100, 100));
+
+			var sut = new AdaptiveTrigger { MinWindowWidth = 0, MinWindowHeight = 0};
+
+			var state = new VisualState { Name = "activeState" };
+			state.StateTriggers.Add(sut);
+
+			var group = new VisualStateGroup();
+			group.States.Add(state);
+
+			group.CurrentState.Should().Be(state);
+		}
+
 	}
 }

--- a/src/Uno.UI/UI/Xaml/AdaptiveTrigger.cs
+++ b/src/Uno.UI/UI/Xaml/AdaptiveTrigger.cs
@@ -27,12 +27,16 @@ namespace Windows.UI.Xaml
 			var mw = MinWindowWidth;
 			var mh = MinWindowHeight;
 
-			if (mw >= 0 && w >= mw)
+			var isActive = w >= mw && h >= mh;
+
+			if (isActive && mw >= 0)
 			{
+				// If we have 'mw' and 'mh' we activate using the 'MinWidthTrigger' as it's higher ranked by 'ViusalStateGroup.GetActiveTrigger()'
 				SetActivePrecedence(StateTriggerPrecedence.MinWidthTrigger);
 			}
-			else if (mh >= 0 && h > mh)
+			else if (isActive)
 			{
+				// We don't validate that 'mh > 0' so we are able to activate trigger with 'MinWindowWidth = 0' and 'MinWindowHeight = 0'
 				SetActivePrecedence(StateTriggerPrecedence.MinHeightTrigger);
 			}
 			else


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
As soon as width constraint is set and passed on a visual state trigger, the sate is flagged as active no matter the height constraint

## What is the new behavior?
The trigger is activated only if both constraints are met

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/_workitems/edit/154711