### PR TITLE
[Wasm] Fix the processing of the GotFocus event FocusManager

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -137,6 +137,7 @@
 * 154815 [WASM] ItemClick event could be raised for wrong item
 * 155256 Fixed xaml generated enum value not being globalized
 * 155161 [Android] fixed keyboard flicker when backing from a page with CommandBar
+* Fix the processing of the GotFocus event FocusManager (#973)
 
 ## Release 1.44.0
 

--- a/src/Uno.UI/UI/Xaml/Controls/Control/Control.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Control/Control.wasm.cs
@@ -78,18 +78,24 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		internal void SetFocused(bool isFocused)
+		internal bool SetFocused(bool isFocused)
 		{
 			if (isFocused)
 			{
 				if (IsFocusable)
 				{
 					FocusState = _pendingFocusRequestState ?? FocusState.Pointer;
+					return true;
+				}
+				else
+				{
+					return false;
 				}
 			}
 			else
 			{
 				Unfocus();
+				return true;
 			}
 		}
 	}


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #973, fixes #826

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The focus state of a control is not set properly, leading to incorrect focus cues or invalid TextBox bindings updates.

## What is the new behavior?
The FocusManager now sets the FocusState property correctly, by handling the bubbling of the GotFocus event properly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
