### PR TITLE
fixed keyboard flicker when backing from a page with CommandBar

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -133,6 +133,7 @@
 * #154969 [iOS] MediaPlayer ApplyStretch breaking mediaplayer- fixed
 * 154815 [WASM] ItemClick event could be raised for wrong item
 * 155256 Fixed xaml generated enum value not being globalized
+* 155161 [Android] fixed keyboard flicker when backing from a page with CommandBar
 
 ## Release 1.44.0
 

--- a/src/Uno.UI/Controls/CommandBarRenderer.Android.cs
+++ b/src/Uno.UI/Controls/CommandBarRenderer.Android.cs
@@ -20,6 +20,8 @@ using Android.App;
 using Uno.Extensions;
 using Uno.Logging;
 using Microsoft.Extensions.Logging;
+using Android.Views.InputMethods;
+using Android.Content;
 
 namespace Uno.UI.Controls
 {
@@ -264,7 +266,7 @@ namespace Uno.UI.Controls
 
 		private void Native_MenuItemClick(object sender, Toolbar.MenuItemClickEventArgs e)
 		{
-			ClearCurrentFocus();
+			CloseKeyboard();
 
 			var hashCode = e.Item.ItemId;
 			var appBarButton = Element.PrimaryCommands
@@ -277,7 +279,7 @@ namespace Uno.UI.Controls
 
 		private void Native_NavigationClick(object sender, Toolbar.NavigationClickEventArgs e)
 		{
-			ClearCurrentFocus();
+			CloseKeyboard();
 
 			var navigationCommand = Element.GetValue(NavigationCommandProperty) as AppBarButton;
 			if (navigationCommand != null)
@@ -290,11 +292,12 @@ namespace Uno.UI.Controls
 			}
 		}
 
-		private void ClearCurrentFocus()
+		private void CloseKeyboard()
 		{
 			if ((ContextHelper.Current as Activity)?.CurrentFocus is View focused)
 			{
-				focused.ClearFocus();
+				var imm = (InputMethodManager)ContextHelper.Current.GetSystemService(Context.InputMethodService);
+				imm.HideSoftInputFromWindow(focused.WindowToken, HideSoftInputFlags.None);
 			}
 		}
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): #n/a

## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
On **android**, using the back button on the `CommandBar` with the soft keyboard closed will cause the keyboard to flicker.

## What is the new behavior?
No flickering.

## PR Checklist
Please check if your PR fulfills the following requirements:
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
This is a regression from #847. In that PR, I attempted to forced close the keyboard when an `AppBarButton` is pressed by clearing focus from the currently focused view. In doing so, we gave chance to other view on that page to take the focus. This causes the keyboard to open, only to be closed immediately because we are navigating away from that page.

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/155161