### PR TITLE
Fix to iOS MediaPlayer breaking at applystretch

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -127,6 +127,7 @@
 * [Android] Fix MediaPlayerElement.Stretch not applied
 * Fix Grid.ColumnDefinitions.Clear exception (#1006)
 * [Wasm] Align Window.SizeChanged and ApplicationView.VisibleBoundsChanged ordering with UWP (#1015)
+* #154969 [iOS] MediaPlayer ApplyStretch breaking mediaplayer- fixed
 
 ## Release 1.44.0
 

--- a/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MediaPlayer/MediaPlayerPresenter.iOS.cs
@@ -17,12 +17,12 @@ namespace Windows.UI.Xaml.Controls
 		
 		private void OnStretchChanged(Stretch newValue, Stretch oldValue)
 		{
-			ApplyStretch();
+			ApplyStretch(newValue);
 		}
 
-		internal void ApplyStretch()
+		internal void ApplyStretch(Stretch stretchValue = null)
 		{
-			switch (Stretch)
+			switch (stretchValue?? Stretch)
 			{
 				case Stretch.Uniform:
 					MediaPlayer.UpdateVideoGravity(AVLayerVideoGravity.ResizeAspect);
@@ -38,7 +38,7 @@ namespace Windows.UI.Xaml.Controls
 					break;
 
 				default:
-					throw new NotSupportedException($"Stretch mode {Stretch} is not supported");
+					throw new NotSupportedException($"Stretch mode {stretchValue?? Stretch} is not supported");
 			}
 		}
 	}


### PR DESCRIPTION
##GitHub Issue (If applicable): #
#1022 

## PR Type
What kind of change does this PR introduce?
 Bugfix 


## What is the current behavior?
iOS MediaPlayer not initializing/breaking at applystretch


## What is the new behavior?
iOS Mediaplayer works 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
- [x] Tested in Parkland

Internal Issue (If applicable):
#154969
