### PR TITLE
Fix text wrapping does not wrap words longer than the viewport

### DIFF
--- a/src/Uno.UI/UI/Xaml/Documents/UIElementTextHelper.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Documents/UIElementTextHelper.wasm.cs
@@ -240,25 +240,18 @@ namespace Uno.UI.UI.Xaml.Documents
 							("word-break", ""),
 							("text-overflow", ""));
 						break;
-					case TextWrapping.WordEllipsis:
-						element.SetAttribute("wrap", "soft");
-						element.SetStyle(
-							("white-space", "pre"),
-							("word-break", ""),
-							("text-overflow", "ellipsis"));
-						break;
 					case TextWrapping.Wrap:
 						element.SetAttribute("wrap", "soft");
 						element.SetStyle(
 							("white-space", ""),
-							("word-break", ""),
-							("text-overflow", ""));
+							("word-break", "break-word"), // This is required to still wrap words that are longer than the ViewPort
+							("text-overflow", "")); 
 						break;
 					case TextWrapping.WrapWholeWords:
 						element.SetAttribute("wrap", "soft");
 						element.SetStyle(
 							("white-space", ""),
-							("word-break", "keep-all"),
+							("word-break", "keep-all"), // This is required to still wrap words that are longer than the ViewPort
 							("text-overflow", ""));
 						break;
 				}


### PR DESCRIPTION
GitHub Issue (If applicable): https://github.com/nventive/calculator/issues/116

## BugFix
Word wrapping on WASM does not behaves as UWP

## What is the current behavior?
Words longer than the viewport overflows instead of wrapping

## What is the new behavior?
Long words are wrap in the middle of the word if needed

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

## Additional information
This feature is tested by the tests of  https://github.com/nventive/Uno/pull/1053