### PR TITLE
Ensure FrameworkElement.LayoutUpdated is invoked properly

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -122,9 +122,12 @@
 
         <Member fullName="System.Void Windows.UI.Xaml.Controls.ScrollViewer.set_BackgroundColor(Windows.UI.Color value)"
                 reason="This was a legacy mock done during initial Wasm POC, never implemented, never used." />
-        
+
         <Member fullName="System.Void Windows.UI.Xaml.Shapes.Rectangle.LayoutSubviews()"
                 reason="Removed to use ArrangeOverride for macOS compatibility"/>
+        
+        <Member fullName="System.Void Windows.UI.Xaml.FrameworkElement.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
 
       </Methods>
 

--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -125,8 +125,51 @@
 
         <Member fullName="System.Void Windows.UI.Xaml.Shapes.Rectangle.LayoutSubviews()"
                 reason="Removed to use ArrangeOverride for macOS compatibility"/>
+
+        <Member fullName="System.Void Windows.UI.Xaml.Shapes.Rectangle.LayoutSubviews()"
+                reason="Removed to use ArrangeOverride for macOS compatibility"/>
+
+        <Member fullName="System.Void Windows.UI.Xaml.StateTriggerBase.SetActive(System.Boolean isActive)"
+                reason="Aligned visiblity with UWP" />
+        <Member fullName="System.Void Windows.UI.Xaml.UIElement.set_RenderSize(Windows.Foundation.Size value)"
+                reason="Aligned visiblity with UWP" />
+
+        <Member fullName="System.Void Uno.UI.UnoViewGroup.set_IsPointerCaptured(System.Boolean value)"
+                reason="Aligned visiblity with UWP" />
         
         <Member fullName="System.Void Windows.UI.Xaml.FrameworkElement.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Windows.UI.Xaml.StateTriggerBase.SetActive(System.Boolean isActive)"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.Image.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.ProgressRing.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.ScrollContentPresenter.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.NativeListViewBase.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.NativePagedView.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.TextBoxView.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Uno.UI.Controls.Legacy.GridView.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Uno.UI.Controls.Legacy.HorizontalGridView.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Uno.UI.Controls.Legacy.HorizontalListView.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Uno.UI.Controls.Legacy.ListView.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Windows.UI.Xaml.Shapes.ArbitraryShapeBase.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.Picker.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.MultilineTextBoxView.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.SinglelineTextBoxView.OnLayoutUpdated()"
+                reason="Invalid method visibility"/>
+        <Member fullName="System.Void Uno.UI.Controls.Legacy.ListViewBase.OnLayoutUpdated()"
                 reason="Invalid method visibility"/>
 
       </Methods>

--- a/build/Uno.UI.Build.csproj
+++ b/build/Uno.UI.Build.csproj
@@ -198,7 +198,7 @@
 	</Target>
 
 	<Target Name="ValidatePackage" AfterTargets="UnoBuild" Condition="'$(BuildingInsideVisualStudio)'==''">
-		<Exec Command="dotnet tool install --global Uno.PackageDiff --version 1.0.0-dev.6" IgnoreExitCode="true" />
+		<Exec Command="dotnet tool install --global Uno.PackageDiff --version 1.0.0-dev.8" IgnoreExitCode="true" />
 		<Exec Command="generatepkgdiff --base=Uno.UI --other=Uno.UI.$(GITVERSION_FullSemVer).nupkg --diffignore=PackageDiffIgnore.xml --outfile=$(OutputDir)\ApiDiff.$(GITVERSION_FullSemVer).md" />
 	</Target>
 

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -71,6 +71,7 @@
 * MenuBar
     - Import of MenuBar code, not functional yet as MenuItemFlyout (Issue #801)
     - Basic support for macOS native system menus
+* Ensure FrameworkElement.LayoutUpdated is invoked on all elements being arranged
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.

--- a/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid.cs
+++ b/src/Uno.UI.Tests/Windows_UI_XAML_Controls/GridTests/Given_Grid.cs
@@ -1004,27 +1004,19 @@ namespace Uno.UI.Tests.GridTests
 		{
 			var SUT = new Grid();
 
-			SUT.ColumnDefinitions.Add(new ColumnDefinition { Width = "*" });
-			SUT.ColumnDefinitions.Add(new ColumnDefinition { Width = "auto" });
-
-			SUT.AddChild(new View { RequestedDesiredSize = new Windows.Foundation.Size(100, 100) });
-			SUT.AddChild(new View { RequestedDesiredSize = new Windows.Foundation.Size(100, 100) })
-				.GridPosition(0, 1)
-				.GridColumnSpan(3);
-
-			SUT.Measure(new Windows.Foundation.Size(1000, 100));
-			var measuredSize = SUT.DesiredSize;
-			SUT.Arrange(new Windows.Foundation.Rect(0, 0, 1000, 100));
+			SUT.ColumnDefinitions.Clear();
+			SUT.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+			SUT.ColumnDefinitions.Clear();
 		}
 
 		[TestMethod]
 		public void When_Clear_ColumnDefinitions()
 		{
 			var SUT = new Grid();
-			SUT.ForceLoaded();
 
-			SUT.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
 			SUT.ColumnDefinitions.Clear();
+			SUT.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+			SUT.ColumnDefinitions.Clear(); //Throws System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
 		}
 
 		[TestMethod]

--- a/src/Uno.UI.Tests/Windows_UI_Xaml/FrameworkElementTests/Given_FrameworkElement.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml/FrameworkElementTests/Given_FrameworkElement.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Windows.UI.Xaml.Controls;
+
+namespace Uno.UI.Tests.Windows_UI_Xaml.FrameworkElementTests
+{
+	[TestClass]
+	public class Given_FrameworkElement
+	{
+		[TestMethod]
+		public void When_LayoutUpdated()
+		{
+			var SUT = new Grid();
+
+			var item1 = new Border();
+
+			var sutLayoutUpdatedCount = 0;
+
+			SUT.LayoutUpdated += delegate {
+				sutLayoutUpdatedCount ++;
+			};
+
+			var item1LayoutUpdatedCount = 0;
+			item1.LayoutUpdated += delegate
+			{
+				item1LayoutUpdatedCount++;
+			};
+
+			SUT.Children.Add(item1);
+
+			SUT.Measure(new Windows.Foundation.Size(1, 1));
+			SUT.Arrange(new Windows.Foundation.Rect(0, 0, 1, 1));
+
+			Assert.AreEqual(1, sutLayoutUpdatedCount);
+			Assert.AreEqual(1, item1LayoutUpdatedCount);
+
+			SUT.Measure(new Windows.Foundation.Size(2, 2));
+			SUT.Arrange(new Windows.Foundation.Rect(0, 0, 2, 2));
+
+			Assert.AreEqual(2, sutLayoutUpdatedCount);
+			Assert.AreEqual(2, item1LayoutUpdatedCount);
+		}
+	}
+}

--- a/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/Generated/3.0.0.0/Windows.UI.Xaml/FrameworkElement.cs
@@ -654,7 +654,7 @@ namespace Windows.UI.Xaml
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.DataContextProperty.get
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.StyleProperty.get
 		// Forced skipping of method Windows.UI.Xaml.FrameworkElement.FlowDirectionProperty.get
-		#if false || false || NET461 || __WASM__ || false
+		#if false || false || false || false || false
 		[global::Uno.NotImplemented]
 		public  event global::System.EventHandler<object> LayoutUpdated
 		{

--- a/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Layouter/Layouter.cs
@@ -130,6 +130,11 @@ namespace Windows.UI.Xaml.Controls
 				}
 
 				ArrangeOverride(finalRect.Size);
+
+				if (_element is FrameworkElement fe)
+				{
+					fe.OnLayoutUpdated();
+				}
 			}
 		}
 
@@ -303,6 +308,11 @@ namespace Windows.UI.Xaml.Controls
 		/// <param name="frame">The rectangle to use, in Logical position</param>
 		public void ArrangeChild(View view, Rect frame)
 		{
+			ArrangeChild(view, frame, true);
+		}
+
+		internal void ArrangeChild(View view, Rect frame, bool raiseLayoutUpdated)
+		{
 			if ((view as IFrameworkElement)?.Visibility == Visibility.Collapsed)
 			{
 				return;
@@ -310,6 +320,11 @@ namespace Windows.UI.Xaml.Controls
 			frame = ApplyMarginAndAlignments(view, frame);
 
 			ArrangeChildOverride(view, frame);
+
+			if (raiseLayoutUpdated && view is FrameworkElement fe)
+			{
+				fe?.OnLayoutUpdated();
+			}
 		}
 
 		private void LogArrange(View view, Rect frame)

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.Android.cs
@@ -277,7 +277,6 @@ namespace Windows.UI.Xaml
 
 				_layouter.Arrange(new Rect(0, 0, newSize.Width, newSize.Height));
 
-				OnLayoutUpdated();
 				OnAfterArrange();
 			}
 

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.cs
@@ -179,7 +179,7 @@ namespace Windows.UI.Xaml
 		public override void Arrange(Rect finalRect)
 		{
 			_layouter.Arrange(finalRect);
-			_layouter.ArrangeChild(this, finalRect);
+			_layouter.ArrangeChild(this, finalRect, raiseLayoutUpdated: false);
 		}
 #endif
 
@@ -423,6 +423,13 @@ namespace Windows.UI.Xaml
 		internal bool GoToElementState(string stateName, bool useTransitions) => GoToElementStateCore(stateName, useTransitions);
 
 		protected virtual bool GoToElementStateCore(string stateName, bool useTransitions) => false;
+
+		public event EventHandler<object> LayoutUpdated;
+
+		internal virtual void OnLayoutUpdated()
+		{
+			LayoutUpdated?.Invoke(this, RoutedEventArgs.Empty);
+		}
 
 #if XAMARIN
 		private static FrameworkElement FindPhaseEnabledRoot(ContentControl content)

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.iOS.cs
@@ -56,7 +56,6 @@ namespace Windows.UI.Xaml
 					var size = SizeFromUISize(Bounds.Size);
 					_layouter.Arrange(new Rect(0, 0, size.Width, size.Height));
 
-					OnLayoutUpdated();
 					OnAfterArrange();
 				}
 				finally

--- a/src/Uno.UI/UI/Xaml/FrameworkElement.macOS.cs
+++ b/src/Uno.UI/UI/Xaml/FrameworkElement.macOS.cs
@@ -59,7 +59,6 @@ namespace Windows.UI.Xaml
 					var size = SizeFromUISize(Bounds.Size);
 					_layouter.Arrange(new Rect(0, 0, size.Width, size.Height));
 
-					OnLayoutUpdated();
 					OnAfterArrange();
 				}
 				finally

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
@@ -93,7 +93,7 @@ namespace <#= mixin.NamespaceName #>
 
 		public event EventHandler<object> LayoutUpdated;
 
-		protected virtual void OnLayoutUpdated()
+		internal virtual void OnLayoutUpdated()
 		{
 			if (LayoutUpdated != null)
 			{

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.Android.tt
@@ -47,8 +47,6 @@ namespace <#= mixin.NamespaceName #>
 
 		public event RoutedEventHandler Unloaded;
 
-		public event EventHandler<object> LayoutUpdated;
-
 		public event SizeChangedEventHandler SizeChanged;
 
 		public IFrameworkElement FindName(string name)
@@ -92,6 +90,16 @@ namespace <#= mixin.NamespaceName #>
 
 		// This is also defined in UIElement for actual UIElement hierarchy
 		internal bool IsRenderingSuspended { get; set; }
+
+		public event EventHandler<object> LayoutUpdated;
+
+		protected virtual void OnLayoutUpdated()
+		{
+			if (LayoutUpdated != null)
+			{
+				LayoutUpdated(this, RoutedEventArgs.Empty);
+			}
+		}
 #endif
 
 		internal void SuspendRendering()
@@ -830,14 +838,6 @@ namespace <#= mixin.NamespaceName #>
 		}
 
 		partial void OnUnloadedPartial();
-
-		protected virtual void OnLayoutUpdated()
-		{
-			if (LayoutUpdated != null)
-			{
-				LayoutUpdated(this, RoutedEventArgs.Empty);
-			}
-		}
 
 		private static void OnGenericPropertyUpdated(object dependencyObject, DependencyPropertyChangedEventArgs args)
 		{

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
@@ -484,7 +484,7 @@ namespace <#= mixin.NamespaceName #>
 
 		public event EventHandler<object> LayoutUpdated;
 
-		public virtual void OnLayoutUpdated ()
+		internal virtual void OnLayoutUpdated ()
 		{
 			if (LayoutUpdated != null) {
 				LayoutUpdated (this, EventArgs.Empty);

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.iOS.tt
@@ -159,8 +159,6 @@ namespace <#= mixin.NamespaceName #>
 
 		public event RoutedEventHandler Unloaded;
 
-		public event EventHandler<object> LayoutUpdated;
-
 		public event SizeChangedEventHandler SizeChanged;
 		
 #if <#= mixin.DefineLayoutSubviews #> || <#= mixin.DefineSetNeedsLayout #>
@@ -204,14 +202,6 @@ namespace <#= mixin.NamespaceName #>
 			if (actualSuperview != null)
 			{
 				actualSuperview.SetNeedsLayout();
-			}
-		}
-
-
-		public virtual void OnLayoutUpdated ()
-		{
-			if (LayoutUpdated != null) {
-				LayoutUpdated (this, EventArgs.Empty);
 			}
 		}
 
@@ -491,6 +481,16 @@ namespace <#= mixin.NamespaceName #>
 		public Rect AppliedFrame { get; private set; }
 
 #if !<#= mixin.IsFrameworkElement #>
+
+		public event EventHandler<object> LayoutUpdated;
+
+		public virtual void OnLayoutUpdated ()
+		{
+			if (LayoutUpdated != null) {
+				LayoutUpdated (this, EventArgs.Empty);
+			}
+		}
+
 		// This is also defined in UIElement for actual UIElement hierarchy
 		internal bool IsRenderingSuspended { get; set; }
 

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
@@ -470,7 +470,7 @@ namespace <#= mixin.NamespaceName #>
 #if !<#= mixin.IsFrameworkElement #>
 		public event EventHandler<object> LayoutUpdated;
 
-		public virtual void OnLayoutUpdated ()
+		internal virtual void OnLayoutUpdated ()
 		{
 			if (LayoutUpdated != null) {
 				LayoutUpdated (this, EventArgs.Empty);

--- a/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
+++ b/src/Uno.UI/UI/Xaml/IFrameworkElementImplementation.macOS.tt
@@ -153,8 +153,6 @@ namespace <#= mixin.NamespaceName #>
 
 		public event RoutedEventHandler Unloaded;
 
-		public event EventHandler<object> LayoutUpdated;
-
 		public event SizeChangedEventHandler SizeChanged;
 		
 #if <#= mixin.DefineLayoutSubviews #> || <#= mixin.DefineSetNeedsLayout #>
@@ -200,14 +198,6 @@ namespace <#= mixin.NamespaceName #>
 			if (actualSuperview != null)
 			{
 				actualSuperview.NeedsLayout = true;
-			}
-		}
-
-
-		public virtual void OnLayoutUpdated ()
-		{
-			if (LayoutUpdated != null) {
-				LayoutUpdated (this, EventArgs.Empty);
 			}
 		}
 
@@ -478,6 +468,15 @@ namespace <#= mixin.NamespaceName #>
 		public Rect AppliedFrame { get; private set; }
 
 #if !<#= mixin.IsFrameworkElement #>
+		public event EventHandler<object> LayoutUpdated;
+
+		public virtual void OnLayoutUpdated ()
+		{
+			if (LayoutUpdated != null) {
+				LayoutUpdated (this, EventArgs.Empty);
+			}
+		}
+
 		// This is also defined in UIElement for actual UIElement hierarchy
 		internal bool IsRenderingSuspended { get; set; }
 

--- a/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.iOSmacOS.cs
+++ b/src/Uno.UI/UI/Xaml/Shapes/ArbitraryShapeBase.iOSmacOS.cs
@@ -41,7 +41,7 @@ namespace Windows.UI.Xaml.Shapes
 
 		protected abstract CGPath GetPath();
 
-		public override void OnLayoutUpdated()
+		internal override void OnLayoutUpdated()
 		{
 			base.OnLayoutUpdated();
 			var size = SizeFromUISize(Bounds.Size);


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
`FrameworkElement.LayoutUpdated` is not raised on all elements being arranged, and is not available on Wasm.

## What is the new behavior?
`FrameworkElement.LayoutUpdated` is invoked on all arranged elements.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
