### PR TITLE
MenuFlyoutItems can now receive DataContext

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/MenuFlyout/MenuFlyout.cs
@@ -40,7 +40,26 @@ namespace Windows.UI.Xaml.Controls
 					default:
 						break;
 				}
+
+				SetFlyoutItemsDataContext();
 			}
+		}
+
+		internal protected override void OnDataContextChanged(DependencyPropertyChangedEventArgs e)
+		{
+			base.OnDataContextChanged(e);
+
+			SetFlyoutItemsDataContext();
+		}
+
+		private void SetFlyoutItemsDataContext()
+		{
+			// This is present to force the dataContext to be passed to the popup of the flyout since it is not directly a child in the visual tree of the flyout. 
+			Items?.ForEach(item => item?.SetValue(
+				MenuFlyoutItem.DataContextProperty,
+				this.DataContext,
+				precedence: DependencyPropertyValuePrecedences.Inheritance
+			));
 		}
 
 		#region Items DependencyProperty


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
Bugfix

## What is the current behavior?
Bindings in menuflyoutitems aren't set in its commands/parameters


## What is the new behavior?
MenuFlyoutItems can now receive DataContext


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/155170
https://nventive.visualstudio.com/Umbrella/_workitems/edit/155327
