### PR TITLE
Virtualize ComboBox dropdown

### DIFF
--- a/build/PackageDiffIgnore.xml
+++ b/build/PackageDiffIgnore.xml
@@ -171,6 +171,8 @@
                 reason="Invalid method visibility"/>
         <Member fullName="System.Void Uno.UI.Controls.Legacy.ListViewBase.OnLayoutUpdated()"
                 reason="Invalid method visibility"/>
+        <Member fullName="System.Void Windows.UI.Xaml.Controls.VirtualizingPanelLayout.UpdateLayoutAttributesForItem(UIKit.UICollectionViewLayoutAttributes layoutAttributes)"
+                reason="Implementation detail, made internal"/>
       </Methods>
 	  
 	  <Fields>

--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -84,6 +84,7 @@
 * `Grid` now supports `ColumnDefinition.MinWidth` and `MaxWidth` and `RowDefinition.MinHeight` and `MaxHeight` (#1032)
 * Implement the `PivotPanel` measure/arrange to allow text wrapping in pivot items
 * [Wasm] Add `PathIcon` support
+* `ComboBox`'s dropdown list (`CarouselPanel`) is now virtualized (#1012)
 
 ### Breaking Changes
 * The `WebAssemblyRuntime.InvokeJSUnmarshalled` method with three parameters has been removed.
@@ -91,6 +92,12 @@
 * Localized Text, Content etc is now applied even if the Text (etc) property isn't set in Xaml. Nested implicit content (eg `<Button><Border>...`) will be overridden by localized values if available.
 * [Android] Unless nested under `SecondaryCommands`, the `AppBarButton.Label` property will no longer be used for the title of menu item, instead use the `AppBarButton.Content` property. For `SecondaryCommands`, keep using `AppBarButton.Label`.
 * The `WordEllipsis` was removed from the `TextWrapping` as it's not a valid value for UWP (And it was actually supported only on WASM) (The right way to get ellipsis is with the `TextTrimming.WordEllipsis`)
+* If `ComboBox` has a modified template (eg from overriding the default `Style`), then the `ScrollViewer` hosting the `ItemsPresenter` needs to have its `Style` set to `StaticResource ListViewBaseScrollViewerStyle` (as [here](https://github.com/nventive/Uno/blob/21c49fd1d6136352f71a894686a9b4130e300b95/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml#L754)). Eg:
+```xaml
+								<ScrollViewer x:Name="ScrollViewer"
+											  xamarin:Style="{StaticResource ListViewBaseScrollViewerStyle}"
+											  ...
+```
 
 ### Bug fixes
 * DatePicker FlyoutPlacement now set to Full by default

--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -202,6 +202,11 @@ namespace Windows.UI.Xaml.Controls
 				{
 					popupChild.SizeChanged += PopupChildChanged;
 				}
+
+				if (SelectedItem != null)
+				{
+					ScrollIntoView(SelectedItem);
+				}
 			}
 			else
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsControl/ItemsControl.cs
@@ -787,6 +787,10 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		internal virtual void OnItemsSourceSingleCollectionChanged(object sender, NotifyCollectionChangedEventArgs args, int section)
 		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().LogDebug($"Called {nameof(OnItemsSourceSingleCollectionChanged)}(), Action={args.Action}, NoOfItems={NumberOfItems}");
+			}
 			UpdateItems();
 		}
 
@@ -795,6 +799,10 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		internal virtual void OnItemsSourceGroupsChanged(object sender, NotifyCollectionChangedEventArgs args)
 		{
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				this.Log().LogDebug($"Called {nameof(OnItemsSourceGroupsChanged)}(), Action={args.Action}, NoOfItems={NumberOfItems}, NoOfGroups={NumberOfGroups}");
+			}
 			UpdateItems();
 		}
 

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/IVirtualizingPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/IVirtualizingPanel.cs
@@ -1,5 +1,4 @@
-﻿#if !NET461
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -17,5 +16,3 @@ namespace Windows.UI.Xaml.Controls
 		VirtualizingPanelLayout GetLayouter();
 	}
 }
-
-#endif

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.cs
@@ -1,5 +1,4 @@
-﻿#if !NET461 && !__MACOS__
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -10,5 +9,3 @@ namespace Windows.UI.Xaml.Controls
 		public override Orientation ScrollOrientation { get { return Orientation; } }
 	}
 }
-
-#endif

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.iOS.cs
@@ -76,7 +76,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes updatingItem, bool shouldRecurse)
+		private protected override void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes updatingItem, bool shouldRecurse)
 		{
 			//Update extent of either subsequent item in group, subsequent group header, or footer
 			var currentIndex = updatingItem.IndexPath;

--- a/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ItemsStackPanel/ItemsStackPanelLayout.iOS.cs
@@ -76,7 +76,7 @@ namespace Windows.UI.Xaml.Controls
 			}
 		}
 
-		protected override void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes updatingItem)
+		protected override void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes updatingItem, bool shouldRecurse)
 		{
 			//Update extent of either subsequent item in group, subsequent group header, or footer
 			var currentIndex = updatingItem.IndexPath;
@@ -115,6 +115,11 @@ namespace Windows.UI.Xaml.Controls
 				var frame = elementToAdjust.Frame;
 				SetExtentStart(ref frame, GetExtentEnd(updatingItem.Frame));
 				elementToAdjust.Frame = frame;
+
+				if (shouldRecurse)
+				{
+					UpdateLayoutAttributesForItem(elementToAdjust, shouldRecurse: true);
+				}
 			}
 			else
 			{

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Stub.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.Stub.cs
@@ -1,0 +1,16 @@
+﻿#if NET461 || __MACOS__
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.UI.Xaml.Controls;
+
+namespace Windows.UI.Xaml.Controls
+{
+	abstract partial class VirtualizingPanelLayout
+	{
+		public abstract Orientation ScrollOrientation { get; }
+
+		public Orientation Orientation { get; set; }
+	}
+}
+#endif

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -179,7 +179,7 @@ namespace Windows.UI.Xaml.Controls
 					if (SupportsDynamicItemSizes && HasDynamicElementSizes && areItems)
 					{
 						//Propagate layout changes for materialized items that may have a different size to the non-databound template.
-						UpdateLayoutAttributesForItem(layoutAttributes);
+						UpdateLayoutAttributesForItem(layoutAttributes, shouldRecurse: false);
 					}
 
 					if (rect.Contains(frame) ||
@@ -1078,7 +1078,7 @@ namespace Windows.UI.Xaml.Controls
 
 			if (SupportsDynamicItemSizes && layoutAttributes.RepresentedElementKind == null)
 			{
-				UpdateLayoutAttributesForItem(layoutAttributes);
+				UpdateLayoutAttributesForItem(layoutAttributes, shouldRecurse: true);
 			}
 
 			// If this pushes content size bigger than viewport, and we 'left money on the table' when we requested desired size, send up a layout request
@@ -1173,7 +1173,7 @@ namespace Windows.UI.Xaml.Controls
 			_sectionEnd[groupHeaderLayout.IndexPath.Section] += extentDifference;
 		}
 
-		protected virtual void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes layoutAttributes)
+		protected virtual void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes layoutAttributes, bool shouldRecurse)
 		{
 			throw new NotSupportedException($"This should be overridden by types which set {nameof(SupportsDynamicItemSizes)} to true.");
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -588,7 +588,10 @@ namespace Windows.UI.Xaml.Controls
 				}
 
 				//Ensure container for group exists even if group contains no items, to simplify subsequent logic
-				_itemLayoutInfos[section] = new Dictionary<NSIndexPath, UICollectionViewLayoutAttributes>();
+				if (createLayoutInfo)
+				{
+					_itemLayoutInfos[section] = new Dictionary<NSIndexPath, UICollectionViewLayoutAttributes>(); 
+				}
 				//b. Layout items in group
 				var itemsBreadth = LayoutItemsInGroup(section, availableGroupBreadth, ref frame, createLayoutInfo, oldItemSizes);
 				var groupBreadth = itemsBreadth;

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -64,7 +64,13 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		#region Members
+		/// <summary>
+		/// All cached item <see cref="UICollectionViewLayoutAttributes"/>s, grouped by collection group.
+		/// </summary>
 		private readonly Dictionary<int, LayoutInfoDictionary> _itemLayoutInfos = new Dictionary<int, LayoutInfoDictionary>();
+		/// <summary>
+		/// All cached <see cref="UICollectionViewLayoutAttributes"/> for supplementary elements (Header, Footer, group headers), grouped by element type.
+		/// </summary>
 		private readonly Dictionary<string, LayoutInfoDictionary> _supplementaryLayoutInfos = new Dictionary<string, LayoutInfoDictionary>();
 		/// <summary>
 		/// The last element in the list. This is set when the layout is created (and will point to the databound size and position of 
@@ -72,6 +78,9 @@ namespace Windows.UI.Xaml.Controls
 		/// </summary>
 		private UICollectionViewLayoutAttributes _lastElement;
 
+		/// <summary>
+		/// Locations of group header frames if they were to appear inline with items (ie not 'sticky').
+		/// </summary>
 		private readonly Dictionary<int, CGRect> _inlineHeaderFrames = new Dictionary<int, CGRect>();
 		protected readonly Dictionary<int, nfloat> _sectionEnd = new Dictionary<int, nfloat>();
 
@@ -79,7 +88,13 @@ namespace Windows.UI.Xaml.Controls
 		private Dictionary<CachedTuple<int, int>, NSIndexPath> _indexPaths = new Dictionary<CachedTuple<int, int>, NSIndexPath>(CachedTuple<int, int>.Comparer);
 		private Dictionary<CachedTuple<int, int>, UICollectionViewLayoutAttributes> _layoutAttributesForIndexPaths = new Dictionary<CachedTuple<int, int>, UICollectionViewLayoutAttributes>(CachedTuple<int, int>.Comparer);
 		private DirtyState _dirtyState;
+		/// <summary>
+		/// The most recently returned desired size.
+		/// </summary>
 		private CGSize _lastReportedSize;
+		/// <summary>
+		/// The most recent available size given by measure.
+		/// </summary>
 		private CGSize _lastAvailableSize;
 		private bool _invalidatingHeadersOnBoundsChange;
 		private bool _invalidatingOnCollectionChanged;
@@ -354,6 +369,14 @@ namespace Windows.UI.Xaml.Controls
 			return PrepareLayout(false, size);
 		}
 
+		/// <summary>
+		/// Prepare layout if necessary and return its size.
+		/// </summary>
+		/// <param name="createLayoutInfo">Should we create <see cref="UICollectionViewLayoutAttributes"/>?</param>
+		/// <param name="size">The available size</param>
+		/// <returns>The total collection size</returns>
+		/// <remarks>This is called by overidden methods which need to know the total dimensions of the panel content. If a full relayout is required,
+		/// it calls <see cref="PrepareLayoutInternal(bool, bool, CGSize)"/>; otherwise it returns a cached value.</remarks>
 		private CGSize PrepareLayout(bool createLayoutInfo, CGSize? size = null)
 		{
 			using (
@@ -384,7 +407,7 @@ namespace Windows.UI.Xaml.Controls
 						_lastElement = null;
 					}
 					_lastReportedSize = PrepareLayoutInternal(createLayoutInfo, _dirtyState == DirtyState.CollectionChanged, availableSize);
-					
+
 					if (_dirtyState == DirtyState.NeedsRelayout && GetExtent(_lastReportedSize) < GetExtent(_lastAvailableSize))
 					{
 						SetHasUnusedSpace();
@@ -436,7 +459,7 @@ namespace Windows.UI.Xaml.Controls
 		}
 
 		/// <summary>
-		/// Determine the layout for all elements (items, header, footer, and group headers).
+		/// Recalculate the layout for all elements (items, header, footer, and group headers).
 		/// </summary>
 		/// <param name="createLayoutInfo">Should we create <see cref="UICollectionViewLayoutAttributes"/>?</param>
 		/// <param name="isCollectionChanged">Is this a partial layout in response to an INotifyCollectionChanged operation</param>
@@ -791,6 +814,9 @@ namespace Windows.UI.Xaml.Controls
 			return value;
 		}
 
+		/// <summary>
+		/// Apply 'stickiness' to group header positions.
+		/// </summary>
 		private void UpdateHeaderPositions()
 		{
 			// Get coordinate index to modify
@@ -1022,6 +1048,9 @@ namespace Windows.UI.Xaml.Controls
 			InvalidateLayout();
 		}
 
+		/// <summary>
+		/// Update cached layout attributes for an element after the materialized, databound element has been measured.
+		/// </summary>
 		public void UpdateLayoutAttributesForElement(UICollectionViewLayoutAttributes layoutAttributes)
 		{
 			//Update frame of target layoutAttributes

--- a/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ListViewBase/VirtualizingPanelLayout.iOS.cs
@@ -1205,7 +1205,7 @@ namespace Windows.UI.Xaml.Controls
 			_sectionEnd[groupHeaderLayout.IndexPath.Section] += extentDifference;
 		}
 
-		protected virtual void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes layoutAttributes, bool shouldRecurse)
+		private protected virtual void UpdateLayoutAttributesForItem(UICollectionViewLayoutAttributes layoutAttributes, bool shouldRecurse)
 		{
 			throw new NotSupportedException($"This should be overridden by types which set {nameof(SupportsDynamicItemSizes)} to true.");
 		}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/CarouselPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/CarouselPanel.cs
@@ -6,10 +6,17 @@ using Windows.Foundation;
 
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	public partial class CarouselPanel : StackPanel // TODO: VirtualizingPanel
+	public partial class CarouselPanel : VirtualizingPanel
 	{
+		private readonly ItemsStackPanelLayout _layout = new ItemsStackPanelLayout();
+
 		public CarouselPanel()
 		{
+#if __WASM__
+			_layout.Initialize(this);
+#endif
 		}
+
+		private protected override VirtualizingPanelLayout GetLayouterCore() => _layout;
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/CarouselPanel.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/CarouselPanel.wasm.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Windows.Foundation;
+
+namespace Windows.UI.Xaml.Controls.Primitives
+{
+	public partial class CarouselPanel
+	{
+		protected override Size MeasureOverride(Size availableSize) => _layout.MeasureOverride(availableSize);
+
+		protected override Size ArrangeOverride(Size finalSize) => _layout.ArrangeOverride(finalSize);
+	}
+}

--- a/src/Uno.UI/UI/Xaml/Controls/Primitives/OrientedVirtualizingPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Primitives/OrientedVirtualizingPanel.cs
@@ -1,12 +1,7 @@
 #pragma warning disable 108 // new keyword hiding
 namespace Windows.UI.Xaml.Controls.Primitives
 {
-	#if __ANDROID__
 	[global::Uno.NotImplemented]
-	#endif
-	#if false
-	[global::Uno.NotImplemented]
-	#endif
 	public  partial class OrientedVirtualizingPanel 
 	{
 		public OrientedVirtualizingPanel()

--- a/src/Uno.UI/UI/Xaml/Controls/VirtualizingPanel.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/VirtualizingPanel.cs
@@ -1,17 +1,17 @@
 #pragma warning disable 108 // new keyword hiding
+using System;
+
 namespace Windows.UI.Xaml.Controls
 {
-	#if __ANDROID__
-	[global::Uno.NotImplemented]
-	#endif
-	#if false
-	[global::Uno.NotImplemented]
-	#endif
-	public  partial class VirtualizingPanel : global::Windows.UI.Xaml.Controls.Panel
+	public  partial class VirtualizingPanel : Panel, IVirtualizingPanel
 	{
 		public VirtualizingPanel()
 		{
 
 		}
+
+		public VirtualizingPanelLayout GetLayouter() => GetLayouterCore();
+
+		private protected virtual VirtualizingPanelLayout GetLayouterCore() => throw new NotSupportedException($"This method must be overridden by implementing classes.");
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
+++ b/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml
@@ -751,6 +751,7 @@
 									Margin="0,-1,0,-1"
 									HorizontalAlignment="Stretch">
 								<ScrollViewer x:Name="ScrollViewer"
+											  xamarin:Style="{StaticResource ListViewBaseScrollViewerStyle}"
 											  Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
 											  win:MinWidth="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DropDownContentMinWidth}"
 											  VerticalSnapPointsType="OptionalSingle"


### PR DESCRIPTION
GitHub Issue (If applicable): fixes #555 
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
Feature
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
<!-- - Documentation content changes -->
<!-- - Other... Please describe: -->

 - Inherit CarouselPanel from VirtualizingPanel (for now borrows layouting logic from ItemsStackPanel)
 - Fixes to measure properly on iOS
 - Ensure selected item is always in view when dropdown opens

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
ComboBox dropdown isn't virtualized. Extremely slow for large numbers of items.

## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->
Now it's virtualized.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [ ] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->
Breaking change:
* If `ComboBox` has a modified template (eg from overriding the default `Style`), then the `ScrollViewer` hosting the `ItemsPresenter` needs to have its `Style` set to `StaticResource ListViewBaseScrollViewerStyle` (as [here](https://github.com/nventive/Uno/blob/21c49fd1d6136352f71a894686a9b4130e300b95/src/Uno.UI/UI/Xaml/Style/Generic/Generic.xaml#L754)). Eg:
```xaml
	<ScrollViewer x:Name="ScrollViewer"
				  xamarin:Style="{StaticResource ListViewBaseScrollViewerStyle}"
				  ...
```

## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
