### PR TITLE
use nameof(backingproperty) so that references show up in visual studio

### DIFF
--- a/src/Uno.UWPSyncGenerator/Generator.cs
+++ b/src/Uno.UWPSyncGenerator/Generator.cs
@@ -586,7 +586,7 @@ namespace Uno.UWPSyncGenerator
 			};
 
 			string[] skipBaseTypes = new[] {
-				
+
 				// skipped because of legacy mismatched hierarchy
 				"Windows.UI.Xaml.FrameworkElement",
 				"Windows.UI.Xaml.UIElement",
@@ -925,7 +925,7 @@ namespace Uno.UWPSyncGenerator
 			{
 				switch (method.Name)
 				{
-					// The base type does not match for this parameter until Uno adjusts the 
+					// The base type does not match for this parameter until Uno adjusts the
 					// hierarchy based on IFrameworkElement.
 					case "SetRow":
 					case "SetRowSpan":
@@ -1156,7 +1156,7 @@ namespace Uno.UWPSyncGenerator
 
 								b.AppendLineInvariant($"Windows.UI.Xaml.DependencyProperty.Register{attachedModifier}(");
 
-								b.AppendLineInvariant($"\t\"{propertyName}\", typeof({propertyDisplayType}), ");
+								b.AppendLineInvariant($"\tnameof({propertyName})\", typeof({propertyDisplayType}), ");
 								b.AppendLineInvariant($"\ttypeof({property.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)}), ");
 								b.AppendLineInvariant($"\tnew FrameworkPropertyMetadata(default({propertyDisplayType})));");
 							}
@@ -1444,7 +1444,7 @@ namespace Uno.UWPSyncGenerator
 			{
 				// In this case, this may mean that Rolsyn failed to execute some msbuild task that loads the
 				// references in a UWA project (or NuGet 3.0+ with project.json, more specifically). For these
-				// projects, references are materialized through a task using a output parameter that injects 
+				// projects, references are materialized through a task using a output parameter that injects
 				// "References" nodes. If this task fails, no references are loaded, and simple type resolution
 				// such "int?" may fail.
 
@@ -1521,7 +1521,7 @@ namespace Uno.UWPSyncGenerator
 				}
 
 				// Lookup for the highest version matching assembly in the current app domain.
-				// There may be an existing one that already matches, even though the 
+				// There may be an existing one that already matches, even though the
 				// fusion loader did not find an exact match.
 				var loadedAsm = (
 									from asm in AppDomain.CurrentDomain.GetAssemblies()


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type
What kind of change does this PR introduce?

- Refactoring (no functional changes, no api changes) 


## What is the current behavior?

```
		public static DependencyProperty PlaceholderValueProperty { get; } =
			DependencyProperty.Register(
				"PlaceholderValue", typeof(double),
				typeof(RatingControl),
				new FrameworkPropertyMetadata(-1.0, OnStaticPropertyChanged));
```

## What is the new behavior?

```
		public static DependencyProperty PlaceholderValueProperty { get; } =
			DependencyProperty.Register(
				nameof(PlaceholderValue), typeof(double),
				typeof(RatingControl),
				new FrameworkPropertyMetadata(-1.0, OnStaticPropertyChanged));
```

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

## Other information

I did this edit in the GitHub editor, so critique it accordingly. 
