### PR TITLE
Misc fixes for the ComboBox

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -74,6 +74,12 @@
 * Ensure FrameworkElement.LayoutUpdated is invoked on all elements being arranged
 * Fix Grid.ColumnDefinitions.Clear exception (#1006)
 * 155086 [Android] Fixed `AppBarButton.Label` taking precedence over `AppBarButton.Content` when used as `PrimaryCommands`.
+* ComboBox
+	- Remove dependency to a "Background" template part which is unnecessary and not required on UWP
+	- Make sure that the `PopupPanel` hides itself if collapsed (special cases as it's at the top of the `Window`)
+	- [iOS] Add support of `INotifyCollectionChanged` in the `Picker`
+	- [iOS] Remove the arbitrary `null` item added at the top of the `Picker`
+	- [iOS] Fix infinite layouting cycle in the iOS picker (Removed workaround which is no longer necessary as the given method is invoked properly on each measure/arrange phases)
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -32,7 +32,6 @@ namespace Windows.UI.Xaml.Controls
 
 		private IPopup _popup;
 		private Border _popupBorder;
-		private FrameworkElement _background;
 		private ContentPresenter _contentPresenter;
 		private ContentPresenter _headerContentPresenter;
 
@@ -53,13 +52,7 @@ namespace Windows.UI.Xaml.Controls
 
 			_popup = this.GetTemplateChild("Popup") as IPopup;
 			_popupBorder = this.GetTemplateChild("PopupBorder") as Border;
-			_background = this.GetTemplateChild("Background") as FrameworkElement;
 			_contentPresenter = this.GetTemplateChild("ContentPresenter") as ContentPresenter;
-
-			if (_background == null)
-			{
-				this.Log().Warn("ComboBox.Template is missing a 'Background' element. To ensure proper dropdown popup positionning, make sure the ControlTemplate contains a FrameworkElement named 'Background'.");
-			}
 
 			UpdateHeaderVisibility();
 			UpdateContentPresenter();
@@ -261,16 +254,15 @@ namespace Windows.UI.Xaml.Controls
 						popupChild.Width = windowSize.Width;
 						popupChild.Height = windowSize.Height;
 					}
-					else if (_background is FrameworkElement background)
+					else
 					{
 						// Reset popup offsets (Windows seems to do that)
 						popup.VerticalOffset = 0;
 						popup.HorizontalOffset = 0;
 
 						// Inject layouting constraints
-						popupChild.MinHeight = background.ActualHeight;
-						popupChild.MinWidth = background.ActualWidth;
-						popupChild.MaxHeight = MaxDropDownHeight;
+						popupChild.MinHeight = ActualHeight;
+						popupChild.MinWidth = ActualWidth;
 
 						var windowRect = Xaml.Window.Current.Bounds;
 						var visibleBounds = ApplicationView.GetForCurrentView().VisibleBounds;
@@ -280,25 +272,17 @@ namespace Windows.UI.Xaml.Controls
 						popupChild.MaxHeight = Math.Min(MaxDropDownHeight, visibleBounds.Height * 0.6);
 
 						var popupRect = popup.GetAbsoluteBoundsRect();
-						var backgroundRect = background.GetAbsoluteBoundsRect();
-
-						// Because Popup.Child is not part of the visual tree until Popup.IsOpen,
-						// some descendent Controls may never have loaded and materialized their templates.
-						// We force the materialization of all templates to ensure that Measure works properly.
-						foreach (var control in popupChild.EnumerateAllChildren().OfType<Control>())
-						{
-							control.ApplyTemplate();
-						}
+						var comboRect = this.GetAbsoluteBoundsRect();
 
 						popupChild.Measure(visibleBounds.Size);
 						var popupChildRect = new Rect(new Point(), popupChild.DesiredSize);
 
 						// Align left of popup with left of background 
-						popupChildRect.X = backgroundRect.Left;
+						popupChildRect.X = comboRect.Left;
 						if (popupChildRect.Right > visibleBounds.Right) // popup overflows at right
 						{
 							// Align right of popup with right of background
-							popupChildRect.X = backgroundRect.Right - popupChildRect.Width;
+							popupChildRect.X = comboRect.Right - popupChildRect.Width;
 						}
 						if (popupChildRect.Left < visibleBounds.Left) // popup overflows at left
 						{
@@ -307,11 +291,11 @@ namespace Windows.UI.Xaml.Controls
 						}
 
 						// Align top of popup with top of background
-						popupChildRect.Y = backgroundRect.Top;
+						popupChildRect.Y = comboRect.Top;
 						if (popupChildRect.Bottom > visibleBounds.Bottom) // popup overflows at bottom
 						{
 							// Align bottom of popup with bottom of background
-							popupChildRect.Y = backgroundRect.Bottom - popupChildRect.Height;
+							popupChildRect.Y = comboRect.Bottom - popupChildRect.Height;
 						}
 						if (popupChildRect.Top < visibleBounds.Top) // popup overflows at top
 						{

--- a/src/Uno.UI/UI/Xaml/Controls/Picker/Picker.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Picker/Picker.iOS.cs
@@ -9,6 +9,7 @@ using Uno.UI.Extensions;
 using Uno.Extensions;
 using UIKit;
 using System.Collections;
+using System.Collections.Specialized;
 using System.Windows.Input;
 using CoreGraphics;
 using Uno.Extensions.Specialized;
@@ -44,44 +45,50 @@ namespace Windows.UI.Xaml.Controls
 				size = base.SizeThatFits(size);
 			}
 
-			if (this.Frame.Size != size)
-			{
-				this.SetDimensions(size.Width, size.Height);
-				
-				// forces PickerModel.GetComponentWidth to get called, 
-				// which then receives the new dimensions (which might differ from the default value of 320)
-				this.SetNeedsLayout(); 
-			}
 
 			return size;
 		}
-
-
 
 		public object[] Items { get; private set; } = new object[] { null }; // ensure there's always a null present to allow deselection
 		
 		partial void OnItemsSourceChangedPartialNative(object oldItemsSource, object newItemsSource)
 		{
-			var items = (newItemsSource as IEnumerable)?.ToObjectArray() ?? new object[0];
-			Items = new[] { (object)null }.Concat(items).ToArray(); // ensure there's always a null present to allow deselection
+			if (oldItemsSource is INotifyCollectionChanged oldObservableCollection)
+			{
+				oldObservableCollection.CollectionChanged -= OnItemSourceChanged;
+			}
 
-			ReloadAllComponents();
-			ClearSelection();
+			if (newItemsSource is INotifyCollectionChanged newObservableCollection)
+			{
+				newObservableCollection.CollectionChanged += OnItemSourceChanged;
+			}
+
+			OnItemSourceChanged(newItemsSource, null);
 		}
 
-		private void ClearSelection()
+		private void OnItemSourceChanged(object collection, NotifyCollectionChangedEventArgs _)
 		{
-			this.SelectedItem = null;
+			Items = (collection as IEnumerable)?.ToObjectArray() ?? new object[0];
+			ReloadAllComponents();
+
+			if (!Items.Contains(SelectedItem))
+			{
+				SelectedItem = Items.FirstOrDefault();
+			}
 		}
 
 		partial void OnSelectedItemChangedPartial(object oldSelectedItem, object newSelectedItem)
 		{
-			var row = Items.Safe().IndexOf(newSelectedItem);
+			var row = Items?.IndexOf(newSelectedItem) ?? -1;
 			if (row == -1) // item not found
 			{
-				ClearSelection();
-				return;
-			}			
+				var firstItem = Items?.FirstOrDefault();
+				if (firstItem != newSelectedItem) // We compare to 'newSelectedItem' so we allow them to be both 'null'
+				{
+					SelectedItem = firstItem;
+					return;
+				}
+			}
 
 			Select(row, component: 0, animated: true);
 

--- a/src/Uno.UI/UI/Xaml/Controls/Picker/PickerModel.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Picker/PickerModel.iOS.cs
@@ -17,22 +17,17 @@ namespace Windows.UI.Xaml.Controls
 
 		public PickerModel(Picker picker)
 		{
-			if (picker == null)
-			{
-				throw new ArgumentNullException(nameof(picker));
-			}
-
-			_picker = picker;
+			_picker = picker ?? throw new ArgumentNullException(nameof(picker));
 		}
 
 		public override string GetTitle(UIPickerView picker, nint row, nint component) => string.Empty;
 		public override nint GetComponentCount(UIPickerView picker) => 1; // designed to support only 1 column
-		public override nint GetRowsInComponent(UIPickerView picker, nint component) => _picker.Items.Count();
+		public override nint GetRowsInComponent(UIPickerView picker, nint component) => _picker.Items.Length;
 		public override nfloat GetRowHeight(UIPickerView picker, nint component) => 44;
 		public override nfloat GetComponentWidth(UIPickerView picker, nint component) => picker.Bounds.Width;
 		public override UIView GetView(UIPickerView picker, nint row, nint component, UIView view)
 		{
-			var item = GetItem(row) ?? _picker.Placeholder;
+			var item = FindItem(row) ?? _picker.Placeholder;
 			var selectorItem = (view as ContentPresenter)?.Content as SelectorItem;
 
 			//Note: at present selectorItem is always null because recycling is apparently broken in UIPickerView in iOS 7-9; see eg http://stackoverflow.com/questions/20635949/reusing-view-in-uipickerview-with-ios-7
@@ -59,16 +54,16 @@ namespace Windows.UI.Xaml.Controls
 			selectorItem.DataContext = item;
 
 			// Wrap the PickerItem inside another container. This prevents a Xamarin run-time crash which occurs when accessing Superview that is being removed when clearing bindings from ContentControl.
-			var internalContainer = new ContentPresenter() { Content = selectorItem };
+			var internalContainer = new ContentPresenter { Content = selectorItem };
 			return internalContainer;
 		}
 
 		public override void Selected(UIPickerView picker, nint row, nint component)
 		{
-			_picker.SelectedItem = GetItem(row);
+			_picker.SelectedItem = FindItem(row);
 		}
 
-		private object GetItem(nint row)
+		private object FindItem(nint row)
 		{
 			return _picker.Items.ElementAtOrDefault((int)row);
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -35,6 +35,11 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override Size MeasureOverride(Size availableSize)
 		{
+			if (Visibility == Visibility.Collapsed)
+			{
+				availableSize = new Size(); // 0,0
+			}
+
 			var child = this.GetChildren().FirstOrDefault();
 			if (child != null)
 			{
@@ -48,6 +53,12 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override Size ArrangeOverride(Size finalSize)
 		{
+			var size = _lastMeasuredSize;
+			if (Visibility == Visibility.Collapsed)
+			{
+				size = finalSize = new Size();
+			}
+
 			var child = this.GetChildren().FirstOrDefault();
 			if (child == null)
 			{
@@ -58,8 +69,8 @@ namespace Windows.UI.Xaml.Controls
 			var finalFrame = new Rect(
 				(float)transform.Matrix.OffsetX + (float)Popup.HorizontalOffset,
 				(float)transform.Matrix.OffsetY + (float)Popup.VerticalOffset,
-				_lastMeasuredSize.Width,
-				_lastMeasuredSize.Height);
+				size.Width,
+				size.Height);
 
 			ArrangeElement(child, finalFrame);
 

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupPanel.cs
@@ -35,6 +35,9 @@ namespace Windows.UI.Xaml.Controls
 
 		protected override Size MeasureOverride(Size availableSize)
 		{
+			// Usually this check is acheived by the parent, but as this Panel
+			// is injected at the root (it's a subView of the Window), we make sure
+			// to enforce it here.
 			if (Visibility == Visibility.Collapsed)
 			{
 				availableSize = new Size(); // 0,0
@@ -54,6 +57,10 @@ namespace Windows.UI.Xaml.Controls
 		protected override Size ArrangeOverride(Size finalSize)
 		{
 			var size = _lastMeasuredSize;
+			
+			// Usually this check is acheived by the parent, but as this Panel
+			// is injected at the root (it's a subView of the Window), we make sure
+			// to enforce it here.
 			if (Visibility == Visibility.Collapsed)
 			{
 				size = finalSize = new Size();


### PR DESCRIPTION
- Remove dependency to a "Background" template part which is unnecessary and not required on UWP
- Make sure that the `PopupPanel` hides itself if collapsed (special cases as it's at the top of the `Window`)
- [iOS] Add support of `INotifyCollectionChanged` in the `Picker`
- [iOS] Remove the arbitrary `null` item added at the top of the `Picker`
- [iOS] Fix infinite layouting cycle in the iOS picker (Removed workaround which is no longer necessary as the given method is invoked properly on each measure/arrange phases)

## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The opposite to what is described in commit comment above

## What is the new behavior?
What is described in commit comment above

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Other information
Internal Issue (If applicable):
https://dev.azure.com/nventive/_workitems/edit/155101
https://dev.azure.com/nventive/_workitems/edit/155106
https://dev.azure.com/nventive/_workitems/edit/155140