### PR TITLE
Fix Two-Way binding when DataContext has wrong datatype

### DIFF
--- a/doc/ReleaseNotes/_ReleaseNotes.md
+++ b/doc/ReleaseNotes/_ReleaseNotes.md
@@ -165,6 +165,7 @@
 * #1062 TextBlock measure caching can wrongly hit
 * Fix support for ScrollBar touch events (#871)
 * `LinearGradientBrush.EndPoint` now defaults to (1,1) to match UWP
+* Fixed an issue where a Two-Way binding would sometimes not update values back to source correctly
 
 ## Release 1.44.0
 

--- a/src/Uno.UI.Tests/BinderTests/Given_BindingPath.cs
+++ b/src/Uno.UI.Tests/BinderTests/Given_BindingPath.cs
@@ -137,9 +137,39 @@ namespace Uno.UI.Tests.BinderTests
 			Assert.AreEqual("TargetLocalValue", target.GetPrecedenceSpecificValue(MyTarget.ValueProperty, DependencyPropertyValuePrecedences.Local));
 		}
 
+		[TestMethod]
+		public void When_Initially_Incorrect_DataContext()
+		{
+			var (target, sut) = ArrangeIncorrect(DependencyPropertyValuePrecedences.Local);
+
+			// Expecting this to fail because the DataContext does not match expectations
+			sut.SetLocalValue("Initial");
+
+			// Fix the DataContext, which should also fix the setters and allow the BindingPath to work correctly
+			var vm = new MyTarget();
+			sut.DataContext = vm;
+
+			// Expecting this to succeed
+			sut.SetLocalValue("Initial2");
+
+			Assert.AreEqual("Initial2", sut.Value);
+			Assert.AreEqual("Initial2", vm.Value);
+		}
+
 		private static (MyTarget target, BindingPath binding) Arrange(DependencyPropertyValuePrecedences? precedence = null)
 		{
 			var target = new MyTarget();
+			var binding = new BindingPath(nameof(MyTarget.Value), MyTarget.FallbackValue, precedence, false)
+			{
+				DataContext = target
+			};
+
+			return (target, binding);
+		}
+
+		private static (object target, BindingPath binding) ArrangeIncorrect(DependencyPropertyValuePrecedences? precedence = null)
+		{
+			var target = new object();
 			var binding = new BindingPath(nameof(MyTarget.Value), MyTarget.FallbackValue, precedence, false)
 			{
 				DataContext = target

--- a/src/Uno.UI/DataBinding/BindingPath.cs
+++ b/src/Uno.UI/DataBinding/BindingPath.cs
@@ -527,6 +527,7 @@ namespace Uno.UI.DataBinding
 					_valueGetter = null;
 					_precedenceSpecificGetter = null;
 					_substituteValueGetter = null;
+					_localValueSetter = null;
 					_valueSetter = null;
 					_valueUnsetter = null;
 				}


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

Bugfix 

## What is the current behavior?
If a two-way binding is activated at a time when the DataContext has the wrong datatype, it will remain invalid even after the DataContext changes - the source will not be updated.


## What is the new behavior?
After a two-way binding's DataContext is set to the correct DataType, it will update its source correctly.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tested code with current [supported SDKs](../README.md#supported)
- [ ] Docs have been added/updated which fit [documentation template](https://github.com/nventive/Uno/blob/master/doc/.feature-template.md). (for bug fixes / features)
- [x] [Unit Tests and/or UI Tests](doc/articles/working-with-the-samples-apps.md) for the changes have been added (for bug fixes / features) (if applicable)
- [ ] [Wasm UI Tests](doc/articles/working-with-the-samples-apps.md#running-the-webassembly-ui-tests-snapshots) are not showing unexpected any differences
- [x] Contains **NO** breaking changes
- [x] Updated the [Release Notes](https://github.com/nventive/Uno/tree/master/doc/ReleaseNotes)
- [x] Associated with an issue (GitHub or internal)

Internal Issue (If applicable):
https://nventive.visualstudio.com/Umbrella/_workitems/edit/155331
