### PR TITLE
Fix infinite loop when closing a "FullScreenDropDown"

### DIFF
--- a/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/ComboBox/ComboBox.cs
@@ -274,10 +274,10 @@ namespace Windows.UI.Xaml.Controls
 				if (_combo.IsPopupFullscreen)
 				{
 					// Size : Note we set both Min and Max to match the UWP behavior which alter only those properties
-					child.MinWidth = visibleSize.Width;
-					child.MinHeight = visibleSize.Height;
-					child.MaxWidth = visibleSize.Width;
-					child.MaxHeight = visibleSize.Height;
+					child.MinWidth = available.Width;
+					child.MinHeight = available.Height;
+					child.MaxWidth = available.Width;
+					child.MaxHeight = available.Height;
 				}
 				else
 				{

--- a/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
+++ b/src/Uno.UI/UI/Xaml/Controls/Popup/PopupBase.cs
@@ -117,7 +117,7 @@ namespace Windows.UI.Xaml.Controls
 			/// Measure the content of the popup
 			/// </summary>
 			/// <param name="available">The available size to place to render the popup. This is expected to be the screen size.</param>
-			/// <param name="visibleSize">The size of the visible bounds of the window. This is expected to ba AtMost the available.</param>
+			/// <param name="visibleSize">The size of the visible bounds of the window. This is expected to be AtMost the available.</param>
 			/// <returns>The desired size to render the content</returns>
 			Size Measure(Size available, Size visibleSize);
 


### PR DESCRIPTION
+ Fix bottom padding of picker on iPhone X*

## BugFix
App crashes when closing the picker on iOS

## What is the current behavior?
The `visibleBounds` are not constrained by the `available` / `finalSize` so the `ICustomPopupLayouter` receive unexpected values when the popup is being closed, especially since we make sure sure to set those  `available` / `finalSize` to `0,0` when closing popup.

## What is the new behavior?
`visibleBounds` are "at most" the `available` / `finalSize`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)