### PR TITLE
Fix layout issue with a ListView inside another ListView

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -12,6 +12,7 @@
 ### Bug fixes
 * [iOS] Area of view outside Clip rect now allows touch to pass through, this fixes NavigationView not allowing touches to children (#1018)
 * `ComboBox` drop down is now placed following a logic which is closer to UWP and it longer flickers when it appears (especilly on WASM)
+* [Android] A ListView inside another ListView no longer causes an app freeze/crash
 * #854 `BasedOn` on a `<Style>` in `App.Xaml` were not resolving properly
 * #706 `x:Name` in `App.Xaml`'s resources were crashing the compilation.
 * #846 `x:Name` on non-`DependencyObject` resources were crashing the compilation

--- a/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
+++ b/src/SamplesApp/UITests.Shared/UITests.Shared.projitems
@@ -797,6 +797,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Inside_ListView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\HorizontalListViewGrouped.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -2424,6 +2428,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Image_Stretch_Full_Wider.xaml.cs">
       <DependentUpon>Image_Stretch_Full_Wider.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\ListView_Inside_ListView.xaml.cs">
+      <DependentUpon>ListView_Inside_ListView.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ListView\HorizontalListViewGrouped.xaml.cs">
       <DependentUpon>HorizontalListViewGrouped.xaml</DependentUpon>
     </Compile>
@@ -2576,6 +2583,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\ImageTests\Models\ImageWithLateSourceViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\TextBlockViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\TimePickerViewModel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Models\TwoLevelListItem.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\NavigationViewTests\NavigationView_TopNavigation.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Pivot\PivotSimpleTest.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Windows_UI_Xaml_Controls\Popup\MessageDialog.xaml.cs" />

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Inside_ListView.xaml
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Inside_ListView.xaml
@@ -1,0 +1,33 @@
+﻿<UserControl x:Class="SamplesApp.Windows_UI_Xaml_Controls.ListView.ListView_Inside_ListView"
+			 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+			 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+			 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+			 xmlns:controls="using:Uno.UI.Samples.Controls"
+			 xmlns:u="using:Uno.UI.Samples.Controls"
+			 mc:Ignorable="d"
+			 d:DesignHeight="300"
+			 d:DesignWidth="400">
+
+	<!--Testing that the fix for https://nventive.visualstudio.com/Umbrella/_workitems/edit/156620 stays valid
+	If not, the app will crash when displaying this sample-->
+	<controls:SampleControl SampleDescription="Sample control for testing that a ListView can be displayed inside another ListView">
+		<controls:SampleControl.SampleContent>
+			<DataTemplate>
+				<ListView ItemsSource="{Binding TwoLevelsItemList}">
+					<ListView.ItemTemplate>
+						<DataTemplate>
+							<ListView ItemsSource="{Binding SubLevelItems}">
+								<ListView.ItemTemplate>
+									<DataTemplate>
+										<TextBlock Text="{Binding}" />
+									</DataTemplate>
+								</ListView.ItemTemplate>
+							</ListView>
+						</DataTemplate>
+					</ListView.ItemTemplate>
+				</ListView>
+			</DataTemplate>
+		</controls:SampleControl.SampleContent>
+	</controls:SampleControl>
+</UserControl>

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Inside_ListView.xaml.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/ListView/ListView_Inside_ListView.xaml.cs
@@ -1,0 +1,16 @@
+﻿using Uno.UI.Samples.Controls;
+using Windows.UI.Xaml.Controls;
+using Uno.UI.Samples.Presentation.SamplePages;
+
+namespace SamplesApp.Windows_UI_Xaml_Controls.ListView
+{
+	[SampleControlInfo("ListView", "ListView_BoundSelectedItem", typeof(ListViewSelectionsViewModel))]
+	public sealed partial class ListView_Inside_ListView : UserControl
+	{
+		public ListView_Inside_ListView()
+		{
+			this.InitializeComponent();
+
+		}
+	}
+}

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Models/ListViewSelectionsViewModel.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Models/ListViewSelectionsViewModel.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Input;
+﻿using System.Collections.Generic;
+using System.Windows.Input;
 using Windows.UI.Core;
 using Uno.UI.Samples.UITests.Helpers;
 
@@ -59,6 +60,18 @@ namespace Uno.UI.Samples.Presentation.SamplePages
 				"Ike",
 				"Paloma"
 			};
+		}
+
+		public List<TwoLevelListItem> TwoLevelsItemList
+		{
+			get
+			{
+				return new List<TwoLevelListItem>
+				{
+					new TwoLevelListItem { SubLevelItems = new List<string> { "1a", "1b" } },
+					new TwoLevelListItem { SubLevelItems = new List<string> { "2a", "2b", "2c" } }
+				};
+			}
 		}
 	}
 }

--- a/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Models/TwoLevelListItem.cs
+++ b/src/SamplesApp/UITests.Shared/Windows_UI_Xaml_Controls/Models/TwoLevelListItem.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Uno.UI.Samples.Presentation.SamplePages
+{
+    public class TwoLevelListItem
+    {
+		public List<string> SubLevelItems { get; set; }
+	}
+}

--- a/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoViewGroup.java
+++ b/src/Uno.UI.BindingHelper.Android/Uno/UI/UnoViewGroup.java
@@ -620,6 +620,12 @@ public abstract class UnoViewGroup
 	 * This should be called subsequently to {{@link #endLayoutingFromMeasure()}}, typically during a true layout pass, to flush any captured layout requests.
 	 */
 	public static void measureBeforeLayout() {
+		if (_isLayoutingFromMeasure)
+		{
+			// This can happen when nested controls call startLayoutingFromMeasure()/measureBeforeLayout()
+			return;
+		}
+
 		try {
 			for (int i = 0; i < callToRequestLayout.size(); i++) {
 				UnoViewGroup view = callToRequestLayout.get(i);


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?
<!-- - Bugfix -->

## What is the current behavior?
Displaying a ListView inside another ListView sometimes makes the Android app freeze then crash with an endless loop.

## What is the new behavior?
Displaying a ListView inside another ListView is properly supported on Android.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [ ] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/156620