### PR TITLE
Enumerate a copy of the grid row/column subscriptions

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -71,6 +71,7 @@
 * MenuBar
     - Import of MenuBar code, not functional yet as MenuItemFlyout (Issue #801)
     - Basic support for macOS native system menus
+* Fix Grid.ColumnDefinitions.Clear exception (#1006)
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid.cs
@@ -1016,5 +1016,25 @@ namespace Uno.UI.Tests.GridTests
 			var measuredSize = SUT.DesiredSize;
 			SUT.Arrange(new Windows.Foundation.Rect(0, 0, 1000, 100));
 		}
+
+		[TestMethod]
+		public void When_Clear_ColumnDefinitions()
+		{
+			var SUT = new Grid();
+			SUT.ForceLoaded();
+
+			SUT.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+			SUT.ColumnDefinitions.Clear();
+		}
+
+		[TestMethod]
+		public void When_Clear_RowDefinitions()
+		{
+			var SUT = new Grid();
+			SUT.ForceLoaded();
+
+			SUT.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+			SUT.RowDefinitions.Clear();
+		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Grid/Grid.cs
@@ -224,7 +224,7 @@ namespace Windows.UI.Xaml.Controls
 			// Removed definitions
 			var definitionSet = new HashSet<T>(definitions, ReferenceEqualityComparer<T>.Default);
 
-			foreach (var existing in subcriptions)
+			foreach (var existing in subcriptions.ToArray())
 			{
 				if (!definitionSet.Contains(existing.Key))
 				{
@@ -237,7 +237,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private static void DisposeDefinitionsSubscriptions<T>(Dictionary<T, IDisposable> subcriptions)
 		{
-			foreach (var pair in subcriptions)
+			foreach (var pair in subcriptions.ToArray())
 			{
 				pair.Value.Dispose();
 			}


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #1006 

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Calling Grid.ColumnDefintions.Clear() throws an exception.

## What is the new behavior?
The Columns are cleared.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)