### PR TITLE
[Wasm] Fixed measure cache when text clipping is used

### DIFF
--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -441,14 +441,6 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Transforms_On_Target.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Vanilla.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Events.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -458,6 +450,14 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Target.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Transforms_On_Target.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Vanilla.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -685,6 +685,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListViewGroupedLargeLegacy.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListViewGroupedVariableHeightComplexTemplate.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -761,18 +765,6 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
-    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_LightDismiss.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_Simple.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
-    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\MessageDialog.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
-    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Mkv_Extension.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -786,6 +778,18 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Original.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\MessageDialog.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_LightDismiss.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_Simple.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
@@ -2089,19 +2093,18 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Hyperlink_Disabled.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Nested_Buttons.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Overlapped_Buttons.xaml.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\RadioButton_Combined_Style.xaml.cs">
-      <DependentUpon>RadioButton_Combined_Style.xaml</DependentUpon>
-    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\RadioButton_Combined_Style.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\RadioButton_Multiple_Unnamed_Groups.xaml.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\RadioButton_Pressed.xaml.cs">
-      <DependentUpon>RadioButton_Pressed.xaml</DependentUpon>
-    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\RadioButton_Pressed.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\RadioButton_With_GroupName.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Radio_Button.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Simple_Button.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Simple_Button_With_CanExecute_Changing.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\VisualStateProbeControl.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_MaxDropdownHeight.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_SelectedIndex.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Transforms.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Virtualizing.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\BackGesture\BackGesture_Chooser.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\BackGesture\BackGesture_Collapsed.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\BackGesture\BackGesture_CollapsedNavigationCommand.xaml.cs" />
@@ -2121,9 +2124,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Padding.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Uppercase_Resource.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_With_Long_Sentences.xaml.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_MaxDropdownHeight.xaml.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Transforms.xaml.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Virtualizing.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\DatePicker\DatePickerSample.xaml.cs">
       <DependentUpon>DatePickerSample.xaml</DependentUpon>
     </Compile>
@@ -2131,13 +2131,13 @@
       <DependentUpon>Flyout_Attached.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_ButtonInContent.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Events.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Simple.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Target.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Transforms_On_Target.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Vanilla.xaml.cs">
       <DependentUpon>Flyout_Vanilla.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Events.xaml.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Simple.xaml.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Target.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\MenuFlyoutViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\MenuFlyout_Simple.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\FontIcon\FontIconControlTest.xaml.cs">
@@ -2239,6 +2239,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListViewGroupedLarge.xaml.cs">
       <DependentUpon>ListViewGroupedLarge.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListViewGroupedLargeLegacy.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListViewGroupedVariableHeightComplexTemplate.xaml.cs">
       <DependentUpon>ListViewGroupedVariableHeightComplexTemplate.xaml</DependentUpon>
     </Compile>
@@ -2254,6 +2255,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_ItemTemplateSelector_And_ItemContainerStyleSelector.xaml.cs">
       <DependentUpon>ListView_ItemTemplateSelector_And_ItemContainerStyleSelector.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_OwnContainer_Virtualized.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_TransformsOnList.xaml.cs">
       <DependentUpon>ListView_TransformsOnList.xaml</DependentUpon>
     </Compile>
@@ -2263,6 +2265,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Explicit_Items.xaml.cs">
       <DependentUpon>ListView_Explicit_Items.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ParallaxListView\ParallaxListView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\RandomDataTemplateSelector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MapPresenter\MapControl.xaml.cs">
       <DependentUpon>MapControl.xaml</DependentUpon>
@@ -2282,10 +2285,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Minimal.xaml.cs">
       <DependentUpon>MediaPlayerElement_Minimal.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuBarTests\SimpleMenuBar.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Stretch_Fill.xaml.cs">
       <DependentUpon>MediaPlayerElement_Stretch_Fill.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuBarTests\SimpleMenuBar.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\ChatBoxViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MediaPlayerElement\MediaPlayerElement_Mkv_Extension.xaml.cs">
       <DependentUpon>MediaPlayerElement_Mkv_Extension.xaml</DependentUpon>
@@ -2368,9 +2371,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\TimePickerViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\NavigationViewTests\NavigationView_TopNavigation.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Pivot\PivotSimpleTest.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\MessageDialog.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_LightDismiss.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_Simple.xaml.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\MessageDialog.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Progress\ProgressRing.xaml.cs">
       <DependentUpon>ProgressRing.xaml</DependentUpon>
     </Compile>
@@ -2606,7 +2609,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_SelectedItem.xaml.cs">
       <DependentUpon>ListView_SelectedItem.xaml</DependentUpon>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ParallaxListView\ParallaxListView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ScrollIntoViewTest.xaml.cs">
       <DependentUpon>ScrollIntoViewTest.xaml</DependentUpon>
     </Compile>
@@ -3152,8 +3154,353 @@
     <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\GridTestsControl\Simpletwocolumnsplitgrid.xaml.cs">
       <DependentUpon>Simpletwocolumnsplitgrid.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\Src\GitHub\nventive\Uno\src\SamplesApp\UITests.Shared\Windows_UI_Xaml_Controls\Pivot\PivotSimpleTest.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Pivot\PivotSimpleTest.xaml.cs">
       <DependentUpon>PivotSimpleTest.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Lottie\SampleLottieAnimation.xaml.cs">
+      <DependentUpon>SampleLottieAnimation.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Wasm\Wasm_CustomEvent.xaml.cs">
+      <DependentUpon>Wasm_CustomEvent.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_Globalization\Language_Properties.xaml.cs">
+      <DependentUpon>Language_Properties.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_Security_Credentials\PasswordVaultTests\CredentialsPersistence.xaml.cs">
+      <DependentUpon>CredentialsPersistence.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Core\SystemNavigationManagerTests\HardwareBackButton.xaml.cs">
+      <DependentUpon>HardwareBackButton.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\Arrange_Performance01.xaml.cs">
+      <DependentUpon>Arrange_Performance01.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml\UIElementTests\TransformToVisual_Simple.xaml.cs">
+      <DependentUpon>TransformToVisual_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\AutoSuggestBoxTests\BasicAutoSuggestBox.xaml.cs">
+      <DependentUpon>BasicAutoSuggestBox.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\AppBarButtonTest.xaml.cs">
+      <DependentUpon>AppBarButtonTest.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\AppBarButtonWithIconTest.xaml.cs">
+      <DependentUpon>AppBarButtonWithIconTest.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\AppBarToggleButtonTest.xaml.cs">
+      <DependentUpon>AppBarToggleButtonTest.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Buttons.xaml.cs">
+      <DependentUpon>Buttons.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Button_IsEnabled.xaml.cs">
+      <DependentUpon>Button_IsEnabled.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\CheckBox_Button.xaml.cs">
+      <DependentUpon>CheckBox_Button.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\CheckBox_Button_UWA_Style.xaml.cs">
+      <DependentUpon>CheckBox_Button_UWA_Style.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\CheckBox_Button_With_CanExecute_Changing.xaml.cs">
+      <DependentUpon>CheckBox_Button_With_CanExecute_Changing.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\ComboBox_Simple.xaml.cs">
+      <DependentUpon>ComboBox_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Custom_Button_With_ContentTemplate.xaml.cs">
+      <DependentUpon>Custom_Button_With_ContentTemplate.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Custom_Button_With_ContentTemplate_And_StackPanel.xaml.cs">
+      <DependentUpon>Custom_Button_With_ContentTemplate_And_StackPanel.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Hyperlink_Button.xaml.cs">
+      <DependentUpon>Hyperlink_Button.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Hyperlink_CanExecute_False.xaml.cs">
+      <DependentUpon>Hyperlink_CanExecute_False.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Hyperlink_Disabled.xaml.cs">
+      <DependentUpon>Hyperlink_Disabled.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Nested_Buttons.xaml.cs">
+      <DependentUpon>Nested_Buttons.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Overlapped_Buttons.xaml.cs">
+      <DependentUpon>Overlapped_Buttons.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\RadioButton_Combined_Style.xaml.cs">
+      <DependentUpon>RadioButton_Combined_Style.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\RadioButton_Multiple_Unnamed_Groups.xaml.cs">
+      <DependentUpon>RadioButton_Multiple_Unnamed_Groups.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\RadioButton_Pressed.xaml.cs">
+      <DependentUpon>RadioButton_Pressed.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\RadioButton_With_GroupName.xaml.cs">
+      <DependentUpon>RadioButton_With_GroupName.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Radio_Button.xaml.cs">
+      <DependentUpon>Radio_Button.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Simple_Button.xaml.cs">
+      <DependentUpon>Simple_Button.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Button\Simple_Button_With_CanExecute_Changing.xaml.cs">
+      <DependentUpon>Simple_Button_With_CanExecute_Changing.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_MaxDropdownHeight.xaml.cs">
+      <DependentUpon>ComboBox_MaxDropdownHeight.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_SelectedIndex.xaml.cs">
+      <DependentUpon>ComboBox_SelectedIndex.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Transforms.xaml.cs">
+      <DependentUpon>ComboBox_Transforms.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ComboBox\ComboBox_Virtualizing.xaml.cs">
+      <DependentUpon>ComboBox_Virtualizing.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_BackGesture.xaml.cs">
+      <DependentUpon>CommandBar_BackGesture.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Content.xaml.cs">
+      <DependentUpon>CommandBar_Content.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Dynamic.xaml.cs">
+      <DependentUpon>CommandBar_Dynamic.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Examples.xaml.cs">
+      <DependentUpon>CommandBar_Examples.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Extensions.xaml.cs">
+      <DependentUpon>CommandBar_Extensions.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Flyout.xaml.cs">
+      <DependentUpon>CommandBar_Flyout.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_LongTitle.xaml.cs">
+      <DependentUpon>CommandBar_LongTitle.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Native.xaml.cs">
+      <DependentUpon>CommandBar_Native.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Padding.xaml.cs">
+      <DependentUpon>CommandBar_Padding.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_Uppercase_Resource.xaml.cs">
+      <DependentUpon>CommandBar_Uppercase_Resource.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\CommandBar\CommandBar_With_Long_Sentences.xaml.cs">
+      <DependentUpon>CommandBar_With_Long_Sentences.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_ButtonInContent.xaml.cs">
+      <DependentUpon>Flyout_ButtonInContent.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Events.xaml.cs">
+      <DependentUpon>Flyout_Events.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Simple.xaml.cs">
+      <DependentUpon>Flyout_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Target.xaml.cs">
+      <DependentUpon>Flyout_Target.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\Flyout_Transforms_On_Target.xaml.cs">
+      <DependentUpon>Flyout_Transforms_On_Target.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Flyout\MenuFlyout_Simple.xaml.cs">
+      <DependentUpon>MenuFlyout_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListViewGroupedLargeLegacy.xaml.cs">
+      <DependentUpon>ListViewGroupedLargeLegacy.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_OwnContainer_Virtualized.xaml.cs">
+      <DependentUpon>ListView_OwnContainer_Virtualized.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\MenuBarTests\SimpleMenuBar.xaml.cs">
+      <DependentUpon>SimpleMenuBar.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\NavigationViewTests\NavigationView_TopNavigation.xaml.cs">
+      <DependentUpon>NavigationView_TopNavigation.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Pivot\PivotSimpleTest.xaml.cs">
+      <DependentUpon>PivotSimpleTest.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\MessageDialog.xaml.cs">
+      <DependentUpon>MessageDialog.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_LightDismiss.xaml.cs">
+      <DependentUpon>Popup_LightDismiss.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\Popup_Simple.xaml.cs">
+      <DependentUpon>Popup_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ScrollViewerTests\ScrollViewer_Options.xaml.cs">
+      <DependentUpon>ScrollViewer_Options.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_FontSize_Changing.xaml.cs">
+      <DependentUpon>Attributed_text_FontSize_Changing.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_Simple.xaml.cs">
+      <DependentUpon>Attributed_text_Simple.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_Simple_databound.xaml.cs">
+      <DependentUpon>Attributed_text_Simple_databound.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Attributed_text_Supserscript.xaml.cs">
+      <DependentUpon>Attributed_text_Supserscript.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock.xaml.cs">
+      <DependentUpon>Progressing_TextBlock.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock_with_inline_margin.xaml.cs">
+      <DependentUpon>Progressing_TextBlock_with_inline_margin.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Progressing_TextBlock_with_margin.xaml.cs">
+      <DependentUpon>Progressing_TextBlock_with_margin.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_One.xaml.cs">
+      <DependentUpon>SimpleText_MaxLines_One.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two.xaml.cs">
+      <DependentUpon>SimpleText_MaxLines_Two.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two_with_Different_Fonts.xaml.cs">
+      <DependentUpon>SimpleText_MaxLines_Two_with_Different_Fonts.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two_With_Wrap.xaml.cs">
+      <DependentUpon>SimpleText_MaxLines_Two_With_Wrap.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxLines_Two_With_Wrap_And_Trim.xaml.cs">
+      <DependentUpon>SimpleText_MaxLines_Two_With_Wrap_And_Trim.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxWidth_NaN.xaml.cs">
+      <DependentUpon>SimpleText_MaxWidth_NaN.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\SimpleText_MaxWidth_Wrap.xaml.cs">
+      <DependentUpon>SimpleText_MaxWidth_Wrap.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Simple_Contrained_Horizontal_Center_Wrap.xaml.cs">
+      <DependentUpon>Simple_Contrained_Horizontal_Center_Wrap.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Simple_Contrained_Horizontal_Center_Wrap2.xaml.cs">
+      <DependentUpon>Simple_Contrained_Horizontal_Center_Wrap2.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Simple_Text.xaml.cs">
+      <DependentUpon>Simple_Text.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Simple_Text_Font_Weight_Bold.xaml.cs">
+      <DependentUpon>Simple_Text_Font_Weight_Bold.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlockMultilineInStarStackPanel.xaml.cs">
+      <DependentUpon>TextBlockMultilineInStarStackPanel.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlockSimpleContrainedHorizontalCenterWrap2.xaml.cs">
+      <DependentUpon>TextBlockSimpleContrainedHorizontalCenterWrap2.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlockTimespan.xaml.cs">
+      <DependentUpon>TextBlockTimespan.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\Textblocktimespancustomformat.xaml.cs">
+      <DependentUpon>Textblocktimespancustomformat.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_CharacterSpacing.xaml.cs">
+      <DependentUpon>TextBlock_CharacterSpacing.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_ConstrainedByContainer.xaml.cs">
+      <DependentUpon>TextBlock_ConstrainedByContainer.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_FixedWidth_With_DataBound_Run.xaml.cs">
+      <DependentUpon>TextBlock_FixedWidth_With_DataBound_Run.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_FontWeight.xaml.cs">
+      <DependentUpon>TextBlock_FontWeight.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Hyperlink.xaml.cs">
+      <DependentUpon>TextBlock_Hyperlink.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Hyperlink_Touch.xaml.cs">
+      <DependentUpon>TextBlock_Hyperlink_Touch.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Inlines_TemplatedParent.xaml.cs">
+      <DependentUpon>TextBlock_Inlines_TemplatedParent.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_Inlines.xaml.cs">
+      <DependentUpon>TextBlock_LineHeight_Inlines.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_Multiline.xaml.cs">
+      <DependentUpon>TextBlock_LineHeight_Multiline.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_TextAlignment.xaml.cs">
+      <DependentUpon>TextBlock_LineHeight_TextAlignment.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_LineHeight_TextTrimming.xaml.cs">
+      <DependentUpon>TextBlock_LineHeight_TextTrimming.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_MeasurePeformance.xaml.cs">
+      <DependentUpon>TextBlock_MeasurePeformance.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Multiline_In_StarStackPanel.xaml.cs">
+      <DependentUpon>TextBlock_Multiline_In_StarStackPanel.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Nested_Measure_With_Outer_Alignments.xaml.cs">
+      <DependentUpon>TextBlock_Nested_Measure_With_Outer_Alignments.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Padding.xaml.cs">
+      <DependentUpon>TextBlock_Padding.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Progressing_Trim.xaml.cs">
+      <DependentUpon>TextBlock_Progressing_Trim.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Run_Inheritance.xaml.cs">
+      <DependentUpon>TextBlock_Run_Inheritance.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Span.xaml.cs">
+      <DependentUpon>TextBlock_Span.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Special_Character.xaml.cs">
+      <DependentUpon>TextBlock_Special_Character.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_Style_Inheritance.xaml.cs">
+      <DependentUpon>TextBlock_Style_Inheritance.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_TextAlignment.xaml.cs">
+      <DependentUpon>TextBlock_TextAlignment.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_TextTrimming_VerticalAlignment_Stretch.xaml.cs">
+      <DependentUpon>TextBlock_TextTrimming_VerticalAlignment_Stretch.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBlock_UpdatePerformance.xaml.cs">
+      <DependentUpon>TextBlock_UpdatePerformance.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBoxSizeChanging.xaml.cs">
+      <DependentUpon>TextBoxSizeChanging.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBoxSizeChangingInlines.xaml.cs">
+      <DependentUpon>TextBoxSizeChangingInlines.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBox_Size_Changing.xaml.cs">
+      <DependentUpon>TextBox_Size_Changing.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\TextBlockControl\TextBox_Size_Changing_Inlines.xaml.cs">
+      <DependentUpon>TextBox_Size_Changing_Inlines.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToggleSwitchControl\Native_ToggleSwitch.xaml.cs">
+      <DependentUpon>Native_ToggleSwitch.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToggleSwitchControl\ToggleSwitchUnloadReload.xaml.cs">
+      <DependentUpon>ToggleSwitchUnloadReload.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToggleSwitchControl\ToggleSwitch_Custom.xaml.cs">
+      <DependentUpon>ToggleSwitch_Custom.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToggleSwitchControl\ToggleSwitch_Default_Style.xaml.cs">
+      <DependentUpon>ToggleSwitch_Default_Style.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ToggleSwitchControl\ToggleSwitch_IsOn.xaml.cs">
+      <DependentUpon>ToggleSwitch_IsOn.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Slider/Slider_Inside_ListViewHeader.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Slider/Slider_Inside_ListViewHeader.xaml.cs
@@ -6,7 +6,8 @@ namespace Uno.UI.Samples.Content.UITests.Slider
 	[SampleControlInfoAttribute("Slider", "Slider_Inside_ListViewHeader")]
 	public sealed partial class Slider_Inside_ListViewHeader : UserControl
     {
-		double OverallPerformance = 0.0;
+#pragma warning disable CS0414
+		private double OverallPerformance = 0.0; // Used in XAML
 
         public Slider_Inside_ListViewHeader()
         {

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_One.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_One.xaml
@@ -30,6 +30,14 @@
 				FontSize="20"
 				MaxLines="1"  />
 		</Border>
+
+		<Border Width="{Binding Value, ElementName=slider}" Background="Yellow" Grid.Row="2" x:Name="border2">
+			<TextBlock
+				Text="This is a very very very very long text that should not wrap even though it goes out of the screen"
+				FontSize="20"
+				TextTrimming="CharacterEllipsis"
+				MaxLines="1"  />
+		</Border>
 		<wasm:TextBlock Grid.Row="3">
 			(WASM ONLY) Cache: Hits=<Run x:Name="hits">0</Run>, Misses=<Run x:Name="misses">0</Run>.
 		</wasm:TextBlock>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/SimpleText_MaxLines_Two_With_Wrap.xaml
@@ -18,27 +18,48 @@
 	<Grid>
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
-			<RowDefinition Height="*" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="Auto" />
 			<RowDefinition Height="*" />
 			<RowDefinition Height="Auto" />
 		</Grid.RowDefinitions>
 		<Slider Minimum="10" Maximum="1600" Value="350" x:Name="slider"/>
+		<Slider Minimum="5" Maximum="300" Value="70" x:Name="sliderV" Grid.Row="1"/>
 
-		<Border Width="{Binding Value, ElementName=slider}" Background="Cyan" Grid.Row="1" x:Name="border1">
+		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Cyan" Grid.Row="2" x:Name="border1">
 			<TextBlock
-				Text="This is a very very very very long WRAPPING text that *should* wrap because it goes out of the screen"
+				Text="This is a very very very very long WRAPPING (Wrap) text that *should* wrap because it goes out of the screen"
 				FontSize="20"
 				TextWrapping="Wrap"
 				MaxLines="2"  />
 		</Border>
-		<Border Width="{Binding Value, ElementName=slider}" Background="Yellow" Grid.Row="2" x:Name="border2">
+		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Yellow" Grid.Row="3" x:Name="border2">
 			<TextBlock
 				Text="This is a very very very very long WRAPPING (WrapWholeWords) text that *should* wrap because it goes out of the screen"
 				FontSize="20"
 				TextWrapping="WrapWholeWords"
 				MaxLines="2"  />
 		</Border>
-		<wasm:TextBlock Grid.Row="3">
+		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Cyan" Grid.Row="4" x:Name="border3">
+			<TextBlock
+				Text="This is a very very very very long WRAPPING (WrapWholeWords/CharacterEllipsis) text that *should* wrap because it goes out of the screen"
+				FontSize="20"
+				TextWrapping="Wrap"
+				TextTrimming="CharacterEllipsis"
+				MaxLines="2"  />
+		</Border>
+		<Border Width="{Binding Value, ElementName=slider}" Height="{Binding Value, ElementName=sliderV}" Background="Yellow" Grid.Row="5" x:Name="border4">
+			<TextBlock
+				Text="This is a very very very very long WRAPPING (Wrap/CharacterEllipsis) text that *should* wrap because it goes out of the screen"
+				FontSize="20"
+				TextWrapping="WrapWholeWords"
+				TextTrimming="CharacterEllipsis"
+				MaxLines="2"  />
+		</Border>
+		<wasm:TextBlock Grid.Row="7">
 			(WASM ONLY) Cache: Hits=<Run x:Name="hits">0</Run>, Misses=<Run x:Name="misses">0</Run>.
 		</wasm:TextBlock>
 	</Grid>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_ConstrainedByContainer.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/TextBlockControl/TextBlock_ConstrainedByContainer.xaml
@@ -26,7 +26,7 @@
 				   Width="200" 
 				   Fill="Black" />
 
-		<TextBlock Text="The following TextBlock is inside a 20x200 Border. There is enough space for one line of text so it should trim"
+		<TextBlock Text="The following TextBlock is inside a 200x20 Border. There is enough space for one line of text so it should trim"
 		           TextWrapping="WrapWholeWords"/>
 
 		<Border Height="20"
@@ -43,7 +43,7 @@
 				   Width="200" 
 				   Fill="Black" />
 
-		<TextBlock Text="The following TextBlock is inside a 40x200 Border. There is enough space for two lines of text so it should wrap and trim"
+		<TextBlock Text="The following TextBlock is inside a 200x40 Border. There is enough space for two lines of text so it should wrap and trim"
 		           TextWrapping="WrapWholeWords"/>
 
 		<Border Height="40"
@@ -60,7 +60,7 @@
 				   Width="200" 
 				   Fill="Black" />
 
-		<TextBlock Text="The following TextBlock is inside a 80x200 Border. There is enough text and space for 4 lines of text but the TextBlock has a MaxLines of 3."
+		<TextBlock Text="The following TextBlock is inside a 200x80 Border. There is enough text and space for 4 lines of text but the TextBlock has a MaxLines of 3."
 		           TextWrapping="WrapWholeWords"/>
 
 		<Border Height="80"

--- a/src/Uno.UI.Tests/Windows_UI_Xaml_Controls/TextBlockTests/Given_TextBlockMeasureCache.cs
+++ b/src/Uno.UI.Tests/Windows_UI_Xaml_Controls/TextBlockTests/Given_TextBlockMeasureCache.cs
@@ -65,11 +65,49 @@ namespace Uno.UI.Tests.Windows_UI_Xaml_Controls.TextBlockTests
 		}
 
 		[TestMethod]
-		public void When_DefaultTextBlock_Wrap()
+		[DataRow(TextTrimming.Clip, DisplayName = "TextTrimming.Clip")]
+		[DataRow(TextTrimming.CharacterEllipsis, DisplayName = "TextTrimming.CharacterEllipsis")]
+		[DataRow(TextTrimming.WordEllipsis, DisplayName = "TextTrimming.WordEllipsis")]
+		public void When_DefaultTextBlock_Clip(TextTrimming trimmingMode)
 		{
 			var SUT = new TextBlockMeasureCache();
 
-			var tb = new TextBlock { Text = "42", TextWrapping = TextWrapping.Wrap }; // Used as key, never measured
+			var tb = new TextBlock { Text = "42", TextTrimming = trimmingMode }; // Used as key, never measured
+
+			SUT.CacheMeasure(tb, new Size(200, 100), new Size(125, 25));
+			SUT.CacheMeasure(tb, new Size(100, 100), new Size(100, 50));
+			SUT.CacheMeasure(tb, new Size(75, 100), new Size(75, 100));
+			SUT.CacheMeasure(tb, new Size(50, 100), new Size(50, 100));
+
+			Assert.AreEqual(
+				new Size(125, 25),
+				SUT.FindMeasuredSize(tb, new Size(125, 100))
+			);
+
+			Assert.AreEqual(
+				new Size(50, 100),
+				SUT.FindMeasuredSize(tb, new Size(50, 70))
+			);
+
+			Assert.AreEqual(
+				null,
+				SUT.FindMeasuredSize(tb, new Size(52, 70))
+			);
+
+			Assert.AreEqual(
+				null,
+				SUT.FindMeasuredSize(tb, new Size(500, 500))
+			);
+		}
+
+		[TestMethod]
+		[DataRow(TextWrapping.Wrap, DisplayName = "TextWrapping.Wrap")]
+		[DataRow(TextWrapping.WrapWholeWords, DisplayName = "TextWrapping.WrapWholeWords")]
+		public void When_DefaultTextBlock_Wrap(TextWrapping wrappingMode)
+		{
+			var SUT = new TextBlockMeasureCache();
+
+			var tb = new TextBlock { Text = "42", TextWrapping = wrappingMode }; // Used as key, never measured
 
 			SUT.CacheMeasure(tb, new Size(200, 100), new Size(125, 25));
 			SUT.CacheMeasure(tb, new Size(100, 100), new Size(100, 50));

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureEntry.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureEntry.cs
@@ -33,6 +33,7 @@ namespace Windows.UI.Xaml.Controls
 				}
 
 				var isWrapping = key.IsWrapping;
+				var isClipping = key.IsClipping;
 
 				foreach (var kvp in _sizes)
 				{
@@ -43,7 +44,7 @@ namespace Windows.UI.Xaml.Controls
 					var measurementAvailableWidth = size.Item1;
 					var measurementAvailableHeight = size.Item2;
 
-					if (isWrapping)
+					if (isWrapping || isClipping)
 					{
 						if (measurementCachedWidth <= currentAvailableWidth
 							&& currentAvailableWidth <= measurementAvailableWidth)

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureKey.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.MeasureKey.cs
@@ -87,6 +87,7 @@ namespace Windows.UI.Xaml.Controls
 			private readonly TextDecorations _textDecorations;
 
 			internal bool IsWrapping => _textWrapping != TextWrapping.NoWrap;
+			internal bool IsClipping => _textTrimming != TextTrimming.None;
 		}
 	}
 }

--- a/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/TextBlock/TextBlockMeasureCache.cs
@@ -20,8 +20,8 @@ namespace Windows.UI.Xaml.Controls
 
 		private static Stopwatch _timer = Stopwatch.StartNew();
 
-		private Dictionary<MeasureKey, MeasureEntry> _entries = new Dictionary<MeasureKey, MeasureEntry>(new MeasureKey.Comparer());
-		private LinkedList<MeasureKey> _queue = new LinkedList<MeasureKey>();
+		private readonly Dictionary<MeasureKey, MeasureEntry> _entries = new Dictionary<MeasureKey, MeasureEntry>(new MeasureKey.Comparer());
+		private readonly LinkedList<MeasureKey> _queue = new LinkedList<MeasureKey>();
 
 		/// <summary>
 		/// Finds a cached measure for the provided <see cref="TextBlock"/> characteristics


### PR DESCRIPTION
## Bugfix
GitHub Issue (If applicable): #1062
PR #1063

## What is the current behavior?
Il previous PR, the bug was still present if the text was clipping.

## What is the new behavior?
When the clipping is activated, it will behave like it's wrapping.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tested code with current [supported SDKs](../README.md#supported)
- [X] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [X] Contains **NO** breaking changes
- ~~[ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)~~
- [X] Associated with an issue (GitHub or internal)
