### PR TITLE
Make sure that the PivotPanel allows text wrapping

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -82,6 +82,7 @@
 	- [iOS] Fix infinite layouting cycle in the iOS picker (Removed workaround which is no longer necessary as the given method is invoked properly on each measure/arrange phases)
 * [Wasm] Refactored the way the text is measured in Wasm. Wasn't working well when a parent with a RenderTransform.
 * `Grid` now supports `ColumnDefinition.MinWidth` and `MaxWidth` and `RowDefinition.MinHeight` and `MaxHeight` (#1032)
+* Implement the `PivotPanel` measure/arrange to allow text wrapping in pivot items
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -753,6 +753,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Pivot\PivotSimpleTest.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_LightDismiss.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2355,6 +2359,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\TextBlockViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\TimePickerViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\NavigationViewTests\NavigationView_TopNavigation.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Pivot\PivotSimpleTest.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_LightDismiss.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_Simple.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\MessageDialog.xaml.cs" />
@@ -3138,6 +3143,9 @@
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Simpletwocolumnsplitgrid.xaml.cs">
       <DependentUpon>Simpletwocolumnsplitgrid.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\Src\GitHub\nventive\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Pivot\PivotSimpleTest.xaml.cs">
+      <DependentUpon>PivotSimpleTest.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Pivot/PivotSimpleTest.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Pivot/PivotSimpleTest.xaml
@@ -1,0 +1,57 @@
+﻿<UserControl
+    x:Class="SamplesApp.Windows_UI_Xaml_Controls.PivotTests.Basics"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:controls="using:Uno.UI.Samples.Controls"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:xamarin="http://uno.ui/xamarin"
+    mc:Ignorable="d xamarin" 
+    d:DesignHeight="300"
+    d:DesignWidth="400">
+
+    <UserControl.Resources>
+
+        <DataTemplate x:Key="FirstPivotItemTemplate">
+            <Ellipse />
+        </DataTemplate>
+
+        <DataTemplate x:Key="SecondPivotItemTemplate">
+            <Rectangle />
+        </DataTemplate>
+
+        <DataTemplate x:Key="ThirdPivotItemTemplate">
+            <Polygon />
+        </DataTemplate>
+
+        <DataTemplate x:Key="FourthPivotItemTemplate">
+            <TextBlock Text="Fourth Template" />
+        </DataTemplate>
+
+    </UserControl.Resources>
+
+    <controls:SampleControl SampleDescription="Simple Pivot">
+        <controls:SampleControl.SampleContent>
+            <DataTemplate>
+                <Border Background="Aqua" Height="400" Width="400">
+                    <xamarin:Pivot Background="Red">
+                        <Pivot.Items>
+                            <PivotItem Header="First"
+									   Content="First Content"/>
+                            <PivotItem Header="Second">
+								<TextBlock 
+									TextWrapping="Wrap"
+									Text="Second Content which is very long so it should wrap as we set the TextWrapping property of this property to Wrap. And_even_this_very_long_word_which_is_not_wrappable_should_wrap_as_the_PivotPanel_has_measured_its_children_using_the_width_of_its_parent_scrollviewer." />
+							</PivotItem>
+                            <PivotItem Header="Third" 
+									   Content="Third Content"/>
+                            <PivotItem Header="Fourth"
+									   Content="Fourth Content"/>
+                        </Pivot.Items>
+                    </xamarin:Pivot>
+                </Border>
+            </DataTemplate>
+        </controls:SampleControl.SampleContent>
+    </controls:SampleControl>
+
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Pivot/PivotSimpleTest.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Pivot/PivotSimpleTest.xaml.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Controls;
+
+namespace SamplesApp.Windows_UI_Xaml_Controls.PivotTests
+{
+	[SampleControlInfo("Pivot Tests", "Basics Pivot Test")]
+	public sealed partial class Basics : UserControl
+    {
+        public Basics()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/PivotPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/PivotPanel.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.Foundation;
+using Uno.Extensions;
+using Uno.Logging;
+using Uno.UI;
+
+#if __IOS__
+using UIKit;
+#elif __MACOS__
+using AppKit;
+#endif
+
+namespace Windows.UI.Xaml.Controls.Primitives
+{
+	public partial class PivotPanel : Panel
+	{
+		/// <inheritdoc />
+		protected override Size MeasureOverride(Size availableSize)
+		{
+			var scroll = this.FindFirstParent<ScrollViewer>();
+			
+			if (scroll == null)
+			{
+				this.Log().Warn("Failed to find expected parent ScrollViewer of this PivotPanel");
+			}
+			else
+			{
+				// Here we are bypassing the infinite width provided by the ScrollViewer of the Pivot's template
+				// and instead we are constraining the items to have the same width of the parent pivot so can be panned properly.
+
+				availableSize = new Size(Math.Min(availableSize.Width, scroll.ViewportMeasureSize.Width), availableSize.Height);
+			}
+
+			// Note: Here we should X-stack the items to allow the ScrollViewer to do its job
+			//		 however currently the Pivot is only changing the Visibility of the items,
+			//		 so we only have to Z-stack items and return the 'availableSize' (which actually disable the 'scroll' ScrollViewer)
+
+			foreach (var child in Children)
+			{
+				MeasureElement(child, availableSize);
+			}
+			
+			return availableSize;
+		}
+
+		/// <inheritdoc />
+		protected override Size ArrangeOverride(Size finalSize)
+		{
+			var scroll = this.FindFirstParent<ScrollViewer>();
+
+			if (scroll == null)
+			{
+				this.Log().Warn("Failed to find expected parent ScrollViewer of this PivotPanel");
+			}
+			else
+			{
+				// Here we are bypassing the infinite width provided by the ScrollViewer of the Pivot's template
+				// and instead we are constraining the items to have the same width of the parent pivot so can be panned properly.
+
+				finalSize = new Size(Math.Min(finalSize.Width, scroll.ViewportArrangeSize.Width), finalSize.Height);
+			}
+
+			// Note: Here we should X-stack the items to allow the ScrollViewer to do its job
+			//		 however currently the Pivot is only changing the Visibility of the items,
+			//		 so we only have to Z-stack items and return the 'finalSize' (which actually disable the 'scroll' ScrollViewer)
+
+			foreach (var child in Children)
+			{
+				ArrangeElement(child, new Rect(new Point(), finalSize));
+			}
+
+			return finalSize;
+		}
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/ScrollBarVisibility.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ScrollBarVisibility.cs
@@ -10,7 +10,7 @@ namespace Windows.UI.Xaml.Controls
 	public enum ScrollBarVisibility
 	{
 		/// <summary>
-		/// Enables the scrollbars if the content is greated that the view port.
+		/// Enables the scrollbars if the content is greater than the view port.
 		/// </summary>
 		Auto,
 


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/nventive/calculator/issues/116

## Feature
Implement measure/arrange of the `PivotPanel` in order to allow text wrapping in `PivotItem`

## What is the current behavior?
`PivotItem` are measured with an infinite width

## What is the new behavior?
`PivotItem` are measured with the view port width of the parent `ScrollViewer`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)
