### PR TITLE
delete branches after merge, enable automatic merging of prs

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,37 @@
+pull_request_rules:
+  - name: automatic deletion of pull-request branches after merge
+    conditions: []
+    actions:
+      # Takes no options, see <https://doc.mergify.io/examples.html#deleting-merged-branch>
+      delete_head_branch: {}
+
+  - name: automatic strict merge when CI passes, has 2 reviews and is labeled 'ready-to-merge' unless labelled 'do-not-merge/breaking-change' or 'do-not-merge/work-in-progress'
+    conditions:
+      # Only pull-requests sent to the master branch
+      - base=master
+
+      # All Azure builds should be green:
+      - status-success=Uno.UI - CI
+
+      # CLA check must pass:
+      #- "status-success=license/cla"
+
+      # Note that this only matches people with write / admin access to the repo,
+      # see <https://doc.mergify.io/conditions.html#attribute-list>
+      - "#approved-reviews-by>=2"
+
+      # Pull-request must be labeled with:
+      - label=ready-to-merge
+
+      # Do not automatically merge pull-requests that are labelled as do-not-merge
+      # see <https://doc.mergify.io/examples.html#id6>
+      - label!=do-not-merge/breaking-change
+      - label!=do-not-merge/work-in-progress
+
+    # Note: mergify cannot break branch protection rules
+    actions:
+      merge:
+        method: merge
+        # https://doc.mergify.io/strict-workflow.html
+        # https://doc.mergify.io/actions.html#label
+        strict: smart

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,7 +5,7 @@ pull_request_rules:
       # Takes no options, see <https://doc.mergify.io/examples.html#deleting-merged-branch>
       delete_head_branch: {}
 
-  - name: automatic strict merge when CI passes, has 2 reviews and is labeled 'ready-to-merge' unless labelled 'do-not-merge/breaking-change' or 'do-not-merge/work-in-progress'
+  - name: automatic strict merge when CI passes, has 2 reviews, no requests for change and is labeled 'ready-to-merge' unless labelled 'do-not-merge/breaking-change' or 'do-not-merge/work-in-progress'
     conditions:
       # Only pull-requests sent to the master branch
       - base=master
@@ -19,6 +19,7 @@ pull_request_rules:
       # Note that this only matches people with write / admin access to the repo,
       # see <https://doc.mergify.io/conditions.html#attribute-list>
       - "#approved-reviews-by>=2"
+      - "#changes-requested-reviews-by=0"
 
       # Pull-request must be labeled with:
       - label=ready-to-merge


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- Build or CI related changes

## What is the current behavior?

- Maintainers need to babysit builds and wait for them to pass before merging.
- Maintainers need to remember to delete branches after they are merged.

## What is the new behavior?

- When a pull-request to `master` has 2 or more approvals and no requests for change it will be automatically merged if the CI passes, is labelled with `ready-to-merge` unless it has been labelled with `do-not-merge/breaking-changes` or `do-not-merge/work-in-progress`

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

## Other information

See https://github.com/digital-asset/daml/blob/master/.mergify.yml for comparison.
See https://doc.mergify.io/configuration.html for documentation