### PR TITLE
resolve SamplesApp crashing upon startup on UWP

### DIFF
--- a/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
+++ b/src/SamplesApp/SamplesApp.Shared/App.xaml.cs
@@ -51,14 +51,15 @@ namespace SamplesApp
 		protected override void OnLaunched(LaunchActivatedEventArgs e)
 		{
 			var sw = Stopwatch.StartNew();
-			var n = Windows.UI.Xaml.Window.Current.Dispatcher.RunAsync(
-				CoreDispatcherPriority.Idle,
-				() => Console.WriteLine("Done loading " + sw.Elapsed));
+			var n = Window.Current.Dispatcher.RunIdleAsync(_ =>
+			{
+				Console.WriteLine("Done loading " + sw.Elapsed);
+			});
 
 #if DEBUG
 			if (System.Diagnostics.Debugger.IsAttached)
 			{
-			   // this.DebugSettings.EnableFrameRateCounter = true;
+				// this.DebugSettings.EnableFrameRateCounter = true;
 			}
 #endif
 			Frame rootFrame = Windows.UI.Xaml.Window.Current.Content as Frame;
@@ -186,12 +187,12 @@ namespace SamplesApp
 							}
 #endif
 
-							var t =  SampleControl.Presentation.SampleChooserViewModel.Instance.SetSelectedSample(CancellationToken.None, metadataName);
+							var t = SampleControl.Presentation.SampleChooserViewModel.Instance.SetSelectedSample(CancellationToken.None, metadataName);
 							var timeout = Task.Delay(30000);
 
 							await Task.WhenAny(t, timeout);
 
-							if(!(t.IsCompleted && !t.IsFaulted))
+							if (!(t.IsCompleted && !t.IsFaulted))
 							{
 								throw new TimeoutException();
 							}


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes https://github.com/nventive/Uno/pull/1111

## PR Type
What kind of change does this PR introduce?

- Bugfix

## What is the current behavior?

The samples app on UWP goes 💥 upon startup.

## What is the new behavior?

🥇 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [ ] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [ ] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
