### PR TITLE
fixed xaml generated enum value not being globalized

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -131,6 +131,7 @@
 * Add VS2019 Solution Filters for known developer tasks
 * #154969 [iOS] MediaPlayer ApplyStretch breaking mediaplayer- fixed
 * 154815 [WASM] ItemClick event could be raised for wrong item
+* 155256 Fixed xaml generated enum value not being globalized
 
 ## Release 1.44.0
 

--- a/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
+++ b/src/SourceGenerators/Uno.UI.SourceGenerators/XamlGenerator/XamlFileGenerator.cs
@@ -2579,7 +2579,7 @@ namespace Uno.UI.SourceGenerators.XamlGenerator
 				}
 
 				var finalFlags = validFlags.Intersect(actualFlags, StringComparer.OrdinalIgnoreCase);
-				return string.Join("|", finalFlags.Select(flag => $"{propertyType.ToDisplayString()}.{flag}"));
+				return string.Join("|", finalFlags.Select(flag => $"{propertyType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}.{flag}"));
 			}
 
 			var hasImplictToString = propertyType

--- a/src/SourceGenerators/XamlGenerationTests/EnumValueNamespaceTest.xaml
+++ b/src/SourceGenerators/XamlGenerationTests/EnumValueNamespaceTest.xaml
@@ -1,0 +1,8 @@
+﻿<Page x:Class="XamlGenerationTests.Shared.NamespaceClashPoint.EnumValueNamespaceTest"
+	  xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	  xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	  xmlns:local="using:XamlGenerationTests.Shared.NamespaceClashPoint"
+	  xmlns:example="using:NamespaceClashPoint.Example">
+
+	<Grid example:GridAsdHelper.Asd="A" />
+</Page>

--- a/src/SourceGenerators/XamlGenerationTests/EnumValueNamespaceTest.xaml.cs
+++ b/src/SourceGenerators/XamlGenerationTests/EnumValueNamespaceTest.xaml.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Controls.Primitives;
+using Windows.UI.Xaml.Data;
+using Windows.UI.Xaml.Input;
+using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Navigation;
+
+// The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
+
+namespace XamlGenerationTests.Shared.NamespaceClashPoint
+{
+	/// <summary>
+	/// An empty page that can be used on its own or navigated to within a Frame.
+	/// </summary>
+	public sealed partial class EnumValueNamespaceTest : Page
+	{
+		public EnumValueNamespaceTest()
+		{
+			this.InitializeComponent();
+		}
+	}
+}
+
+namespace NamespaceClashPoint.Example
+{
+	public enum Asd { A, S, D }
+
+	public static class GridAsdHelper
+	{
+		#region Property: Asd
+		public static readonly DependencyProperty AsdProperty = DependencyProperty.RegisterAttached(
+			"Asd",
+			typeof(Asd),
+			typeof(GridAsdHelper),
+			new PropertyMetadata(default(Asd)));
+
+		public static Asd GetAsd(Grid obj) => (Asd)obj.GetValue(AsdProperty);
+		public static void SetAsd(Grid obj, Asd value) => obj.SetValue(AsdProperty, value);
+		#endregion
+	}
+}


### PR DESCRIPTION
GitHub Issue (If applicable): #n/a

## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
Source generator doesn't prefix enum value with `global::`.

## What is the new behavior?
Source generator now prefixes enum value with `global::`.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
Given this xaml file:
```xaml
<Page x:Class="XamlGenerationTests.Shared.NamespaceClashPoint.EnumValueNamespaceTest"
      xmlns:example="using:NamespaceClashPoint.Example">
    <Grid example:GridAsdHelper.Asd="A" />
```
The source generator would output:
```cs
namespace XamlGenerationTests.Shared.NamespaceClashPoint {
	public sealed partial class EnumValueNamespaceTest : Windows.UI.Xaml.Controls.Page {
		private void InitializeComponent() {
			Content = new global::Windows.UI.Xaml.Controls.Grid { }
			.EnumValueNamespaceTest_0f7eb0893c9244b809db49bed5ffe362_XamlApply((EnumValueNamespaceTest_0f7eb0893c9244b809db49bed5ffe362XamlApplyExtensions.XamlApplyHandler0)(c0 => 
			{
				global::NamespaceClashPoint.Example.GridAsdHelper.SetAsd(c0, NamespaceClashPoint.Example.Asd.A);
```
And, `NamespaceClashPoint.Example...` will never be found because `XamlGenerationTests.Shared.NamespaceClashPoint.Example` never existed.

Internal Issue (If applicable):
https://feedback.nventive.com/communities/1/topics/3511-the-type-or-namespace-name-ui-does-not-exist-in-the-namespace-umbrellaviewsamplesuno