### PR TITLE
Tentative workaround for invalid incremental build of Android binding helper

### DIFF
--- a/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
+++ b/src/Uno.UI.BindingHelper.Android/Uno.UI.BindingHelper.Android.csproj
@@ -76,6 +76,19 @@
 		<Delete Files="@(_JavaFilesToDelete)" />
 	</Target>
 
+	<!-- Workaround for https://github.com/nventive/Uno/issues/986 -->
+	<Target Name="Issue986Workaround" BeforeTargets="ExportJarToXml">
+
+		<!--
+		This is required to ensure the first pass of the BindingsGenerator task is
+		executed properly (inside of ExportJarToXml). If not, the second pass in the
+		GenerateBindings target is not given proper api mappings, ending in the generation
+		of an empty assembly.
+		-->
+		
+		<Delete Files="$(IntermediateOutputPath)\api.xml" />
+	</Target>
+	
 	<ItemGroup>
 		<_CompileUnoJavaBeforeTargets Include="ExportJarToXml"/>
 		<_CompileUnoJavaBeforeTargets Include="GenerateBindings"/>


### PR DESCRIPTION
GitHub Issue (If applicable): #986

## PR Type
What kind of change does this PR introduce?
- Build or CI related changes

## What is the current behavior?
The Uno.UI.BindingHelper assembly may not contain the proper classes leading to errors involving `UnoViewGroup`, when incremental compilation is involved.

## What is the new behavior?
A temporary file is tentatively deleted to force the generation of android bindings.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
