### PR TITLE
Remove `TextWrapping.WordEllipsis`

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -171,8 +171,12 @@
                 reason="Invalid method visibility"/>
         <Member fullName="System.Void Uno.UI.Controls.Legacy.ListViewBase.OnLayoutUpdated()"
                 reason="Invalid method visibility"/>
-
       </Methods>
+	  
+	  <Fields>
+	  	<Member fullName="Windows.UI.Xaml.TextWrapping Windows.UI.Xaml.TextWrapping::WordEllipsis"
+                reason="Invalid enum value"/>
+	  </Fields>
 
       <Properties>
         <Member fullName="Windows.UI.Color Windows.UI.Xaml.Controls.ScrollViewer::BackgroundColor()"

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -90,6 +90,7 @@
 * `NavigationBarHelper` has been removed.
 * Localized Text, Content etc is now applied even if the Text (etc) property isn't set in Xaml. Nested implicit content (eg `<Button><Border>...`) will be overridden by localized values if available.
 * [Android] Unless nested under `SecondaryCommands`, the `AppBarButton.Label` property will no longer be used for the title of menu item, instead use the `AppBarButton.Content` property. For `SecondaryCommands`, keep using `AppBarButton.Label`.
+* The `WordEllipsis` was removed from the `TextWrapping` as it's not a valid value for UWP (And it was actually supported only on WASM) (The right way to get ellipsis is with the `TextTrimming.WordEllipsis`)
 
 ### Bug fixes
 * DatePicker FlyoutPlacement now set to Full by default

--- a/src/Uno.UI/UI/Xaml/Controls/TextWrapping.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextWrapping.cs
@@ -10,7 +10,5 @@ namespace Windows.UI.Xaml
 		NoWrap,
 		Wrap,
 		WrapWholeWords,
-		// Not supported for now on iOS/Android
-		WordEllipsis,
 	}
 }


### PR DESCRIPTION
## API alignment
Remove the invalid value `WordEllipsis` from the `TextWrapping` enum as it's not a valid value for UWP (And it was actually supported only on WASM)

## PR Checklist
- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- ~~[ ] Contains **NO** breaking changes~~
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

## Other information
**This is a breaking change**