### PR TITLE
change dependabot to raise PR's once a week, if a package is published instead of live

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -2,7 +2,7 @@ version: 1
 update_configs:
   - package_manager: "dotnet:nuget"
     directory: "/"
-    update_schedule: "live"
+    update_schedule: "weekly"
 
     default_labels:
       - "kind/dependency"


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- Build or CI related changes

## What is the current behavior?

dependabot raises PR's as soon as packages are published.

## What is the new behavior?

dependabot raises PR's once a week, if a package is published.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

## Other information
