### PR TITLE
Fix to iOS MediaPlayer breaking from nullref

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -127,6 +127,7 @@
 * [Android] Fix MediaPlayerElement.Stretch not applied
 * Fix Grid.ColumnDefinitions.Clear exception (#1006)
 * [Wasm] Align Window.SizeChanged and ApplicationView.VisibleBoundsChanged ordering with UWP (#1015)
+* #154969 [iOS] MediaPlayer ApplyStretch breaking mediaplayer- fixed
 
 ## Release 1.44.0
 

--- a/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
+++ b/src/Uno.UWP/Media/Playback/MediaPlayer.iOS.cs
@@ -397,7 +397,10 @@ namespace Windows.Media.Playback
 
 		internal void UpdateVideoGravity(AVLayerVideoGravity gravity)
 		{
-			_videoLayer.VideoGravity = gravity;
+			if (_videoLayer != null)
+			{
+				_videoLayer.VideoGravity = gravity;
+			}
 		}
 
 		protected override void Dispose(bool disposing)


### PR DESCRIPTION
GitHub Issue (If applicable): #
#1022 

## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
iOS MediaPlayer not breaking at applystretch -> videolayer is null when changing gravity


## What is the new behavior?
iOS Mediaplayer works


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
#154969
