### PR TITLE
[Wasm] Fix TextBlock measure cache algorithm

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -153,6 +153,7 @@
 * [iOS] Fix invalid DataContext propagation when estimating ListView item size (#1051)
 * RadioButton was not applying Checked state correctly with non-standard visual state grouping in style
 * [Android] Fix several bugs preventing AutoSuggestBox from working on Android. (#1012)
+* #1062 TextBlock measure caching can wrongly hit
 
 ## Release 1.44.0
 

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_One.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_One.xaml
@@ -10,10 +10,28 @@
 	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:android="http://uno.ui/android"
 	xmlns:xamarin="http://uno.ui/xamarin"
-	mc:Ignorable="d ios android xamarin"
+	xmlns:wasm="http://uno.ui/xamarin"
+	mc:Ignorable="d ios android xamarin wasm"
 	d:DesignHeight="300"
 	d:DesignWidth="400">
 
-	<TextBlock Text="This is a very very very very long text that should not wrap even though it goes out of the screen" FontSize="20" MaxLines="1"  />
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<Slider Minimum="10" Maximum="1600" Value="350" x:Name="slider"/>
 
+		<Border Width="{Binding Value, ElementName=slider}" Background="Cyan" Grid.Row="1" x:Name="border1">
+			<TextBlock
+				Text="This is a very very very very long text that should not wrap even though it goes out of the screen"
+				FontSize="20"
+				MaxLines="1"  />
+		</Border>
+		<wasm:TextBlock Grid.Row="3">
+			(WASM ONLY) Cache: Hits=<Run x:Name="hits">0</Run>, Misses=<Run x:Name="misses">0</Run>.
+		</wasm:TextBlock>
+	</Grid>
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_One.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_One.xaml.cs
@@ -9,6 +9,17 @@ namespace Uno.UI.Samples.Content.UITests.TextBlockControl
 		public SimpleText_MaxLines_One()
 		{
 			this.InitializeComponent();
+
+#if __WASM__
+			var initialHits = UnoMetrics.TextBlock.MeasureCacheHits;
+			var initialMisses = UnoMetrics.TextBlock.MeasureCacheMisses;
+
+			border1.SizeChanged += (sender, e) =>
+			{
+				hits.Text = (UnoMetrics.TextBlock.MeasureCacheHits - initialHits).ToString();
+				misses.Text = (UnoMetrics.TextBlock.MeasureCacheMisses - initialMisses).ToString();
+			};
+#endif
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml
@@ -7,19 +7,40 @@
 	xmlns:u="using:Uno.UI.Samples.Controls"
 	xmlns:uBehaviors="using:Uno.UI.Samples.Behaviors"
 	xmlns:ios="http://uno.ui/ios"
+	xmlns:wasm="http://uno.ui/wasm"
 	xmlns:win="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:android="http://uno.ui/android"
 	xmlns:xamarin="http://uno.ui/xamarin"
-	mc:Ignorable="d ios android xamarin"
+	mc:Ignorable="d ios android xamarin wasm"
 	d:DesignHeight="300"
 	d:DesignWidth="400">
 
-	<Grid Width="350">
-		<TextBlock
-			Text="This is a very very very very long text that *should* wrap because it goes out of the screen"
-			FontSize="20"
-			TextWrapping="Wrap"
-			MaxLines="2"  />
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="*" />
+			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+		</Grid.RowDefinitions>
+		<Slider Minimum="10" Maximum="1600" Value="350" x:Name="slider"/>
+
+		<Border Width="{Binding Value, ElementName=slider}" Background="Cyan" Grid.Row="1" x:Name="border1">
+			<TextBlock
+				Text="This is a very very very very long WRAPPING text that *should* wrap because it goes out of the screen"
+				FontSize="20"
+				TextWrapping="Wrap"
+				MaxLines="2"  />
+		</Border>
+		<Border Width="{Binding Value, ElementName=slider}" Background="Yellow" Grid.Row="2" x:Name="border2">
+			<TextBlock
+				Text="This is a very very very very long WRAPPING (WrapWholeWords) text that *should* wrap because it goes out of the screen"
+				FontSize="20"
+				TextWrapping="WrapWholeWords"
+				MaxLines="2"  />
+		</Border>
+		<wasm:TextBlock Grid.Row="3">
+			(WASM ONLY) Cache: Hits=<Run x:Name="hits">0</Run>, Misses=<Run x:Name="misses">0</Run>.
+		</wasm:TextBlock>
 	</Grid>
 
 </UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+using Windows.UI.Core;
 using Uno.UI.Samples.Controls;
 using Windows.UI.Xaml.Controls;
 
@@ -9,6 +11,17 @@ namespace Uno.UI.Samples.Content.UITests.TextBlockControl
 		public SimpleText_MaxLines_Two_With_Wrap()
 		{
 			this.InitializeComponent();
+
+#if __WASM__
+			var initialHits = UnoMetrics.TextBlock.MeasureCacheHits;
+			var initialMisses = UnoMetrics.TextBlock.MeasureCacheMisses;
+
+			border1.SizeChanged += (sender, e) =>
+			{
+				hits.Text = (UnoMetrics.TextBlock.MeasureCacheHits - initialHits).ToString();
+				misses.Text = (UnoMetrics.TextBlock.MeasureCacheMisses - initialMisses).ToString();
+			};
+#endif
 		}
 	}
 }

--- a/src/Uno.Foundation/Size.cs
+++ b/src/Uno.Foundation/Size.cs
@@ -22,10 +22,8 @@ namespace Windows.Foundation
 
 		public override bool Equals(object o)
 		{
-			if(o is Size)
+			if(o is Size other)
 			{
-				var other = (Size)o;
-
 				return other.Width == Width 
 					&& other.Height == Height;
 			}

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Controls/TextBlockTests/Given_TextBlockMeasureCache.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Controls/TextBlockTests/Given_TextBlockMeasureCache.cs
@@ -35,25 +35,33 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Controls.TextBlockTests
 		{
 			var SUT = new TextBlockMeasureCache();
 
-			var tb = new TextBlock() { Text = "42" };
+			var tb = new TextBlock { Text = "42" }; // Used as key, never measured
 
 			Assert.AreEqual(TextWrapping.NoWrap, tb.TextWrapping);
 
+			SUT.CacheMeasure(tb, new Size(5, 25), new Size(5, 25));
+			SUT.CacheMeasure(tb, new Size(12, 20), new Size(12, 15));
 			SUT.CacheMeasure(tb, new Size(100, 100), new Size(20, 10));
 
-			Assert.AreEqual(
-				new Size(20, 10),
-				SUT.FindMeasuredSize(tb, new Size(100, 100)).Value
-			);
+			var size20x10 = new Size(20, 10);
 
-			Assert.AreEqual(
-				new Size(20, 10),
-				SUT.FindMeasuredSize(tb, new Size(50, 100)).Value
-			);
+			var resultFor100x100 = SUT.FindMeasuredSize(tb, new Size(100, 100));
+			Assert.AreEqual(size20x10, resultFor100x100);
 
-			Assert.IsNull(
-				SUT.FindMeasuredSize(tb, new Size(10, 100))
-			);
+			var resultFor50x100 = SUT.FindMeasuredSize(tb, new Size(50, 100));
+			Assert.AreEqual(size20x10, resultFor50x100);
+
+			var resultFor20x10 = SUT.FindMeasuredSize(tb, size20x10);
+			Assert.AreEqual(size20x10, resultFor20x10);
+
+			var resultFor10x100 = SUT.FindMeasuredSize(tb, new Size(10, 100));
+			Assert.AreEqual(size20x10, resultFor10x100);
+
+			var resultFor5x20 = SUT.FindMeasuredSize(tb, new Size(5, 20));
+			Assert.AreEqual(new Size(5, 25), resultFor5x20);
+
+			var resultFor5x35 = SUT.FindMeasuredSize(tb, new Size(5, 35));
+			Assert.AreEqual(resultFor10x100, resultFor5x35);
 		}
 
 		[TestMethod]
@@ -61,30 +69,31 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Controls.TextBlockTests
 		{
 			var SUT = new TextBlockMeasureCache();
 
-			var tb = new TextBlock() { Text = "42", TextWrapping = TextWrapping.Wrap };
+			var tb = new TextBlock { Text = "42", TextWrapping = TextWrapping.Wrap }; // Used as key, never measured
 
-			SUT.CacheMeasure(tb, new Size(50, 100), new Size(50, 70));
-
-			Assert.AreEqual(
-				new Size(50, 70),
-				SUT.FindMeasuredSize(tb, new Size(50, 100)).Value
-			);
+			SUT.CacheMeasure(tb, new Size(200, 100), new Size(125, 25));
+			SUT.CacheMeasure(tb, new Size(100, 100), new Size(100, 50));
+			SUT.CacheMeasure(tb, new Size(75, 100), new Size(75, 100));
+			SUT.CacheMeasure(tb, new Size(50, 100), new Size(50, 100));
 
 			Assert.AreEqual(
-				new Size(50, 70),
-				SUT.FindMeasuredSize(tb, new Size(50, 70)).Value
+				new Size(125, 25),
+				SUT.FindMeasuredSize(tb, new Size(125, 100))
 			);
 
-			Assert.IsNull(
-				SUT.FindMeasuredSize(tb, new Size(50, 69))
+			Assert.AreEqual(
+				new Size(50, 100),
+				SUT.FindMeasuredSize(tb, new Size(50, 70))
 			);
 
-			Assert.IsNull(
-				SUT.FindMeasuredSize(tb, new Size(49, 100))
+			Assert.AreEqual(
+				null,
+				SUT.FindMeasuredSize(tb, new Size(52, 70))
 			);
 
-			Assert.IsNull(
-				SUT.FindMeasuredSize(tb, new Size(50.1, 100))
+			Assert.AreEqual(
+				null,
+				SUT.FindMeasuredSize(tb, new Size(500, 500))
 			);
 		}
 
@@ -96,35 +105,35 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Controls.TextBlockTests
 			TextBlockMeasureCache.MaxMeasureKeyEntries = 2;
 			TextBlockMeasureCache.MaxMeasureSizeKeyEntries = 2;
 
-			var tb = new TextBlock() { Text = "42", TextWrapping = TextWrapping.Wrap };
+			var tb = new TextBlock { Text = "42", TextWrapping = TextWrapping.Wrap }; // Used as key, never measured
 
-			SUT.CacheMeasure(tb, new Size(11, 11), new Size(1, 1));
+			SUT.CacheMeasure(tb, new Size(11, 11), new Size(11, 11));
 			Assert.AreEqual(
-				new Size(1, 1),
-				SUT.FindMeasuredSize(tb, new Size(11, 11)).Value
+				new Size(11, 11),
+				SUT.FindMeasuredSize(tb, new Size(11, 11))
 			);
 
-			SUT.CacheMeasure(tb, new Size(22, 22), new Size(2, 2));
+			SUT.CacheMeasure(tb, new Size(22, 22), new Size(22, 22));
 			Assert.AreEqual(
-				new Size(1, 1),
-				SUT.FindMeasuredSize(tb, new Size(11, 11)).Value
+				new Size(11, 11),
+				SUT.FindMeasuredSize(tb, new Size(11, 11))
 			);
 			Assert.AreEqual(
-				new Size(2, 2),
-				SUT.FindMeasuredSize(tb, new Size(22, 22)).Value
+				new Size(22, 22),
+				SUT.FindMeasuredSize(tb, new Size(22, 22))
 			);
 
-			SUT.CacheMeasure(tb, new Size(33, 33), new Size(3, 3));
+			SUT.CacheMeasure(tb, new Size(33, 33), new Size(33, 33));
 			Assert.IsNull(
 				SUT.FindMeasuredSize(tb, new Size(11, 11))
 			);
 			Assert.AreEqual(
-				new Size(2, 2),
-				SUT.FindMeasuredSize(tb, new Size(22, 22)).Value
+				new Size(22, 22),
+				SUT.FindMeasuredSize(tb, new Size(22, 22))
 			);
 			Assert.AreEqual(
-				new Size(3, 3),
-				SUT.FindMeasuredSize(tb, new Size(33, 33)).Value
+				new Size(33, 33),
+				SUT.FindMeasuredSize(tb, new Size(33, 33))
 			);
 		}
 
@@ -136,36 +145,36 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Controls.TextBlockTests
 			TextBlockMeasureCache.MaxMeasureKeyEntries = 2;
 			TextBlockMeasureCache.MaxMeasureSizeKeyEntries = 2;
 
-			var tb1 = new TextBlock() { Text = "42", TextWrapping = TextWrapping.Wrap };
+			var tb1 = new TextBlock { Text = "42", TextWrapping = TextWrapping.Wrap }; // Used as key, never measured
 
 			SUT.CacheMeasure(tb1, new Size(11, 11), new Size(1, 1));
 			Assert.AreEqual(
 				new Size(1, 1),
-				SUT.FindMeasuredSize(tb1, new Size(11, 11)).Value
+				SUT.FindMeasuredSize(tb1, new Size(11, 11))
 			);
 
-			var tb2 = new TextBlock() { Text = "43", TextWrapping = TextWrapping.Wrap };
+			var tb2 = new TextBlock { Text = "43", TextWrapping = TextWrapping.Wrap }; // Used as key, never measured
 
 			SUT.CacheMeasure(tb2, new Size(11, 11), new Size(1, 1));
 			Assert.AreEqual(
 				new Size(1, 1),
-				SUT.FindMeasuredSize(tb2, new Size(11, 11)).Value
+				SUT.FindMeasuredSize(tb2, new Size(11, 11))
 			);
 			Assert.AreEqual(
 				new Size(1, 1),
-				SUT.FindMeasuredSize(tb1, new Size(11, 11)).Value
+				SUT.FindMeasuredSize(tb1, new Size(11, 11))
 			);
 
-			var tb3 = new TextBlock() { Text = "44", TextWrapping = TextWrapping.Wrap };
+			var tb3 = new TextBlock { Text = "44", TextWrapping = TextWrapping.Wrap }; // Used as key, never measured
 
 			SUT.CacheMeasure(tb3, new Size(11, 11), new Size(1, 1));
 			Assert.AreEqual(
 				new Size(1, 1),
-				SUT.FindMeasuredSize(tb3, new Size(11, 11)).Value
+				SUT.FindMeasuredSize(tb3, new Size(11, 11))
 			);
 			Assert.AreEqual(
 				new Size(1, 1),
-				SUT.FindMeasuredSize(tb2, new Size(11, 11)).Value
+				SUT.FindMeasuredSize(tb2, new Size(11, 11))
 			);
 			Assert.IsNull(
 				SUT.FindMeasuredSize(tb1, new Size(11, 11))
@@ -176,8 +185,7 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Controls.TextBlockTests
 		public void When_SmallerAvailableSize()
 		{
 			var SUT = new TextBlockMeasureCache();
-
-			var tb = new TextBlock() { Text = "42" };
+			var tb = new TextBlock { Text = "42" }; // Used as key, never measured
 
 			Assert.AreEqual(TextWrapping.NoWrap, tb.TextWrapping);
 

--- a/src/Uno.UI/FeatureConfiguration.cs
+++ b/src/Uno.UI/FeatureConfiguration.cs
@@ -13,7 +13,7 @@ namespace Uno.UI
 		public static class UIElement
 		{
 			/// <summary>
-			/// Enables the legacy clipping behavior which only applies binding to itself and 
+			/// Enables the legacy clipping behavior which only applies binding to itself and
 			/// its children. Normal clipping only applies to a single UIElement considering its
 			/// clipping parent, based on <see cref="Windows.UI.Xaml.UIElement.ClipChildrenToBounds"/>.
 			/// </summary>
@@ -43,7 +43,7 @@ namespace Uno.UI
 			public static bool UseLegacyApplyStylePhase { get; set; } = false;
 
 			/// <summary>
-			/// When changing a style on a <see cref="Windows.UI.Xaml.FrameworkElement"/> clears 
+			/// When changing a style on a <see cref="Windows.UI.Xaml.FrameworkElement"/> clears
 			/// the previous style setters. This property is applicable only when <see cref="UseLegacyApplyStylePhase"/>
 			/// is set to <see cref="false"/>.
 			/// </summary>
@@ -53,7 +53,7 @@ namespace Uno.UI
 			/// <summary>
 			/// Controls the propagation of <see cref="Windows.UI.Xaml.FrameworkElement.Loaded"/> and
 			/// <see cref="Windows.UI.Xaml.FrameworkElement.Unloaded"/> events through managed
-			/// or native visual tree traversal. 
+			/// or native visual tree traversal.
 			/// </summary>
 			/// <remarks>
 			/// This setting impacts significantly the loading performance of controls on Android.
@@ -66,7 +66,7 @@ namespace Uno.UI
 			/// <summary>
 			/// Controls the propagation of <see cref="Windows.UI.Xaml.FrameworkElement.Loaded"/> and
 			/// <see cref="Windows.UI.Xaml.FrameworkElement.Unloaded"/> events through managed
-			/// or native visual tree traversal. 
+			/// or native visual tree traversal.
 			/// </summary>
 			/// <remarks>
 			/// This setting impacts significantly the loading performance of controls on Web Assembly.
@@ -113,8 +113,8 @@ namespace Uno.UI
 		public static class ListViewBase
 		{
 			/// <summary>
-			/// Sets the value to use for <see cref="ItemsStackPanel.CacheLength"/> and <see cref="ItemsWrapGrid.CacheLength"/> if not set 
-			/// explicitly in Xaml or code. Higher values will cache more views either side of the visible window, improving list performance 
+			/// Sets the value to use for <see cref="ItemsStackPanel.CacheLength"/> and <see cref="ItemsWrapGrid.CacheLength"/> if not set
+			/// explicitly in Xaml or code. Higher values will cache more views either side of the visible window, improving list performance
 			/// at the expense of consuming more memory. Setting this to null will leave the default value at the UWP default of 4.0.
 			/// </summary>
 			public static double? DefaultCacheLength = 1.0;
@@ -153,20 +153,20 @@ namespace Uno.UI
 			/// Enable a mode that simplifies accessibility by automatically grouping accessible elements into top-level accessible elements. The default value is false.
 			/// </summary>
 			/// <remarks>
-			/// When enabled, the accessibility name of top-level accessible elements (elements that return a non-null AutomationPeer in <see cref="UIElement.OnCreateAutomationPeer()"/> and/or have <see cref="AutomationProperties.Name" /> set to a non-empty string) 
+			/// When enabled, the accessibility name of top-level accessible elements (elements that return a non-null AutomationPeer in <see cref="UIElement.OnCreateAutomationPeer()"/> and/or have <see cref="AutomationProperties.Name" /> set to a non-empty string)
 			/// will be an aggregate of the accessibility name of all child accessible elements.
-			/// 
-			/// For example, if you have a <see cref="Button"/> that contains 3 <see cref="TextBlock"/> "A" "B" "C", the accessibility name of the <see cref="Button"/> will be "A, B, C". 
+			///
+			/// For example, if you have a <see cref="Button"/> that contains 3 <see cref="TextBlock"/> "A" "B" "C", the accessibility name of the <see cref="Button"/> will be "A, B, C".
 			/// These 3 <see cref="TextBlock"/> will also be automatically excluded from accessibility focus.
-			/// 
+			///
 			/// This greatly facilitates accessibility, as you would need to do this manually on UWP.
-			/// 
+			///
 			/// A limitation of this strategy is that you can't nest interactive elements, as children of an accessible elements are excluded from accessibility focus.
 			/// For example, if you put a <see cref="Button"/> inside another <see cref="Button"/>, only the parent <see cref="Button"/> will be focusable.
 			/// This happens to match a limitation of iOS, which does this by default and forces developers to make elements as siblings instead of nesting them.
-			/// 
+			///
 			/// To prevent a top-level accessible element from being accessible and make its children accessibility focusable, you can set <see cref="AutomationProperties.AccessibilityViewProperty"/> to <see cref="AccessibilityView.Raw"/>.
-			/// 
+			///
 			/// Note: This is incompatible with the way accessibility works on UWP.
 			/// </remarks>
 			public static bool UseSimpleAccessibility { get; set; } = false;

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlock.wasm.cs
@@ -10,6 +10,7 @@ using Uno.UI.UI.Xaml.Documents;
 using Microsoft.Extensions.Logging;
 using Windows.UI.Text;
 using Windows.UI.Xaml.Media;
+using Uno.UI;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -42,10 +43,12 @@ namespace Windows.UI.Xaml.Controls
 			{
 				if (_cache.FindMeasuredSize(this, availableSize) is Size desiredSize)
 				{
+					UnoMetrics.TextBlock.MeasureCacheHits++;
 					return desiredSize;
 				}
 				else
 				{
+					UnoMetrics.TextBlock.MeasureCacheMisses++;
 					desiredSize = MeasureView(availableSize);
 
 					_cache.CacheMeasure(this, availableSize, desiredSize);

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureKey.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureKey.cs
@@ -1,35 +1,42 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using Windows.UI.Text;
 using Windows.UI.Xaml.Media;
 using Uno.Extensions;
 
 namespace Windows.UI.Xaml.Controls
 {
+	[DebuggerDisplay("\"{_text}\"")]
 	internal partial class TextBlockMeasureCache
 	{
 		/// <summary>
 		/// Defines text characteristics
 		/// </summary>
-		class MeasureKey
+		private class MeasureKey
 		{
 			public class Comparer : IEqualityComparer<MeasureKey>
 			{
 				public static Comparer Instance { get; } = new Comparer();
 
-				public bool Equals(MeasureKey x, MeasureKey y) =>
-					x.Text == y.Text
-					&& x.FontSize == y.FontSize
-					&& x.FontFamily == y.FontFamily
-					&& x.FontStyle == y.FontStyle
-					&& x.TextWrapping == y.TextWrapping
-					&& x.FontWeight == y.FontWeight
-					&& x.MaxLines == y.MaxLines
-					&& x.TextTrimming == y.TextTrimming
-					&& x.TextAlignment == y.TextAlignment
-					&& x.LineHeight == y.LineHeight
-					&& x.LineStackingStrategy == y.LineStackingStrategy
-					&& x.TextDecorations == y.TextDecorations
-					&& x.CharacterSpacing == y.CharacterSpacing;
+				public bool Equals(MeasureKey x, MeasureKey y)
+				{
+					var v = x._text == y._text
+						&& Math.Abs(x._fontSize - y._fontSize) < 0.1e-8
+						&& x._fontFamily == y._fontFamily
+						&& x._fontStyle == y._fontStyle
+						&& x._textWrapping == y._textWrapping
+						&& x._fontWeight == y._fontWeight
+						&& x._maxLines == y._maxLines
+						&& x._textTrimming == y._textTrimming
+						&& x._textAlignment == y._textAlignment
+						&& Math.Abs(x._lineHeight - y._lineHeight) < 0.1e-8
+						&& x._lineStackingStrategy == y._lineStackingStrategy
+						&& x._textDecorations == y._textDecorations
+						&& x._characterSpacing == y._characterSpacing;
+
+					return v;
+				}
 
 				public int GetHashCode(MeasureKey obj)
 					=> obj._hashCode;
@@ -41,44 +48,45 @@ namespace Windows.UI.Xaml.Controls
 				TextBlock source
 			)
 			{
-				FontStyle = source.FontStyle;
-				TextWrapping = source.TextWrapping;
-				FontWeight = source.FontWeight;
-				Text = source.Text;
-				FontFamily = source.FontFamily;
-				FontSize = source.FontSize;
-				MaxLines = source.MaxLines;
-				TextTrimming = source.TextTrimming;
-				TextAlignment = source.TextAlignment;
-				LineHeight = source.LineHeight;
-				LineStackingStrategy = source.LineStackingStrategy;
-				CharacterSpacing = source.CharacterSpacing;
-				TextDecorations = source.TextDecorations;
+				_fontStyle = source.FontStyle;
+				_textWrapping = source.TextWrapping;
+				_fontWeight = source.FontWeight;
+				_text = source.Text;
+				_fontFamily = source.FontFamily;
+				_fontSize = source.FontSize;
+				_maxLines = source.MaxLines;
+				_textTrimming = source.TextTrimming;
+				_textAlignment = source.TextAlignment;
+				_lineHeight = source.LineHeight;
+				_lineStackingStrategy = source.LineStackingStrategy;
+				_characterSpacing = source.CharacterSpacing;
+				_textDecorations = source.TextDecorations;
 
-				_hashCode = Text?.GetHashCode() ?? 0
-					^ FontFamily.GetHashCode()
-					^ FontSize.GetHashCode();
+				_hashCode = _text?.GetHashCode() ?? 0
+					^ _fontFamily.GetHashCode()
+					^ _fontSize.GetHashCode();
 			}
 
 			public override int GetHashCode() => _hashCode;
 
 			public override bool Equals(object obj)
-				=> obj is MeasureKey key ? Comparer.Instance.Equals(this, key) : false;
+				=> obj is MeasureKey key && Comparer.Instance.Equals(this, key);
 
-			public FontStyle FontStyle { get; }
-			public TextWrapping TextWrapping { get; }
-			public FontWeight FontWeight { get; }
-			public string Text { get; }
-			public FontFamily FontFamily { get; }
-			public double FontSize { get; }
-			public int MaxLines { get; }
-			public TextTrimming TextTrimming { get; }
-			public TextAlignment TextAlignment { get; }
-			public double LineHeight { get; }
-			public LineStackingStrategy LineStackingStrategy { get; }
-			public int CharacterSpacing { get; }
-			public TextDecorations TextDecorations { get; }
+			private readonly FontStyle _fontStyle;
+			private readonly TextWrapping _textWrapping;
+			private readonly FontWeight _fontWeight;
+			private readonly string _text;
+			private readonly FontFamily _fontFamily;
+			private readonly double _fontSize;
+			private readonly int _maxLines;
+			private readonly TextTrimming _textTrimming;
+			private readonly TextAlignment _textAlignment;
+			private readonly double _lineHeight;
+			private readonly LineStackingStrategy _lineStackingStrategy;
+			private readonly int _characterSpacing;
+			private readonly TextDecorations _textDecorations;
+
+			internal bool IsWrapping => _textWrapping != TextWrapping.NoWrap;
 		}
-
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureSizeEntry.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureSizeEntry.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
-using Uno;
 using Windows.Foundation;
+using Uno;
 
 namespace Windows.UI.Xaml.Controls
 {
@@ -17,7 +17,11 @@ namespace Windows.UI.Xaml.Controls
 				ListNode = node;
 			}
 
+			/// <summary>
+			/// Computed Size
+			/// </summary>
 			public Size MeasuredSize { get; }
+
 			public LinkedListNode<CachedTuple<double, double>> ListNode { get; }
 		}
 	}

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
@@ -1,15 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Diagnostics;
 using System.Text;
 using Windows.Foundation;
-using Windows.UI.Text;
-using Windows.UI.Xaml;
-using Windows.UI.Xaml.Media;
 using Microsoft.Extensions.Logging;
-using Uno.Extensions;
 using Uno;
-using System.Diagnostics;
+using Uno.Extensions;
 using Uno.UI;
 
 namespace Windows.UI.Xaml.Controls
@@ -36,28 +32,38 @@ namespace Windows.UI.Xaml.Controls
 		/// <returns>An optional <see cref="Size"/> if found.</returns>
 		public Size? FindMeasuredSize(TextBlock source, Size availableSize)
 		{
-			var key = new MeasureKey(source);
-
-			if (FeatureConfiguration.TextBlock.IsMeasureCacheEnabled && _entries.TryGetValue(key, out var entry))
+			if (!FeatureConfiguration.TextBlock.IsMeasureCacheEnabled)
 			{
-				var measuredSize = entry.FindMeasuredSize(key, availableSize);
+				return null; // Mesure cache feature disabled
+			}
+
+			var key = new MeasureKey(source); // Extract a key from TextBlock properties
+			if (!_entries.TryGetValue(key, out var entry))
+			{
 
 				if (this.Log().IsEnabled(LogLevel.Debug))
 				{
 					// {0} is used to avoid parsing errors caused by formatting a "{}" in the text
-					this.Log().LogDebug("{0}", $"TextMeasure-cached [{source.Text} / {source.TextWrapping} / {source.MaxLines}]: {availableSize} -> {measuredSize}");
+					this.Log().LogDebug("{0}", $"TextMeasure-cached [{source.Text} / {source.TextWrapping} / {source.MaxLines}]: {availableSize} -> NOT FOUND.");
 				}
 
-				return measuredSize;
-
+				return null; // This key not present in cache
 			}
 
-			return null;
+			var measuredSize = entry.FindMeasuredSize(key, availableSize);  // Get cache for specified availableSize, if exists
+
+			if (this.Log().IsEnabled(LogLevel.Debug))
+			{
+				// {0} is used to avoid parsing errors caused by formatting a "{}" in the text
+				this.Log().LogDebug("{0}", $"TextMeasure-cached [{source.Text} / {source.TextWrapping} / {source.MaxLines}]: {availableSize} -> {measuredSize}");
+			}
+
+			return measuredSize;
 		}
 
 		/// <summary>
 		/// Cache a <paramref name="measuredSize"/> for an <paramref name="availableSize"/>, given
-		/// the <paramref name="source"/> charateristics.
+		/// the <paramref name="source"/> characteristics.
 		/// </summary>
 		/// <param name="source"></param>
 		/// <param name="availableSize"></param>
@@ -66,19 +72,20 @@ namespace Windows.UI.Xaml.Controls
 		{
 			var key = new MeasureKey(source);
 
-			if (!_entries.TryGetValue(key, out var entry))
+			if (_entries.TryGetValue(key, out var entry))
+			{
+				if (_queue.Count > 1 && _queue.Last.Value.Equals(key))
+				{
+					// Move this key as last in the queue for perf
+					_queue.Remove(entry.ListNode);
+					_queue.AddLast(entry.ListNode);
+				}
+			}
+			else
 			{
 				Scavenge();
 				var node = _queue.AddLast(key);
 				_entries[key] = entry = new MeasureEntry(node);
-			}
-			else
-			{
-				if (_queue.Count != 0 && _queue.Last.Value != key)
-				{
-					_queue.Remove(entry.ListNode);
-					_queue.AddLast(entry.ListNode);
-				}
 			}
 
 			if (this.Log().IsEnabled(LogLevel.Debug))
@@ -92,7 +99,7 @@ namespace Windows.UI.Xaml.Controls
 
 		private void Scavenge()
 		{
-			if (_queue.Count >= MaxMeasureKeyEntries)
+			while (_queue.Count >= MaxMeasureKeyEntries)
 			{
 				_entries.Remove(_queue.First.Value);
 				_queue.RemoveFirst();

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
@@ -74,7 +74,7 @@ namespace Windows.UI.Xaml.Controls
 
 			if (_entries.TryGetValue(key, out var entry))
 			{
-				if (_queue.Count > 1 && _queue.Last.Value.Equals(key))
+				if (_queue.Count > 1 && !_queue.Last.Value.Equals(key))
 				{
 					// Move this key as last in the queue for perf
 					_queue.Remove(entry.ListNode);

--- a/src/Uno.UI/UI/Xaml/FontFamily.cs
+++ b/src/Uno.UI/UI/Xaml/FontFamily.cs
@@ -1,23 +1,20 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Windows.UI.Xaml.Media
 {
 	public partial class FontFamily
 	{
-		private readonly string _source;
 		private readonly int _hashCode;
 
 		public FontFamily(string familyName)
 		{
-			_source = familyName;
+			Source = familyName;
 
 			// This instance is immutable, we can cache the hash code.
-			_hashCode = _source.GetHashCode();
+			_hashCode = Source.GetHashCode();
 		}
 
-		public string Source => _source;
+		public string Source { get; }
 
 		// Makes introduction of FontFamily a non-breaking change (for now)
 		public static implicit operator FontFamily(string familyName) => new FontFamily(familyName);
@@ -26,16 +23,34 @@ namespace Windows.UI.Xaml.Media
 
 		public override bool Equals(object obj)
 		{
-			var fontFamily = obj as FontFamily;
-
-			if (fontFamily != null)
+			if (obj is FontFamily fontFamily)
 			{
-				return Source.Equals(fontFamily.Source);
+				return Source.Equals(fontFamily.Source, StringComparison.Ordinal);
 			}
 
 			return false;
 		}
 
 		public override int GetHashCode() => _hashCode;
+
+		public static bool operator ==(FontFamily a, FontFamily b)
+		{
+			if (ReferenceEquals(a, b))
+			{
+				return true;
+			}
+
+			return !ReferenceEquals(a, null) && a.Equals(b);
+		}
+
+		public static bool operator !=(FontFamily a, FontFamily b)
+		{
+			if (ReferenceEquals(a, b))
+			{
+				return false;
+			}
+
+			return ReferenceEquals(a, null) || !a.Equals(b);
+		}
 	}
 }

--- a/src/Uno.UI/UnoMetrics.cs
+++ b/src/Uno.UI/UnoMetrics.cs
@@ -1,0 +1,11 @@
+namespace Uno.UI
+{
+	public static class UnoMetrics
+	{
+		public static class TextBlock
+		{
+			public static long MeasureCacheMisses { get; internal set; }
+			public static long MeasureCacheHits { get; internal set; }
+		}
+	}
+}


### PR DESCRIPTION
# Bugfix
GitHub Issue (If applicable): #1062 

## What is the current behavior?
A cached value was hit even when it was the result of a constrained sized.
With this bug, a textblock with the same properties would be the same constrains
even if it's not asked anymore.

This was causing textblock measured to availableSize=[0, 0] to disappear completely.

## What is the new behavior?
Cache are now hit only when appropriate.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [X] Contains **NO** breaking changes
- [X] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [X] Associated with an issue (GitHub or internal)
