### PR TITLE
Adjust namespaces for VS16.2 support

### DIFF
--- a/src/Uno.UI/Controls/BindableUIButton.iOS.cs
+++ b/src/Uno.UI/Controls/BindableUIButton.iOS.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Drawing;
 using Uno.Extensions;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Media;
@@ -35,7 +34,7 @@ namespace Uno.UI.Views.Controls
 			InitializeBinder();
 		}
 
-		public BindableUIButton(RectangleF frame)
+		public BindableUIButton(System.Drawing.RectangleF frame)
 			: base(frame)
 		{
 			InitializeBinder();

--- a/src/Uno.UI/Controls/BindableUISwitch.iOS.cs
+++ b/src/Uno.UI/Controls/BindableUISwitch.iOS.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Drawing;
 using Uno.Disposables;
 using System.Runtime.CompilerServices;
 using Windows.UI.Xaml.Data;
@@ -31,7 +30,7 @@ namespace Uno.UI.Views.Controls
 			IsOn = On;
 		}
 
-		public BindableUISwitch(RectangleF frame)
+		public BindableUISwitch(System.Drawing.RectangleF frame)
 			: base(frame)
 		{
 			InitializeBinder();

--- a/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Border/BorderLayerRenderer.iOSmacOS.cs
@@ -2,7 +2,6 @@
 using CoreGraphics;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using Uno.Disposables;
 using System.Text;
 using Uno;

--- a/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.iOS.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Drawing;
 using Uno.UI.Views.Controls;
 using Windows.UI.Xaml;
 using Uno.Extensions;

--- a/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Panel/Panel.macOS.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Drawing;
 using Windows.UI.Xaml;
 using Uno.Extensions;
 using Uno.Logging;

--- a/src/Uno.UI/UI/Xaml/Shapes/Rectangle.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/Rectangle.iOS.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Text;
 using Windows.UI.Xaml.Media;
 using Uno.Extensions;
@@ -75,13 +74,13 @@ namespace Windows.UI.Xaml.Shapes
 					break;
 				case Stretch.Uniform:
 					area = (area.Height > area.Width)
-						? (new RectangleF((float)area.X, (float)area.Y, (float)area.Width, (float)area.Width))
-						: (new RectangleF((float)area.X, (float)area.Y, (float)area.Height, (float)area.Height));
+						? (new global::System.Drawing.RectangleF((float)area.X, (float)area.Y, (float)area.Width, (float)area.Width))
+						: (new global::System.Drawing.RectangleF((float)area.X, (float)area.Y, (float)area.Height, (float)area.Height));
 					break;
 				case Stretch.UniformToFill:
 					area = (area.Height > area.Width)
-						? (new RectangleF((float)area.X, (float)area.Y, (float)area.Height, (float)area.Height))
-						: (new RectangleF((float)area.X, (float)area.Y, (float)area.Width, (float)area.Width));
+						? (new global::System.Drawing.RectangleF((float)area.X, (float)area.Y, (float)area.Height, (float)area.Height))
+						: (new global::System.Drawing.RectangleF((float)area.X, (float)area.Y, (float)area.Width, (float)area.Width));
 					break;
 			}
 


### PR DESCRIPTION
GitHub Issue (If applicable): #985

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Compilation fail in VS16.2 preview

## What is the new behavior?
Compilation does not fail, as System.Drawing.Brush is now available in Xamarin and conflicts with UWP type.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->