### PR TITLE
Xaml Generator crashing because of formatting exception

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -14,7 +14,7 @@
 
 ### Features
 * Updated `CheckBox` glyph to match UWP style on all platforms
-* Add support for the following `DisplayInformation` properties on iOS and Android:   
+* Add support for the following `DisplayInformation` properties on iOS and Android:
 * Add support for `CurrentInputMethodLanguageTag` and `TrySetInputMethodLanguageTag` on Android, iOS and WASM
 * Add support for `ChatMessageManager.ShowComposeSmsMessageAsync` (and `ChatMessage` `Body` and `Recipients` properties) on iOS and Android
 * Add support for the following `DisplayInformation` properties on iOS and Android:
@@ -117,6 +117,7 @@
 * #921 Ensure localization works even if the property isn't defined in XAML
 * [WASM] Using x:Load was causing _Collection was modified_ exception.
 * Fix support for localized attached properties.
+* Fix a potential crash during code generated from XAML, content were not properly escaped.
 
 ## Release 1.44.0
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/GridTestViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/GridTestsControl/GridTestViewModel.cs
@@ -7,14 +7,33 @@ namespace UITests.Shared.Windows_UI_Xaml_Controls.GridTestsControl
 {
 	public class GridTestsViewModel : ViewModelBase
 	{
+		private long _gridColumnAlternating;
+		private object _gridWidthAlternatingNull;
+
 		public GridTestsViewModel(CoreDispatcher dispatcher) : base(dispatcher)
 		{
 			ObserveGridColumnAlternating();
 		}
 
-		public long GridColumnAlternating { get; set; }
+		public long GridColumnAlternating
+		{
+			get => _gridColumnAlternating;
+			set
+			{
+				_gridColumnAlternating = value;
+				RaisePropertyChanged();
+			}
+		}
 
-		public object GridWidthAlternatingNull { get; set; }
+		public object GridWidthAlternatingNull
+		{
+			get => _gridWidthAlternatingNull;
+			set
+			{
+				_gridWidthAlternatingNull = value;
+				RaisePropertyChanged();
+			}
+		}
 
 		private async void ObserveGridColumnAlternating()
 		{

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -1187,6 +1187,11 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 			}
 		}
 
+		private void GenerateError(IIndentedStringBuilder writer, string message)
+		{
+			GenerateError(writer, message.Replace("{", "{{").Replace("}", "}}"), new object[0]);
+		}
+
 		private void GenerateError(IIndentedStringBuilder writer, string message, params object[] options)
 		{
 			if (ShouldWriteErrorOnInvalidXaml)


### PR DESCRIPTION
## Bugfix
Crash during code generation from XAML.

## What is the current behavior?
Some strings were not properly escaped and were interpreted as `.Format()` format, causing a `FormattingException` error.

## What is the new behavior?
Some of the strings are now properly escaped.

## PR Checklist

Please check if your PR fulfills the following requirements:

- ~~[ ] Tested code with current [supported SDKs](../README.md#supported)~~
- ~~[ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)~~
- ~~[ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)~~ (CI is enough to test this)
- ~~[ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences~~
- [X] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- ~~[ ] Associated with an issue (GitHub or internal)~~
