### PR TITLE
GitHub labels will now be automatically applied when people use the new issue button

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,9 +1,7 @@
 ---
 name: Bug Report
 about: Report a bug encountered while developing with Uno
-labels:
-- kind/bug
-- triage/untriaged
+labels: kind/bug, triage/untriaged
 ---
 
 <!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!

--- a/.github/ISSUE_TEMPLATE/documentation-issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation-issue.md
@@ -1,10 +1,7 @@
 ---
 name: Documentation Issue
 about: Report a issue with the Uno documentation
-labels:
-- kind/consumer-experience
-- kind/documentation
-- triage/untriaged
+labels: kind/consumer-experience, kind/documentation, triage/untriaged
 ---
 
 <!-- Please only use this template for reporting issues with the documentation where the fix isn't clear. We greatly appreciate it when people send in pull-requests with fixes. If there's any friction, apart from knowledge, that's preventing you from doing so please let us know below. -->

--- a/.github/ISSUE_TEMPLATE/documentation-request.md
+++ b/.github/ISSUE_TEMPLATE/documentation-request.md
@@ -1,10 +1,7 @@
 ---
 name: Documentation Request
 about: Request an enhancement to the Uno documentation
-labels:
-- kind/consumer-experience
-- kind/documentation
-- triage/untriaged
+labels: kind/consumer-experience, kind/documentation, triage/untriaged
 ---
 
 <!-- Please only use this template for submitting documentation requests -->

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,9 +1,7 @@
 ---
 name: Enhancement Request
 about: Suggest an enhancement to the Uno project
-labels:
-- kind/enhancement
-- triage/untriaged
+labels: kind/enhancement, triage/untriaged
 ---
 
 <!-- Please only use this template for submitting enhancement requests -->

--- a/.github/ISSUE_TEMPLATE/feedback.md
+++ b/.github/ISSUE_TEMPLATE/feedback.md
@@ -1,9 +1,7 @@
 ---
 name: Feedback
 about: Share feedback with the Uno team 💖
-labels:
-- kind/feedback
-- triage/untriaged
+labels: kind/feedback, triage/untriaged
 ---
 
 <!-- Thanks for stopping on by to share feedback 💖

--- a/.github/ISSUE_TEMPLATE/samples-issue.md
+++ b/.github/ISSUE_TEMPLATE/samples-issue.md
@@ -1,10 +1,7 @@
 ---
 name: Samples Issue
 about: Report a issue with the Uno samples
-labels:
-- kind/consumer-experience
-- kind/documentation
-- triage/untriaged
+labels: kind/contributor-experience, kind/documentation, triage/untriaged
 ---
 
 <!-- Please only use this template for reporting issues with the samples where the fix isn't clear. We greatly appreciate it when people send in pull-requests with fixes. If there's any friction, apart from knowledge, that's preventing you from doing so please let us know below. -->

--- a/.github/ISSUE_TEMPLATE/samples-request.md
+++ b/.github/ISSUE_TEMPLATE/samples-request.md
@@ -1,10 +1,7 @@
 ---
 name: Samples Request
 about: Request an enhancement to the Uno samples
-labels:
-- kind/consumer-experience
-- kind/documentation
-- triage/untriaged
+labels: kind/contributor-experience, kind/documentation, triage/untriaged
 ---
 
 <!-- Please only use this template for submitting enhancement requests -->

--- a/.github/ISSUE_TEMPLATE/success-story.md
+++ b/.github/ISSUE_TEMPLATE/success-story.md
@@ -1,10 +1,7 @@
 ---
 name: Success Story
 about: If you are using Uno in production, we would love to hear about it.
-labels:
-- kind/consumer-experience
-- kind/documentation
-- triage/untriaged
+labels: kind/consumer-experience, kind/documentation, triage/untriaged
 ---
 
 <!-- STOP -- PLEASE READ!


### PR DESCRIPTION
GitHub Issue (If applicable): #

## PR Type
What kind of change does this PR introduce?
- Other

It turns out GitHub requires multiple labels to be separated by commas:

https://raw.githubusercontent.com/ghuntley/cccccchnfddrftgubenfebrvtduutuvtfvtgdtidj/master/.github/ISSUE_TEMPLATE/bug_report.md

https://help.github.com/en/articles/creating-issue-templates-for-your-repository

## What is the current behavior?

When someone uses the `new issue` button the labels are not automatically applied.

## What is the new behavior?

Labels are automatically applied.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
