### PR TITLE
Docs - filter event handlers from implemented views

### DIFF
--- a/src/Uno.UWPSyncGenerator/DocGenerator.cs
+++ b/src/Uno.UWPSyncGenerator/DocGenerator.cs
@@ -122,19 +122,15 @@ namespace Uno.UWPSyncGenerator
 							}
 
 							var properties = view.UAPSymbol.GetMembers().OfType<IPropertySymbol>().Select(p => GetAllMatchingPropertyMember(view, p)).ToArray();
-							var methods = view.UAPSymbol.GetMembers().OfType<IMethodSymbol>().Where(m => m.MethodKind == MethodKind.Ordinary).Select(m => GetAllMatchingMethods(view, m)).ToArray();
-							var events = view.UAPSymbol.GetMembers().OfType<IEventSymbol>().Select(e => GetAllMatchingEvents(view, e)).ToArray();
-
-							var allMethods = view.UAPSymbol.GetMembers().OfType<IMethodSymbol>().ToArray();
-							var allMethodNames = allMethods.Select(m => m.Name).ToArray();
-							var methodNames = view.UAPSymbol
-								.GetMembers()
-								.OfType<IMethodSymbol>()
+							var methods = view.UAPSymbol
+								.GetMembers().
+								OfType<IMethodSymbol>()
 								.Where(m => m.MethodKind == MethodKind.Ordinary &&
 									!(m.Name.StartsWith("add_") || m.Name.StartsWith("remove_")) // Filter out explicit event add/remove methods (associated with routed events). These should already be filtered out by the MethodKind.Ordinary check but for some reason, on the build server only, aren't.
 								)
-								.Select(m => m.Name)
+								.Select(m => GetAllMatchingMethods(view, m))
 								.ToArray();
+							var events = view.UAPSymbol.GetMembers().OfType<IEventSymbol>().Select(e => GetAllMatchingEvents(view, e)).ToArray();
 
 							AppendImplementedMembers("properties", "Property", properties);
 							AppendImplementedMembers("methods", "Method", methods);

--- a/src/Uno.UWPSyncGenerator/DocGenerator.cs
+++ b/src/Uno.UWPSyncGenerator/DocGenerator.cs
@@ -123,8 +123,8 @@ namespace Uno.UWPSyncGenerator
 
 							var properties = view.UAPSymbol.GetMembers().OfType<IPropertySymbol>().Select(p => GetAllMatchingPropertyMember(view, p)).ToArray();
 							var methods = view.UAPSymbol
-								.GetMembers().
-								OfType<IMethodSymbol>()
+								.GetMembers()
+								.OfType<IMethodSymbol>()
 								.Where(m => m.MethodKind == MethodKind.Ordinary &&
 									!(m.Name.StartsWith("add_") || m.Name.StartsWith("remove_")) // Filter out explicit event add/remove methods (associated with routed events). These should already be filtered out by the MethodKind.Ordinary check but for some reason, on the build server only, aren't.
 								)


### PR DESCRIPTION
Remove debugging code, put filter in the correct place


GitHub Issue (If applicable): #267
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
<!-- Please uncomment one ore more that apply to this PR -->

<!-- - Bugfix -->
<!-- - Feature -->
<!-- - Code style update (formatting) -->
<!-- - Refactoring (no functional changes, no api changes) -->
<!-- - Build or CI related changes -->
 - Documentation content changes
<!-- - Other... Please describe: -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?
<!-- Please describe the new behavior after your modifications. -->


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->