### PR TITLE
Adjust _CompileUnoJava dependencies for #986

### DIFF
--- a/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
+++ b/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
@@ -55,7 +55,9 @@
 	
 	<Import Project="..\Uno.CrossTargetting.props" />
 
-	<Target Name="_CompileUnoJavaCreateOutputs" BeforeTargets="Build">
+	<Target Name="_CompileUnoJavaCreateOutputs"
+					BeforeTargets="Build"
+					AfterTargets="Restore">
 		<!-- 
 		Create the EmbeddedJar itemgroup here so the Xamarin tooling picks it up, 
 		but in the obj folder so we dont have rebuild and git ignore issues.
@@ -74,7 +76,22 @@
 		<Delete Files="@(_JavaFilesToDelete)" />
 	</Target>
 
-	<Target Name="_CompileUnoJava" Condition="'$(DesignTimeBuild)' != 'true'" BeforeTargets="ExportJarToXml;GenerateBindings;_GetLibraryImports;ExportJarToXml" Inputs="@(_JavaFile)" Outputs="@(EmbeddedJar)" DependsOnTargets="_CompileUnoJavaCreateOutputs;@(XamarinBuildRestoreResources);_FillMsBuildVersion">
+	<ItemGroup>
+		<_CompileUnoJavaBeforeTargets Include="ExportJarToXml"/>
+		<_CompileUnoJavaBeforeTargets Include="GenerateBindings"/>
+		<_CompileUnoJavaBeforeTargets Include="_GetLibraryImports"/>
+		<_CompileUnoJavaBeforeTargets Include="ExportJarToXml"/>
+
+		<_CompileUnoJavaAfterTargets Include="_ExtractLibraryProjectImports"/> <!-- This target generates the \lp\**\classes.jar -->
+	</ItemGroup>
+
+	<Target Name="_CompileUnoJava"
+					Condition="'$(DesignTimeBuild)' != 'true'"
+					BeforeTargets="@(_CompileUnoJavaBeforeTargets)"
+					AfterTargets="@(_CompileUnoJavaAfterTargets)"
+					Inputs="@(_JavaFile)"
+					Outputs="@(EmbeddedJar)"
+					DependsOnTargets="_CompileUnoJavaCreateOutputs;@(XamarinBuildRestoreResources);_FillMsBuildVersion">
 	
 		<ItemGroup>
 			<_AndroidJar Include="%ProgramFiles(x86)%\Reference Assemblies\Microsoft\Framework\MonoAndroid\$(TargetFrameworkVersion)\mono.android.jar" />


### PR DESCRIPTION
GitHub Issue (If applicable): #986

## PR Type
What kind of change does this PR introduce?
- Bugfix


## What is the current behavior?
The binding helpers target ordering is not stable enough to work consistently with some VS versions,

## What is the new behavior?
Some more explicit target dependences have been added to avoid being in a condition where the `_CompileUnoJava` target is executed too early.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
