### PR TITLE
Add known solution filters to ease the devloop

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -127,6 +127,7 @@
 * [Android] Fix MediaPlayerElement.Stretch not applied
 * Fix Grid.ColumnDefinitions.Clear exception (#1006)
 * [Wasm] Align Window.SizeChanged and ApplicationView.VisibleBoundsChanged ordering with UWP (#1015)
+* Add VS2019 Solution Filters for known developer tasks
 
 ## Release 1.44.0
 

--- a/src/Uno.UI-Android-only.slnf
+++ b/src/Uno.UI-Android-only.slnf
@@ -1,0 +1,19 @@
+{
+  "solution": {
+    "path": "Uno.UI.sln",
+    "projects": [
+      "AddIns\\Uno.UI.Lottie\\Uno.UI.Lottie.csproj",
+      "SamplesApp\\SamplesApp.Droid\\SamplesApp.Droid.csproj",
+      "SamplesApp\\SamplesApp.Shared\\SamplesApp.Shared.shproj",
+      "SamplesApp\\SamplesApp.UnitTests.Shared\\SamplesApp.UnitTests.Shared.shproj",
+      "SamplesApp\\UITests.Shared\\UITests.Shared.shproj",
+      "Uno.Foundation\\Uno.Foundation.csproj",
+      "Uno.UI.BindingHelper.Android\\Uno.UI.BindingHelper.Android.csproj",
+      "Uno.UI.Maps\\Uno.UI.Maps.csproj",
+      "Uno.UI.RuntimeTests\\Uno.UI.RuntimeTests.csproj",
+      "Uno.UI.Toolkit\\Uno.UI.Toolkit.csproj",
+      "Uno.UI\\Uno.UI.csproj",
+      "Uno.UWP\\Uno.csproj"
+    ]
+  }
+}

--- a/src/Uno.UI-UnitTests-only.slnf
+++ b/src/Uno.UI-UnitTests-only.slnf
@@ -1,0 +1,15 @@
+{
+  "solution": {
+    "path": "Uno.UI.sln",
+    "projects": [
+      "SourceGenerators\\System.Xaml.Tests\\Uno.Xaml.Tests.csproj",
+      "SourceGenerators\\System.Xaml\\Uno.Xaml.csproj",
+      "SourceGenerators\\Uno.UI.SourceGenerators\\Uno.UI.SourceGenerators.csproj",
+      "SourceGenerators\\Uno.UI.Tasks\\Uno.UI.Tasks.csproj",
+      "Uno.Foundation\\Uno.Foundation.csproj",
+      "Uno.UI.Tests\\Uno.UI.Tests.csproj",
+      "Uno.UI\\Uno.UI.csproj",
+      "Uno.UWP\\Uno.csproj"
+    ]
+  }
+}

--- a/src/Uno.UI-Wasm-only.slnf
+++ b/src/Uno.UI-Wasm-only.slnf
@@ -1,0 +1,20 @@
+{
+  "solution": {
+    "path": "Uno.UI.sln",
+    "projects": [
+      "AddIns\\Uno.UI.Lottie\\Uno.UI.Lottie.csproj",
+      "SamplesApp\\Benchmarks.Shared\\SamplesApp.Benchmarks.shproj",
+      "SamplesApp\\SamplesApp.Shared\\SamplesApp.Shared.shproj",
+      "SamplesApp\\SamplesApp.UnitTests.Shared\\SamplesApp.UnitTests.Shared.shproj",
+      "SamplesApp\\SamplesApp.Wasm\\SamplesApp.Wasm.csproj",
+      "SamplesApp\\UITests.Shared\\UITests.Shared.shproj",
+      "Uno.Foundation\\Uno.Foundation.csproj",
+      "Uno.UI.RuntimeTests\\Uno.UI.RuntimeTests.csproj",
+      "Uno.UI.Toolkit\\Uno.UI.Toolkit.csproj",
+      "Uno.UI.Wasm.Tests\\Uno.UI.Wasm.Tests.csproj",
+      "Uno.UI.Wasm\\Uno.UI.Wasm.csproj",
+      "Uno.UI\\Uno.UI.csproj",
+      "Uno.UWP\\Uno.csproj"
+    ]
+  }
+}

--- a/src/Uno.UI-Windows-only.slnf
+++ b/src/Uno.UI-Windows-only.slnf
@@ -1,0 +1,14 @@
+{
+  "solution": {
+    "path": "Uno.UI.sln",
+    "projects": [
+      "SamplesApp\\Benchmarks.Shared\\SamplesApp.Benchmarks.shproj",
+      "SamplesApp\\SamplesApp.Shared\\SamplesApp.Shared.shproj",
+      "SamplesApp\\SamplesApp.UWP\\SamplesApp.UWP.csproj",
+      "SamplesApp\\SamplesApp.UnitTests.Shared\\SamplesApp.UnitTests.Shared.shproj",
+      "SamplesApp\\UITests.Shared\\UITests.Shared.shproj",
+      "Uno.UI.RuntimeTests\\Uno.UI.RuntimeTests.csproj",
+      "Uno.UI.Toolkit\\Uno.UI.Toolkit.csproj"
+    ]
+  }
+}

--- a/src/Uno.UI-iOS-only.slnf
+++ b/src/Uno.UI-iOS-only.slnf
@@ -1,0 +1,18 @@
+{
+  "solution": {
+    "path": "Uno.UI.sln",
+    "projects": [
+      "AddIns\\Uno.UI.Lottie\\Uno.UI.Lottie.csproj",
+      "SamplesApp\\SamplesApp.Shared\\SamplesApp.Shared.shproj",
+      "SamplesApp\\SamplesApp.UnitTests.Shared\\SamplesApp.UnitTests.Shared.shproj",
+      "SamplesApp\\SamplesApp.iOS\\SamplesApp.iOS.csproj",
+      "SamplesApp\\UITests.Shared\\UITests.Shared.shproj",
+      "Uno.Foundation\\Uno.Foundation.csproj",
+      "Uno.UI.Maps\\Uno.UI.Maps.csproj",
+      "Uno.UI.RuntimeTests\\Uno.UI.RuntimeTests.csproj",
+      "Uno.UI.Toolkit\\Uno.UI.Toolkit.csproj",
+      "Uno.UI\\Uno.UI.csproj",
+      "Uno.UWP\\Uno.csproj"
+    ]
+  }
+}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Build or CI related changes 


## What is the current behavior?
Loading the Uno.UI can take a significant time, which ever the current task at hand.

## What is the new behavior?
Added a set of `slnf` solution filters to speed up visual studio's loading time for known tasks (iOS, Android, Wasm, etc...). See [this for more details](https://docs.microsoft.com/en-us/visualstudio/ide/filtered-solutions?view=vs-2019).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
