### PR TITLE
[Wasm] Add PathIcon support

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -83,6 +83,7 @@
 * [Wasm] Refactored the way the text is measured in Wasm. Wasn't working well when a parent with a RenderTransform.
 * `Grid` now supports `ColumnDefinition.MinWidth` and `MaxWidth` and `RowDefinition.MinHeight` and `MaxHeight` (#1032)
 * Implement the `PivotPanel` measure/arrange to allow text wrapping in pivot items
+* [Wasm] Add `PathIcon` support
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.

--- a/src/Uno.UI/UI/Xaml/Controls/PathIcon.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/PathIcon.cs
@@ -37,9 +37,7 @@ namespace Windows.UI.Xaml.Controls
 			_path = new Shapes.Path();
 			_path.Fill = Foreground;
 			_path.Stretch = Stretch.None;
-#if XAMARIN
 			AddIconElementView(_path);
-#endif
 		}
 
 		public Geometry Data


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
- Feature

## What is the new behavior?
`PathIcon` is now supported for Wasm.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [x] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [ ] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
