### PR TITLE
[iOS] Fix invalid DataContext propagation when estimating ListView item size

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -146,6 +146,7 @@
 * 155161 [Android] fixed keyboard flicker when backing from a page with CommandBar
 * Fix the processing of the GotFocus event FocusManager (#973)
 * 116098 [iOS] The time/day pickers are missing diving lines on devices running firmware 11 and up.
+* [iOS] Fix invalid DataContext propagation when estimating ListView item size (#1051)
 
 ## Release 1.44.0
 

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/ListViewBaseSource.iOS.cs
@@ -570,6 +570,10 @@ namespace Windows.UI.Xaml.Controls
 			{
 				var container = CreateContainerForElementKind(elementKind);
 
+				// Force a null DataContext so the parent's value does not flow
+				// through when temporarily adding the container to Owner.XamlParent
+				container.SetValue(FrameworkElement.DataContextProperty, null);
+
 				Style style = null;
 				if (elementKind == NativeListViewBase.ListViewItemElementKind)
 				{
@@ -604,6 +608,9 @@ namespace Windows.UI.Xaml.Controls
 				{
 					Owner.XamlParent.RemoveChild(BlockLayout);
 					BlockLayout.RemoveChild(container);
+
+					// Reset the DataContext for reuse.
+					container.ClearValue(FrameworkElement.DataContextProperty);
 				}
 
 				_templateCache[dataTemplate ?? _nullDataTemplateKey] = size;


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Bugfix

## What is the current behavior?
The ListView's DataContext is propagated to the temporary item created when estimating the size of listview item templates, creating invalid binding errors.

## What is the new behavior?
Temporary items are created with a null DataContext.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)
