### PR TITLE
Adjust owner type of MenuFlyout.Items property

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.cs
@@ -55,7 +55,7 @@ namespace Windows.UI.Xaml.Controls
 			DependencyProperty.Register(
 				"Items",
 				typeof(IList<MenuFlyoutItemBase>),
-				typeof(MenuFlyoutItem),
+				typeof(MenuFlyout),
 				new PropertyMetadata(defaultValue: null)
 			);
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Debugging an application that uses `MenuFlyout.Items` fails with :
```
System.InvalidOperationException: The Dependency Property [Items] is owned by [Windows.UI.Xaml.Controls.MenuFlyoutItem] and cannot be used on [Windows.UI.Xaml.Controls.MenuFlyout]
```

## What is the new behavior?
The application does not fail.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
