### PR TITLE
[Wasm] Align Window.SizeChanged and ApplicationView.VisibleBoundsChanged ordering with UWP

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -71,7 +71,6 @@
 * MenuBar
     - Import of MenuBar code, not functional yet as MenuItemFlyout (Issue #801)
     - Basic support for macOS native system menus
-* Fix Grid.ColumnDefinitions.Clear exception (#1006)
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.
@@ -126,6 +125,8 @@
 * Fix a potential crash during code generated from XAML, content were not properly escaped.
 * #977 Fix exception when setting MediaPlayerElement.Stretch in XAML.
 * [Android] Fix MediaPlayerElement.Stretch not applied
+* Fix Grid.ColumnDefinitions.Clear exception (#1006)
+* [Wasm] Align Window.SizeChanged and ApplicationView.VisibleBoundsChanged ordering with UWP (#1015)
 
 ## Release 1.44.0
 

--- a/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
+++ b/src/Uno.UI/Behaviors/VisibleBoundsPadding.cs
@@ -11,6 +11,8 @@ using Windows.Foundation;
 using Windows.UI.ViewManagement;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using Microsoft.Extensions.Logging;
+
 #if XAMARIN_IOS
 using UIKit;
 #elif __MACOS__
@@ -48,6 +50,12 @@ namespace Uno.UI.Toolkit
 	public static class VisibleBoundsPadding
 #endif
 	{
+#if IS_UNO
+		private static readonly Lazy<ILogger> _log = new Lazy<ILogger>(() => typeof(InternalVisibleBoundsPadding).Log());
+#else
+		private static readonly Lazy<ILogger> _log = new Lazy<ILogger>(() => typeof(VisibleBoundsPadding).Log());
+#endif
+
 		[Flags]
 		public enum PaddingMask
 		{
@@ -69,7 +77,14 @@ namespace Uno.UI.Toolkit
 			{
 				var visibleBounds = ApplicationView.GetForCurrentView().VisibleBounds;
 				var bounds = Window.Current.Bounds;
-				return new Thickness(visibleBounds.Left - bounds.Left, visibleBounds.Top - bounds.Top, bounds.Right - visibleBounds.Right, bounds.Bottom - visibleBounds.Bottom);
+				var result = new Thickness(visibleBounds.Left - bounds.Left, visibleBounds.Top - bounds.Top, bounds.Right - visibleBounds.Right, bounds.Bottom - visibleBounds.Bottom);
+
+				if (_log.Value.IsEnabled(LogLevel.Debug))
+				{
+					_log.Value.LogDebug($"WindowPadding={result} bounds={bounds} visibleBounds={visibleBounds}");
+				}
+
+				return result;
 			}
 		}
 
@@ -257,6 +272,11 @@ namespace Uno.UI.Toolkit
 
 				if (property != null)
 				{
+					if (_log.Value.IsEnabled(LogLevel.Debug))
+					{
+						_log.Value.LogDebug($"ApplyPadding={padding}");
+					}
+
 					Owner.SetValue(property, padding);
 				}
 			}

--- a/src/Uno.UI/UI/Xaml/Window.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Window.wasm.cs
@@ -105,9 +105,6 @@ namespace Windows.UI.Xaml
 		{
 			var newBounds = new Rect(0, 0, size.Width, size.Height);
 
-			// TODO: support for "viewport-fix" on devices with a notch.
-			ApplicationView.GetForCurrentView()?.SetVisibleBounds(newBounds);
-
 			if (newBounds != Bounds)
 			{
 				if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
@@ -119,6 +116,12 @@ namespace Windows.UI.Xaml
 
 				DispatchInvalidateMeasure();
 				RaiseSizeChanged(new WindowSizeChangedEventArgs(size));
+
+				// Note that UWP raises the ApplicationView.VisibleBoundsChanged event
+				// *after* Window.SizeChanged.
+
+				// TODO: support for "viewport-fix" on devices with a notch.
+				ApplicationView.GetForCurrentView()?.SetVisibleBounds(newBounds);
 			}
 		}
 


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #1015
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
Resizing the browser window could result in invalid calculations that use `ApplicationView.VisibleBounds` and `Window.Bounds` simultaneously while being in a `ApplicationView.VisibleBoundsChanged` handler. 

This makes the `VisibleBoundsPadding` behavior fail when resizing the window, making controls such as the `NavigationView` appear blank.

## What is the new behavior?
The ordering of the `Window.SizeChanged` and `ApplicationView.VisibleBoundsChanged` is now aligned with UWP.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
