### PR TITLE
Fix selection indicator not working on iOS Picker

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -145,6 +145,7 @@
 * 155256 Fixed xaml generated enum value not being globalized
 * 155161 [Android] fixed keyboard flicker when backing from a page with CommandBar
 * Fix the processing of the GotFocus event FocusManager (#973)
+* 116098 [iOS] The time/day pickers are missing diving lines on devices running firmware 11 and up.
 
 ## Release 1.44.0
 

--- a/src/Uno.UI/UI/Xaml/Controls/Picker/Picker.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Picker/Picker.iOS.cs
@@ -26,10 +26,23 @@ namespace Windows.UI.Xaml.Controls
 			this.InitializeBinder();
 
 			AutoresizingMask = UIViewAutoresizing.None;
+			SetupSelectionIndicator();
 
 			OnDisplayMemberPathChangedPartial(string.Empty, this.DisplayMemberPath);
 
 			this.Model = new PickerModel(this);
+		}
+
+		private void SetupSelectionIndicator()
+		{
+			// The "selection indicator" refers the the thin lines above and below the selected item in the spinner.
+
+			// Setting this flag should be enough but it isn't.
+			ShowSelectionIndicator = true;
+
+			// Selecting the first item strangely fixes the selection not showing otherwise.
+			// See this for more info: https://stackoverflow.com/questions/39564660/uipickerview-selection-indicator-not-visible-in-ios10
+			Select(row: 0, component: 0, animated: false);
 		}
 
 		public override CGSize SizeThatFits(CGSize size)


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The iOS Picker doesn't display the lines above and below the selected item.

## What is the new behavior?
The iOS Picker displays the lines above and below the selected item.


## PR Checklist

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/116098
