### PR TITLE
Dev/jela/wasm perf

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -64,6 +64,7 @@
 * `x:Bind` now supports binding to fields
 * `Grid` positions (`Row`, `RowSpan`, `Column` & `ColumnSpan`) are now behaving like UWP when the result overflows grid rows/columns definition
 * [Wasm] Improve TextBlock measure performance
+* [Wasm] Improve Html SetAttribute performance
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xBindTests/xBind_Field.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml/xBindTests/xBind_Field.xaml.cs
@@ -27,6 +27,8 @@ namespace UITests.Shared.Windows_UI_Xaml.xBindTests
 		}
 
 		public string PublicField = "Enemy";
+#pragma warning disable CS0414
 		private string PrivateField = "Ryan";
+#pragma warning restore CS0414
 	}
 }

--- a/src/Uno.UI.Wasm/ts/WindowManager.ts
+++ b/src/Uno.UI.Wasm/ts/WindowManager.ts
@@ -290,7 +290,7 @@
 		/**
 			* Set an attribute for an element.
 			*/
-		public setAttribute(elementId: number, attributes: { [name: string]: string }): string {
+		public setAttributes(elementId: number, attributes: { [name: string]: string }): string {
 			const htmlElement = this.getView(elementId);
 
 			for (const name in attributes) {
@@ -305,14 +305,26 @@
 		/**
 			* Set an attribute for an element.
 			*/
-		public setAttributeNative(pParams: number): boolean {
+		public setAttributesNative(pParams: number): boolean {
 
-			const params = WindowManagerSetAttributeParams.unmarshal(pParams);
+			const params = WindowManagerSetAttributesParams.unmarshal(pParams);
 			const htmlElement = this.getView(params.HtmlId);
 
 			for (let i = 0; i < params.Pairs_Length; i += 2) {
 				htmlElement.setAttribute(params.Pairs[i], params.Pairs[i + 1]);
 			}
+
+			return true;
+		}
+
+		/**
+			* Set an attribute for an element.
+			*/
+		public setAttributeNative(pParams: number): boolean {
+
+			const params = WindowManagerSetAttributeParams.unmarshal(pParams);
+			const htmlElement = this.getView(params.HtmlId);
+			htmlElement.setAttribute(params.Name, params.Value);
 
 			return true;
 		}

--- a/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/UIElement.wasm.cs
@@ -202,7 +202,7 @@ namespace Windows.UI.Xaml
 
 		protected internal void SetAttribute(string name, string value)
 		{
-			Uno.UI.Xaml.WindowManagerInterop.SetAttribute(HtmlId, new[] { (name, value) });
+			Uno.UI.Xaml.WindowManagerInterop.SetAttribute(HtmlId, name, value);
 		}
 
 		protected internal void SetAttribute(params (string name, string value)[] attributes)
@@ -212,7 +212,7 @@ namespace Windows.UI.Xaml
 				return; // nothing to do
 			}
 
-			Uno.UI.Xaml.WindowManagerInterop.SetAttribute(HtmlId, attributes);
+			Uno.UI.Xaml.WindowManagerInterop.SetAttributes(HtmlId, attributes);
 		}
 
 		protected internal string GetAttribute(string name)

--- a/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/WindowManagerInterop.wasm.cs
@@ -380,14 +380,14 @@ namespace Uno.UI.Xaml
 
 		#endregion
 
-		#region SetAttribute
+		#region SetAttributes
 
-		internal static void SetAttribute(IntPtr htmlId, (string name, string value)[] attributes)
+		internal static void SetAttributes(IntPtr htmlId, (string name, string value)[] attributes)
 		{
 			if (UseJavascriptEval)
 			{
 				var attributesStr = string.Join(", ", attributes.Select(s => "\"" + s.name + "\": \"" + WebAssemblyRuntime.EscapeJs(s.value) + "\""));
-				var command = "Uno.UI.WindowManager.current.setAttribute(\"" + htmlId + "\", {" + attributesStr + "});";
+				var command = "Uno.UI.WindowManager.current.setAttributes(\"" + htmlId + "\", {" + attributesStr + "});";
 
 				WebAssemblyRuntime.InvokeJS(command);
 			}
@@ -401,11 +401,49 @@ namespace Uno.UI.Xaml
 					pairs[i * 2 + 1] = attributes[i].value;
 				}
 
-				var parms = new WindowManagerSetAttributeParams()
+				var parms = new WindowManagerSetAttributesParams()
 				{
 					HtmlId = htmlId,
 					Pairs_Length = pairs.Length,
 					Pairs = pairs,
+				};
+
+				TSInteropMarshaller.InvokeJS<WindowManagerSetAttributesParams>("Uno:setAttributesNative", parms);
+			}
+		}
+
+
+		[TSInteropMessage]
+		[StructLayout(LayoutKind.Sequential, Pack = 4)]
+		private struct WindowManagerSetAttributesParams
+		{
+			public IntPtr HtmlId;
+
+			public int Pairs_Length;
+
+			[MarshalAs(UnmanagedType.LPArray, ArraySubType = TSInteropMarshaller.LPUTF8Str)]
+			public string[] Pairs;
+		}
+
+		#endregion
+		#region SetAttributes
+
+		internal static void SetAttribute(IntPtr htmlId, string name, string value)
+		{
+			if (UseJavascriptEval)
+			{
+				var attributesStr = "\"" + name + "\": \"" + WebAssemblyRuntime.EscapeJs(value) + "\"";
+				var command = "Uno.UI.WindowManager.current.setAttributes(\"" + htmlId + "\", {" + attributesStr + "});";
+
+				WebAssemblyRuntime.InvokeJS(command);
+			}
+			else
+			{
+				var parms = new WindowManagerSetAttributeParams()
+				{
+					HtmlId = htmlId,
+					Name = name,
+					Value = value,
 				};
 
 				TSInteropMarshaller.InvokeJS<WindowManagerSetAttributeParams>("Uno:setAttributeNative", parms);
@@ -419,10 +457,11 @@ namespace Uno.UI.Xaml
 		{
 			public IntPtr HtmlId;
 
-			public int Pairs_Length;
+			[MarshalAs(TSInteropMarshaller.LPUTF8Str)]
+			public string Name;
 
-			[MarshalAs(UnmanagedType.LPArray, ArraySubType = TSInteropMarshaller.LPUTF8Str)]
-			public string[] Pairs;
+			[MarshalAs(TSInteropMarshaller.LPUTF8Str)]
+			public string Value;
 		}
 
 		#endregion
@@ -480,14 +519,14 @@ namespace Uno.UI.Xaml
 					pairs[i * 2 + 1] = properties[i].value;
 				}
 
-				var parms = new WindowManagerSetAttributeParams()
+				var parms = new WindowManagerSetAttributesParams()
 				{
 					HtmlId = htmlId,
 					Pairs_Length = pairs.Length,
 					Pairs = pairs,
 				};
 
-				TSInteropMarshaller.InvokeJS<WindowManagerSetAttributeParams>("Uno:setPropertyNative", parms);
+				TSInteropMarshaller.InvokeJS<WindowManagerSetAttributesParams>("Uno:setPropertyNative", parms);
 
 			}
 		}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Performance

## What is the new behavior?
WindowManager.SetAttribute now supports a single value interop method, which avoids creating arrays with a single item.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. 
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
