### PR TITLE
add explicit instructions for security researchers how to responsibly disclose security related matters

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Reporting Security Issues
+
+The Uno team and community take security bugs in Uno seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, email [security@platform.uno](mailto:security@platform.uno) and include the word "SECURITY" in the subject line.
+
+The Uno team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #919

## PR Type
What kind of change does this PR introduce?

- Documentation content changes

## What is the current behavior?

No guidance provided for security researchers.

## What is the new behavior?

See https://github.com/TryGhost/Ghost/blob/master/SECURITY.md

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)


## What's required before merging

- [x] Provision the `security@platform.uno` mailbox
- [x] Merge the pull-request

