### PR TITLE
[Wasm] Add support for `DisplayInformation` properties

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -4,6 +4,7 @@
 ### Features
 * Add support for `Windows.Phone.Devices.Notification.VibrationDevice` API on iOS, Android and WASM
 * Basic support for `Windows.Devices.Sensors.Barometer`
+* [Wasm] Add support for `DisplayInformation` properties `LogicalDpi`, `ResolutionScale`, `ScreenWidthInRawPixels`, `RawPixelsPerViewPixel` , and `ScreenHeightInRawPixels`¸
 
 ### Breaking changes
 *

--- a/src/Uno.UWP/Graphics/Display/DisplayInformation.wasm.cs
+++ b/src/Uno.UWP/Graphics/Display/DisplayInformation.wasm.cs
@@ -1,0 +1,58 @@
+﻿#if __WASM__
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Windows.Foundation;
+
+namespace Windows.Graphics.Display
+{
+	public sealed partial class DisplayInformation
+	{
+		// devicePixelRatio of 1 = https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio
+		private const float BaseDPI = 96.0f;
+
+		partial void Initialize()
+		{
+			UpdateProperties();
+		}
+
+		private void UpdateProperties()
+		{
+			UpdateLogicalProperties();
+			UpdateRawProperties();
+		}
+
+		private void UpdateLogicalProperties()
+		{
+			if (ReadJSFloat("window.devicePixelRatio", out var devicePixelRatio))
+			{
+				LogicalDpi = devicePixelRatio * BaseDPI;
+				ResolutionScale = (ResolutionScale)LogicalDpi;
+			}
+			else
+			{
+				LogicalDpi = BaseDPI;
+				ResolutionScale = ResolutionScale.Scale100Percent;
+			}
+		}
+
+		private static bool ReadJSFloat(string property, out float value)
+		{
+			return float.TryParse(WebAssembly.Runtime.InvokeJS(property), out value);
+		}
+
+		private void UpdateRawProperties()
+		{
+			if (ReadJSFloat("window.screen.width", out var width)
+				&& ReadJSFloat("window.screen.height", out var height))
+			{
+				var scale = (double)LogicalDpi / BaseDPI;
+				ScreenWidthInRawPixels = (uint)((double)width * scale);
+				ScreenHeightInRawPixels = (uint)((double)height * scale);
+				RawPixelsPerViewPixel = scale;
+			}
+		}
+	}
+}
+#endif


### PR DESCRIPTION
GitHub Issue (If applicable): Fixes #385
<!-- Link to relevant GitHub issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->

## PR Type
What kind of change does this PR introduce?
- Feature

## What is the new behavior?
Add support for `DisplayInformation` properties `LogicalDpi`, `ResolutionScale`, `ScreenWidthInRawPixels`, `RawPixelsPerViewPixel` , and `ScreenHeightInRawPixels`¸

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [x] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below.
     Please note that breaking changes are likely to be rejected -->


## Other information
<!-- Please provide any additional information if necessary -->

Internal Issue (If applicable):
<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->
